### PR TITLE
Update saw-core.cabal to tighten lower version bound on sbv

### DIFF
--- a/saw-core.cabal
+++ b/saw-core.cabal
@@ -42,7 +42,7 @@ library
     pretty,
     random,
     ref-fd,
-    sbv >= 5.6,
+    sbv >= 5.10,
     template-haskell,
     tf-random,
     transformers,


### PR DESCRIPTION
`saw-core` depends on functions like `svBlastLE` that were added to SBV's dynamic API at v5.10. It happens on some platforms (older CentOS I guess? that the combination of the current weak lower bound and constraint on the `clock` package cause cabal to choose SBV 5.9, which does not have the desired API.