### PR TITLE
Use `TH.lift` instead of `read` in template-haskell-generated code.

### DIFF
--- a/saw-core.cabal
+++ b/saw-core.cabal
@@ -42,6 +42,7 @@ library
     random,
     template-haskell,
     text,
+    th-lift-instances,
     tf-random,
     transformers,
     transformers-compat,

--- a/src/Verifier/SAW/Module.hs
+++ b/src/Verifier/SAW/Module.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE DataKinds #-}
@@ -87,6 +88,8 @@ import qualified Data.HashMap.Strict as HMap
 import GHC.Generics (Generic)
 import Text.PrettyPrint.ANSI.Leijen (Doc)
 
+import qualified Language.Haskell.TH.Syntax as TH
+
 import Prelude hiding (all, foldr, sum)
 
 import Verifier.SAW.Term.Functor
@@ -155,7 +158,7 @@ data DefQualifier
   = NoQualifier
   | PrimQualifier
   | AxiomQualifier
- deriving (Eq, Show, Read, Generic)
+ deriving (Eq, Show, Generic, TH.Lift)
 
 instance Hashable DefQualifier -- automatically derived
 

--- a/src/Verifier/SAW/ParserUtils.hs
+++ b/src/Verifier/SAW/ParserUtils.hs
@@ -37,6 +37,7 @@ import Language.Haskell.TH
 import Language.Haskell.TH.Syntax (qAddDependentFile)
 #endif
 import System.Directory
+import qualified Language.Haskell.TH.Syntax as TH (lift)
 
 import qualified Verifier.SAW.UntypedAST as Un
 import qualified Verifier.SAW.Grammar as Un
@@ -87,7 +88,7 @@ defineModuleFromFile decNameStr path = do
   m <- lift $ runIO $ readModuleFromFile path
   let decName = mkName decNameStr
   moduleTp <- lift $ [t| Un.Module |]
-  body <- lift $ [e| read $(stringE $ show m) |]
+  body <- lift $ TH.lift m
   addDecs [ SigD decName moduleTp
           , FunD decName [ Clause [] (NormalB body) [] ]]
   return m
@@ -140,7 +141,7 @@ declareTypedNameFun sc_fun mnm nm apply_p tp =
   let th_nm = (if apply_p then "scApply" else "sc") ++ show mnm ++ "_" ++ nm in
   declareTermApplyFun th_nm (length $ fst $ Un.asPiList tp) $ \sc ts ->
   [| $(sc_fun) $(varE sc)
-   (mkIdent (read $(stringE (show mnm))) $(stringE nm))
+   (mkIdent mnm $(stringE nm))
    $(ts) |]
 
 -- | Declare a Haskell function

--- a/src/Verifier/SAW/Position.hs
+++ b/src/Verifier/SAW/Position.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveLift #-}
 
 {- |
 Module      : Verifier.SAW.Position
@@ -18,6 +19,7 @@ module Verifier.SAW.Position
   , PosPair(..)
   ) where
 
+import qualified Language.Haskell.TH.Syntax as TH
 import System.FilePath (makeRelative)
 
 data Pos = Pos { -- | Base directory to use for pretty printing purposes
@@ -26,7 +28,7 @@ data Pos = Pos { -- | Base directory to use for pretty printing purposes
                , posLine  :: !Int
                , posCol   :: !Int
                }
-  deriving (Show,Read)
+  deriving (Show, TH.Lift)
 
 posTuple :: Pos -> (Int,Int,FilePath)
 posTuple x = (posLine x, posCol x, posPath x)
@@ -53,7 +55,7 @@ class Positioned v where
   pos :: v -> Pos
 
 data PosPair v = PosPair { _pos :: !Pos, val :: !v }
-  deriving (Eq, Ord, Functor, Show, Read)
+  deriving (Eq, Ord, Functor, Show, TH.Lift)
 
 instance Positioned (PosPair v) where
   pos (PosPair p _) = p

--- a/src/Verifier/SAW/UntypedAST.hs
+++ b/src/Verifier/SAW/UntypedAST.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TupleSections #-}
 
@@ -44,6 +45,8 @@ module Verifier.SAW.UntypedAST
 import Control.Applicative ((<$>))
 #endif
 
+import qualified Language.Haskell.TH.Syntax as TH
+
 import Verifier.SAW.Position
 import Verifier.SAW.TypedAST
   ( ModuleName, mkModuleName
@@ -76,13 +79,13 @@ data Term
     -- | Vector literal.
   | VecLit Pos [Term]
   | BadTerm Pos
- deriving (Show,Read)
+ deriving (Show, TH.Lift)
 
 -- | A pattern used for matching a variable.
 data TermVar
   = TermVar (PosPair String)
   | UnusedVar Pos
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, TH.Lift)
 
 -- | Return the 'String' name associated with a 'TermVar'
 termVarString :: TermVar -> String
@@ -124,7 +127,8 @@ badTerm :: Pos -> Term
 badTerm = BadTerm
 
 -- | A constructor declaration of the form @c (x1 :: tp1) .. (xn :: tpn) :: tp@
-data CtorDecl = Ctor (PosPair String) TermCtx Term deriving (Show,Read)
+data CtorDecl = Ctor (PosPair String) TermCtx Term
+  deriving (Show, TH.Lift)
 
 -- | A top-level declaration in a saw-core file
 data Decl
@@ -138,7 +142,7 @@ data Decl
      -- ^ A declaration of a term having a definition, with variables
    | TypedDef (PosPair String) [(TermVar, Term)] Term Term
      -- ^ A definition of something with a specific type, with parameters
-  deriving (Show,Read)
+  deriving (Show, TH.Lift)
 
 -- | A set of constraints on what 'String' names to import from a module
 data ImportConstraint
@@ -146,7 +150,7 @@ data ImportConstraint
     -- ^ Only import the given names
   | HidingImports [String]
     -- ^ Import all but the given names
- deriving (Eq, Ord, Show, Read)
+ deriving (Eq, Ord, Show, TH.Lift)
 
 -- | An import declaration
 data Import = Import { importModName :: PosPair ModuleName
@@ -154,7 +158,7 @@ data Import = Import { importModName :: PosPair ModuleName
                      , importConstraints :: Maybe ImportConstraint
                        -- ^ The constraints on what to import
                      }
-            deriving (Show, Read)
+            deriving (Show, TH.Lift)
 
 -- | Test whether a 'String' name satisfies the constraints of an 'Import'
 nameSatsConstraint :: Maybe ImportConstraint -> String -> Bool
@@ -167,7 +171,8 @@ nameSatsConstraint (Just (HidingImports ns)) n = notElem n ns
 -- * A name for the module;
 -- * A list of imports; AND
 -- * A list of top-level declarations
-data Module = Module (PosPair ModuleName) [Import] [Decl] deriving (Show, Read)
+data Module = Module (PosPair ModuleName) [Import] [Decl]
+  deriving (Show, TH.Lift)
 
 moduleName :: Module -> ModuleName
 moduleName (Module (PosPair _ mnm) _ _) = mnm


### PR DESCRIPTION
This speeds up saw REPL startup time by about a factor of 3. (On my machine, SAW startup time went from 1.7s to about 0.5s.) Type checking of the already-parsed prelude still happens at startup time, but it seems to be pretty fast (compared to calling `read` on a pretty-printed untyped module, at least).

See GaloisInc/saw-script#394.