### PR TITLE
Reimplement saw-core `error` with `userError` instead of `panic`.

### DIFF
--- a/saw-core/src/Verifier/SAW/Simulator/Prims.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Prims.hs
@@ -39,6 +39,7 @@ import Numeric.Natural (Natural)
 import Verifier.SAW.Term.Functor (Ident, alistAllFields)
 import Verifier.SAW.Simulator.Value
 import Verifier.SAW.Prim
+import qualified Verifier.SAW.Prim as Prim
 
 import qualified Verifier.SAW.Utils as Panic (panic)
 
@@ -1191,8 +1192,8 @@ errorOp =
   constFun $
   strictFun $ \x ->
   case x of
-    VString s -> panic s
-    _ -> panic "unknown error"
+    VString s -> Prim.userError s
+    _ -> Prim.userError "unknown error"
 
 ------------------------------------------------------------
 -- Conditionals


### PR DESCRIPTION
This is a quick fix for #59.

Instead of `panic`, we now throw an asynchronous exception of type `EvalError` using function `userError` from module `Verifier.SAW.Prim`. This is not the perfect solution (`throwIO` would be better) but it is definitely better than `panic`, and calling the saw-core `error` function no longer will cause `saw` to exit.
