### PR TITLE
insDef should populate moduleRDecls

### DIFF
--- a/src/Verifier/SAW/Module.hs
+++ b/src/Verifier/SAW/Module.hs
@@ -396,7 +396,10 @@ completeDataType m (identName -> str) ctors =
 
 -- | Insert a definition into a module
 insDef :: Module -> Def -> Module
-insDef m d = insResolvedName m (ResolvedDef d)
+insDef m d =
+  insResolvedName
+  (m { moduleRDecls = DefDecl d : moduleRDecls m })
+  (ResolvedDef d)
 
 -- | Get the resolved names that are local to a module
 localResolvedNames :: Module -> [ResolvedName]


### PR DESCRIPTION
As of ced8799d7d0bd7458f60cecbea6094b2f0ebcd70, `insDef` uses `insResolvedName` to insert a definition into a module.  However, said change made it so that `insDef` no longer inserts the proper `DefDecl` into the module's declaration list, `moduleRDecls`.  I believe this might have been a mistake.

Someone should also double-check whether we intend for `insImport` to affect `moduleRDecls` or not.