### PR TITLE
Add unique VarIndex to all scConstant terms (GaloisInc/saw-script#568).

### DIFF
--- a/src/Verifier/SAW/ExternalFormat.hs
+++ b/src/Verifier/SAW/ExternalFormat.hs
@@ -77,7 +77,7 @@ scWriteExternal t0 =
         Lambda s t e   -> unwords ["Lam", s, show t, show e]
         Pi s t e       -> unwords ["Pi", s, show t, show e]
         LocalVar i     -> unwords ["Var", show i]
-        Constant x e t -> unwords ["Constant", x, show e, show t]
+        Constant ec e  -> unwords ["Constant", show (ecVarIndex ec), ecName ec, show (ecType ec), show e]
         FTermF ftf     ->
           case ftf of
             GlobalDef ident     -> unwords ["Global", show ident]
@@ -129,7 +129,7 @@ scReadExternal sc input =
         ["Lam", x, t, e]    -> Lambda x (read t) (read e)
         ["Pi", s, t, e]     -> Pi s (read t) (read e)
         ["Var", i]          -> LocalVar (read i)
-        ["Constant",x,e,t]  -> Constant x (read e) (read t)
+        ["Constant",i,x,t,e]-> Constant (EC (read i) x (read t)) (read e)
         ["Global", x]       -> FTermF (GlobalDef (parseIdent x))
         ["Unit"]            -> FTermF UnitValue
         ["UnitT"]           -> FTermF UnitType

--- a/src/Verifier/SAW/Recognizer.hs
+++ b/src/Verifier/SAW/Recognizer.hs
@@ -306,8 +306,8 @@ asLocalVar :: (MonadFail m) => Recognizer m Term DeBruijnIndex
 asLocalVar (unwrapTermF -> LocalVar i) = return i
 asLocalVar _ = fail "not a local variable"
 
-asConstant :: (MonadFail m) => Recognizer m Term (String, Term, Term)
-asConstant (unwrapTermF -> Constant s x t) = return (s, x, t)
+asConstant :: (MonadFail m) => Recognizer m Term (ExtCns Term, Term)
+asConstant (unwrapTermF -> Constant ec t) = return (ec, t)
 asConstant _ = fail "asConstant: not a defined constant"
 
 asExtCns :: (MonadFail m) => Recognizer m Term (ExtCns Term)

--- a/src/Verifier/SAW/Rewriter.hs
+++ b/src/Verifier/SAW/Rewriter.hs
@@ -299,7 +299,7 @@ ruleOfProp (R.asApplyAll -> (R.isGlobalDef boolEqIdent -> Just (), [x, y])) =
   RewriteRule { ctxt = [], lhs = x, rhs = y }
 ruleOfProp (R.asApplyAll -> (R.isGlobalDef vecEqIdent -> Just (), [_, _, _, x, y])) =
   RewriteRule { ctxt = [], lhs = x, rhs = y }
-ruleOfProp (unwrapTermF -> Constant _ body _) = ruleOfProp body
+ruleOfProp (unwrapTermF -> Constant _ body) = ruleOfProp body
 ruleOfProp (R.asEq -> Just (_, x, y)) =
   RewriteRule { ctxt = [], lhs = x, rhs = y }
 ruleOfProp (R.asEqTrue -> Just body) = ruleOfProp body
@@ -519,7 +519,7 @@ rewriteSharedTerm sc ss t0 =
     rewriteAll STApp{ stAppIndex = tidx, stAppTermF = tf } =
         useCache ?cache tidx (traverseTF rewriteAll tf >>= scTermF sc >>= rewriteTop)
     traverseTF :: (a -> IO a) -> TermF a -> IO (TermF a)
-    traverseTF _ tf@(Constant _ _ _) = pure tf
+    traverseTF _ tf@(Constant {}) = pure tf
     traverseTF f tf = traverse f tf
     rewriteTop :: (?cache :: Cache IO TermIndex Term) => Term -> IO Term
     rewriteTop t =
@@ -785,8 +785,8 @@ doHoistIfs sc ss hoistCache itePat = go
 
        goF :: Term -> TermF Term -> IO (HoistIfs s)
 
-       goF t (LocalVar _)     = return (t, [])
-       goF t (Constant _ _ _) = return (t, [])
+       goF t (LocalVar _)  = return (t, [])
+       goF t (Constant {}) = return (t, [])
 
        goF _ (FTermF ftf) = do
                 (ftf', conds) <- runWriterT $ traverse WriterT $ (fmap go ftf)

--- a/src/Verifier/SAW/SCTypeCheck.hs
+++ b/src/Verifier/SAW/SCTypeCheck.hs
@@ -372,7 +372,7 @@ instance TypeInfer (TermF TypedTerm) where
          else
          error ("Context = " ++ show ctx)
          -- throwTCError (DanglingVar (i - length ctx))
-  typeInfer (Constant n (TypedTerm _ tp) (TypedTerm req_tp req_tp_sort)) =
+  typeInfer (Constant (EC _ n (TypedTerm req_tp req_tp_sort)) (TypedTerm _ tp)) =
     do void (ensureSort req_tp_sort)
        -- NOTE: we do the subtype check here, rather than call checkSubtype, so
        -- that we can throw the custom BadConstType error on failure

--- a/src/Verifier/SAW/Simulator/Concrete.hs
+++ b/src/Verifier/SAW/Simulator/Concrete.hs
@@ -50,7 +50,7 @@ evalSharedTerm :: ModuleMap -> Map Ident CValue -> Term -> CValue
 evalSharedTerm m addlPrims t =
   runIdentity $ do
     cfg <- Sim.evalGlobal m (Map.union constMap addlPrims)
-           Sim.noExtCns (const (const Nothing))
+           Sim.noExtCns (const Nothing)
     Sim.evalSharedTerm cfg t
 
 ------------------------------------------------------------

--- a/src/Verifier/SAW/Simulator/RME.hs
+++ b/src/Verifier/SAW/Simulator/RME.hs
@@ -57,7 +57,7 @@ evalSharedTerm :: ModuleMap -> Map Ident RValue -> Term -> RValue
 evalSharedTerm m addlPrims t =
   runIdentity $ do
     cfg <- Sim.evalGlobal m (Map.union constMap addlPrims)
-           Sim.noExtCns (const (const Nothing))
+           Sim.noExtCns (const Nothing)
     Sim.evalSharedTerm cfg t
 
 ------------------------------------------------------------
@@ -358,8 +358,8 @@ bitBlastBasic :: ModuleMap
               -> RValue
 bitBlastBasic m addlPrims t = runIdentity $ do
   cfg <- Sim.evalGlobal m (Map.union constMap addlPrims)
-         (\_varidx name _ty -> error ("RME: unsupported ExtCns: " ++ name))
-         (const (const Nothing))
+         (\ec -> error ("RME: unsupported ExtCns: " ++ ecName ec))
+         (const Nothing)
   Sim.evalSharedTerm cfg t
 
 asPredType :: SharedContext -> Term -> IO [Term]

--- a/src/Verifier/SAW/Term/Pretty.hs
+++ b/src/Verifier/SAW/Term/Pretty.hs
@@ -434,7 +434,7 @@ ppTermF prec (Pi x tp body) =
   (ppPi <$> ppTerm' PrecApp tp <*>
    ppTermInBinder PrecLambda x body)
 ppTermF _ (LocalVar x) = (text <$> varLookupM x) >>= maybeColorM dullgreen
-ppTermF _ (Constant str _ _) = maybeColorM dullblue $ text str
+ppTermF _ (Constant ec _) = maybeColorM dullblue $ text $ ecName ec
 
 
 -- | Internal function to recursively pretty-print a term


### PR DESCRIPTION
This change adds a unique id of type `VarIndex` to `scConstant` terms, making it possible to fix GaloisInc/saw-script#568.