### PR TITLE
Merge cryptol-verifier repository into saw-core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+cabal.sandbox.config
+dist

--- a/cryptol-saw-core/LICENSE
+++ b/cryptol-saw-core/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2014, Galois, Inc.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the names of the authors nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/cryptol-saw-core/README.md
+++ b/cryptol-saw-core/README.md
@@ -1,0 +1,5 @@
+This repository contains the code for the Cryptol Symbolic Simulator
+(CSS). It is currently used primarily as a library from SAWScript, but
+also produces a stand-alone executable, `css`. This executable has
+only limited functionality: it can translate a single Cryptol function
+to an And-Inverter Graph (AIG).

--- a/cryptol-saw-core/Setup.hs
+++ b/cryptol-saw-core/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/cryptol-saw-core/cryptol-saw-core.cabal
+++ b/cryptol-saw-core/cryptol-saw-core.cabal
@@ -1,0 +1,93 @@
+Name:              cryptol-saw-core
+Version:           0.1
+Author:            Galois, Inc.
+License:           BSD3
+License-file:      LICENSE
+Maintainer:        huffman@galois.com
+Copyright:         (c) 2014 Galois Inc.
+Build-type:        Simple
+cabal-version:     >= 1.10
+Category:          Formal Methods
+Synopsis:          Representing Cryptol in SAWCore
+Description:
+  Translate Cryptol syntax into SAWCore terms, which can then
+  be analysed by various backend proof systems.
+
+extra-source-files:
+    saw/Cryptol.sawcore
+
+flag build-css
+  description: Build the css executable
+  default: True
+
+library
+  build-depends:
+    aig,
+    array,
+    base,
+    base-compat,
+    bytestring,
+    containers,
+    cryptol >= 2.3.0,
+    data-inttrie >= 0.1.4,
+    integer-gmp,
+    panic,
+    saw-core,
+    saw-core-aig,
+    saw-core-sbv,
+    saw-core-what4,
+    what4,
+    sbv,
+    vector,
+    text,
+    executable-path,
+    filepath
+  hs-source-dirs: src
+  exposed-modules:
+     Verifier.SAW.Cryptol
+     Verifier.SAW.Cryptol.Panic
+     Verifier.SAW.Cryptol.Prelude
+     Verifier.SAW.Cryptol.Simpset
+     Verifier.SAW.CryptolEnv
+     Verifier.SAW.TypedTerm
+  GHC-options: -Wall -Werror
+
+executable css
+  if !flag(build-css)
+     buildable: False
+
+  other-modules:
+    Paths_cryptol_verifier
+
+  build-depends:
+    array,
+    abcBridge,
+    base,
+    bytestring,
+    containers,
+    cryptol,
+    saw-core,
+    saw-core-aig,
+    text,
+    cryptol-saw-core
+
+  hs-source-dirs : css
+  main-is : Main.hs
+  GHC-options: -Wall -O2 -rtsopts -pgmlc++
+  extra-libraries:      stdc++
+
+test-suite cryptol-saw-core-tc-test
+  type: exitcode-stdio-1.0
+  default-language: Haskell2010
+
+  hs-source-dirs: test
+  main-is: CryptolVerifierTC.hs
+
+  build-depends:
+    base,
+    bytestring,
+    containers,
+    cryptol,
+    cryptol-saw-core,
+    heredoc >= 0.2,
+    saw-core

--- a/cryptol-saw-core/css/Main.hs
+++ b/cryptol-saw-core/css/Main.hs
@@ -1,0 +1,138 @@
+{-# LANGUAGE RankNTypes #-}
+
+module Main where
+
+import           System.Environment( getArgs )
+import           System.Exit( exitFailure )
+import           System.Console.GetOpt
+import           System.IO
+import qualified Data.ByteString as BS
+import           Data.Text ( pack )
+import           Data.Version
+
+import qualified Cryptol.Eval as E
+import qualified Cryptol.TypeCheck.AST as T
+import qualified Cryptol.ModuleSystem as CM
+import qualified Cryptol.ModuleSystem.Env as CME
+import qualified Cryptol.Parser as P
+import           Cryptol.Utils.PP
+import           Cryptol.Utils.Logger (quietLogger)
+
+import qualified Verifier.SAW.Cryptol as C
+import           Verifier.SAW.SharedTerm
+import qualified Verifier.SAW.Cryptol.Prelude as C
+import           Verifier.SAW.CryptolEnv (schemaNoUser)
+
+
+import qualified Data.ABC as ABC
+import qualified Verifier.SAW.Simulator.BitBlast as BBSim
+
+import qualified Paths_cryptol_verifier as Paths
+
+data CSS = CSS
+  { output :: FilePath
+  , cssMode :: CmdMode
+  } deriving (Show)
+
+data CmdMode
+  = NormalMode
+  | HelpMode
+  | VersionMode
+ deriving (Show, Eq)
+
+emptyCSS :: CSS
+emptyCSS =
+  CSS
+  { output = ""
+  , cssMode = NormalMode
+  }
+
+options :: [OptDescr (CSS -> CSS)]
+options =
+  [ Option ['o'] ["output"]
+     (ReqArg (\x css -> css{ output = x }) "FILE")
+     "output file"
+  , Option ['h'] ["help"]
+     (NoArg (\css -> css{ cssMode = HelpMode }))
+     "display help"
+  , Option ['v'] ["version"]
+     (NoArg (\css -> css{ cssMode = VersionMode }))
+     "version"
+  ]
+
+version_string :: String
+version_string = unlines
+  [ "Cryptol Symbolic Simulator (css) version "++showVersion Paths.version
+  , "Copyright 2014 Galois, Inc.  All rights reserved."
+  ]
+
+header :: String
+header = "css [options] <input module> <function to simulate>"
+
+main :: IO ()
+main = do
+  args <- getArgs
+  case getOpt RequireOrder options args of
+    (flags,optArgs,[]) -> cssMain (foldr ($) emptyCSS flags) optArgs
+
+    (_,_,errs) -> do
+       hPutStr stderr (concat errs ++ usageInfo header options)
+       exitFailure
+
+defaultEvalOpts :: E.EvalOpts
+defaultEvalOpts = E.EvalOpts quietLogger E.defaultPPOpts
+
+cssMain :: CSS -> [String] -> IO ()
+cssMain css [inputModule,name] | cssMode css == NormalMode = do
+    let out = if null (output css)
+                 then name++".aig"
+                 else (output css)
+
+    modEnv <- CM.initialModuleEnv
+    (e,warn) <- CM.loadModuleByPath inputModule (defaultEvalOpts, BS.readFile, modEnv)
+    mapM_ (print . pp) warn
+    case e of
+       Left msg -> print msg >> exitFailure
+       Right (_,menv) -> processModule menv out name
+
+cssMain css _ | cssMode css == VersionMode = do
+    hPutStr stdout version_string
+
+cssMain css _ | cssMode css == HelpMode = do
+    hPutStr stdout (usageInfo header options)
+
+cssMain _ _ = do
+    hPutStr stdout (usageInfo header options)
+    exitFailure
+
+
+processModule :: CM.ModuleEnv -> FilePath -> String -> IO ()
+processModule menv fout funcName = do
+   sc <- mkSharedContext
+   C.scLoadPreludeModule sc
+   C.scLoadCryptolModule sc
+   tm <- extractCryptol sc menv funcName
+   writeAIG sc fout tm
+
+writeAIG :: SharedContext -> FilePath -> Term -> IO ()
+writeAIG sc f t = do
+  BBSim.withBitBlastedTerm ABC.giaNetwork sc mempty t $ \be ls -> do
+  ABC.writeAiger f (ABC.Network be (ABC.bvToList ls))
+
+extractCryptol :: SharedContext -> CM.ModuleEnv -> String -> IO Term
+extractCryptol sc modEnv input = do
+  let declGroups = concatMap T.mDecls (CME.loadedModules modEnv)
+  env <- C.importDeclGroups sc C.emptyEnv declGroups
+  pexpr <-
+    case P.parseExpr (pack input) of
+      Left err -> fail (show (P.ppError err))
+      Right x -> return x
+  (exprResult, exprWarnings) <- CM.checkExpr pexpr (defaultEvalOpts, BS.readFile, modEnv)
+  mapM_ (print . pp) exprWarnings
+  ((_, expr, schema), _modEnv') <-
+    case exprResult of
+      Left err -> fail (show (pp err))
+      Right x -> return x
+  putStrLn $ "Extracting expression of type " ++ show (pp (schemaNoUser schema))
+  C.importExpr sc env expr
+

--- a/cryptol-saw-core/saw/Cryptol.sawcore
+++ b/cryptol-saw-core/saw/Cryptol.sawcore
@@ -1,0 +1,1574 @@
+-------------------------------------------------------------------------------
+-- Cryptol primitives for SAWCore
+
+module Cryptol where
+
+import Prelude;
+
+--------------------------------------------------------------------------------
+-- Additional operations on Prelude types
+
+const : (a b : sort 0) -> a -> b -> a;
+const a b x y = x;
+
+compose : (a b c : sort 0) -> (b -> c) -> (a -> b) -> (a -> c);
+compose _ _ _ f g x = f (g x);
+
+bvExp : (n : Nat) -> bitvector n -> bitvector n -> bitvector n;
+bvExp n x y = foldr Bool (bitvector n) n
+  (\ (b : Bool) -> \ (a : bitvector n) ->
+    ite (bitvector n) b (bvMul n x (bvMul n a a)) (bvMul n a a))
+  (bvNat n 1)
+  (reverse n Bool y);
+
+updFst : (a b : sort 0) -> (a -> a) -> (a * b) -> (a * b);
+updFst a b f x = (f x.(1), x.(2));
+
+updSnd : (a b : sort 0) -> (b -> b) -> (a * b) -> (a * b);
+updSnd a b f x = (x.(1), f x.(2));
+
+--------------------------------------------------------------------------------
+-- Extended natural numbers
+
+data Num : sort 0 where {
+    TCNum : Nat -> Num;
+    TCInf : Num;
+  }
+
+Num_rec : (p: Num -> sort 1) -> ((n:Nat) -> p (TCNum n)) -> p TCInf ->
+           (n:Num) -> p n;
+Num_rec p f1 f2 n = Num#rec p f1 f2 n;
+
+-- Helper function: take a Num that we expect to be finite, and extract its Nat,
+-- raising an error if that Num is not finite
+getFinNat : (n:Num) -> Nat;
+getFinNat n =
+  Num#rec (\ (n:Num) -> Nat) (\ (n:Nat) -> n)
+          (error Nat "Unexpected Fin constraint violation!") n;
+
+-- Helper function: destruct a Num that we expect to be finite
+finNumRec : (p: Num -> sort 1) -> ((n:Nat) -> p (TCNum n)) ->
+             (n:Num) -> p n;
+finNumRec p f n =
+  Num#rec p f (error (p TCInf) "Unexpected Fin constraint violation!") n;
+
+-- Helper function: destruct two Nums that we expect to be finite
+finNumRec2 : (p: Num -> Num -> sort 1) ->
+              ((m n:Nat) -> p (TCNum m) (TCNum n)) ->
+              (m n:Num) -> p m n;
+finNumRec2 p f =
+  finNumRec
+    (\ (m:Num) -> (n:Num) -> p m n)
+    (\ (m:Nat) -> finNumRec (p (TCNum m)) (f m));
+
+-- Build a binary function on Nums by lifting a binary function on Nats (the
+-- first argument) and using additional cases for: when the first argument is a
+-- Nat and the second is infinite; when the second is a Nat and the first is
+-- infinite; and when both are infinite
+binaryNumFun : (Nat -> Nat -> Nat) -> (Nat -> Num) -> (Nat -> Num) -> Num ->
+                Num -> Num -> Num;
+binaryNumFun f1 f2 f3 f4 num1 num2 =
+  Num#rec (\ (num1':Num) -> Num)
+          (\ (n1:Nat) ->
+             Num#rec (\ (num2':Num) -> Num)
+                     (\ (n2:Nat) -> TCNum (f1 n1 n2))
+                     (f2 n1) num2)
+          (Num#rec (\ (num2':Num) -> Num) f3 f4 num2)
+          num1;
+
+-- Build a ternary function on Nums by lifting a ternary function on Nats, with
+-- a single default case if any of the Nums is infinite
+ternaryNumFun : (Nat -> Nat -> Nat -> Nat) -> Num ->
+                 Num -> Num -> Num -> Num;
+ternaryNumFun f1 f2 num1 num2 num3 =
+  Num#rec
+    (\ (num1':Num) -> Num)
+    (\ (n1:Nat) ->
+       Num#rec
+         (\ (num2':Num) -> Num)
+         (\ (n2:Nat) ->
+            Num#rec
+              (\ (num3':Num) -> Num)
+              (\ (n3:Nat) -> TCNum (f1 n1 n2 n3))
+              f2 num3)
+         f2 num2)
+    f2 num1;
+
+
+
+tcWidth : Num -> Num;
+tcWidth n = Num#rec (\ (n:Num) -> Num)
+                    (\ (x:Nat) -> TCNum (widthNat x)) TCInf n;
+
+tcAdd : Num -> Num -> Num;
+tcAdd =
+  binaryNumFun addNat (\ (x:Nat) -> TCInf) (\ (y:Nat) -> TCInf) TCInf;
+
+tcSub : Num -> Num -> Num;
+tcSub =
+  binaryNumFun subNat
+               -- x - infinity = 0
+               (\ (x:Nat) -> TCNum 0)
+               -- infinity - y = infinity
+               (\ (y:Nat) -> TCInf)
+               -- infinity - infinity = 0
+               (TCNum 0);
+
+tcMul : Num -> Num -> Num;
+tcMul =
+  binaryNumFun mulNat
+               (\ (x:Nat) -> if0Nat Num x (TCNum 0) TCInf)
+               (\ (y:Nat) -> if0Nat Num y (TCNum 0) TCInf)
+               TCInf;
+
+tcDiv : Num -> Num -> Num;
+tcDiv =
+  binaryNumFun (\ (x:Nat) -> \ (y:Nat) -> divNat x y)
+               (\ (x:Nat) -> TCNum 0)
+               (\ (y:Nat) -> TCInf)
+               -- infinity / infinity = 1
+               (TCNum 1);
+
+tcMod : Num -> Num -> Num;
+tcMod =
+  binaryNumFun (\ (x:Nat) -> \ (y:Nat) -> modNat x y)
+               (\ (x:Nat) -> TCNum 0)
+               -- infinity % y = 0, since y*infinity + 0 = infinity
+               (\ (y:Nat) -> TCNum 0)
+               -- infinity % infinity = 0
+               (TCNum 0);
+
+tcExp : Num -> Num -> Num;
+tcExp =
+  binaryNumFun expNat
+               (\ (x:Nat) ->
+                  natCase
+                    (\ (_:Nat) -> Num) (TCNum 0)
+                    (\ (x_minus_1:Nat) ->
+                       if0Nat Num x_minus_1 (TCNum 1) TCInf)
+                    x)
+               (\ (y:Nat) -> if0Nat Num y (TCNum 1) TCInf)
+               TCInf;
+
+tcMin : Num -> Num -> Num;
+tcMin =
+  binaryNumFun minNat (\ (x:Nat) -> TCNum x) (\ (y:Nat) -> TCNum y) TCInf;
+
+tcMax : Num -> Num -> Num;
+tcMax =
+  binaryNumFun maxNat (\ (x:Nat) -> TCInf) (\ (y:Nat) -> TCInf) TCInf;
+
+ceilDivNat : Nat -> Nat -> Nat;
+ceilDivNat x y = divNat (addNat x (subNat y 1)) y;
+
+ceilModNat : Nat -> Nat -> Nat;
+ceilModNat x y = subNat (mulNat (ceilDivNat x y) y) x;
+
+tcCeilDiv : Num -> Num -> Num;
+tcCeilDiv =
+  binaryNumFun ceilDivNat (\ (x:Nat) -> TCNum 0) (\ (y:Nat) -> TCInf) TCInf;
+
+tcCeilMod : Num -> Num -> Num;
+tcCeilMod =
+  binaryNumFun ceilModNat (\ (x:Nat) -> TCNum 0) (\ (y:Nat) -> TCInf) TCInf;
+
+tcLenFromThenTo_Nat : Nat -> Nat -> Nat -> Nat;
+tcLenFromThenTo_Nat x y z =
+  ite Nat (ltNat x y)
+    (ite Nat (ltNat z x) 0
+         (addNat (divNat (subNat z x) (subNat y x)) 1)) -- increasing
+    (ite Nat (ltNat x z) 0
+         (addNat (divNat (subNat x z) (subNat x y)) 1)); -- decreasing
+
+tcLenFromThenTo : Num -> Num -> Num -> Num;
+tcLenFromThenTo = ternaryNumFun tcLenFromThenTo_Nat TCInf;
+
+
+--------------------------------------------------------------------------------
+-- Possibly infinite sequences
+
+seq : Num -> sort 0 -> sort 0;
+seq num a =
+  Num#rec (\ (num:Num) -> sort 0) (\ (n:Nat) -> Vec n a) (Stream a) num;
+
+-- FIXME: this rule should be derived by scDefRewriteRules
+seq_TCNum : (n:Nat) -> (a:sort 0) -> Eq (sort 0) (seq (TCNum n) a) (Vec n a);
+seq_TCNum n a = Refl (sort 0) (Vec n a);
+seq_TCInf : (a:sort 0) -> Eq (sort 0) (seq TCInf a) (Stream a);
+seq_TCInf a = Refl (sort 0) (Stream a);
+
+seqMap : (a b : sort 0) -> (n : Num) -> (a -> b) -> seq n a -> seq n b;
+seqMap a b num f =
+  Num#rec (\ (n:Num) -> seq n a -> seq n b) (map a b f) (streamMap a b f) num;
+
+seqConst : (n : Num) -> (a : sort 0) -> a -> seq n a;
+seqConst n =
+  Num#rec (\ (n:Num) -> (a : sort 0) -> a -> seq n a) replicate streamConst n;
+
+--------------------------------------------------------------------------------
+-- Integers mod n
+
+IntModNum : (num : Num) -> sort 0;
+IntModNum num =
+  Num#rec (\ (n : Num) -> sort 0) IntMod Integer num;
+
+-------------------------------------------------------------------------------
+-- Rationals (TODO)
+
+Rational : sort 0;
+Rational = #();
+
+ecRatio : Integer -> Integer -> Rational;
+ecRatio x y = ();
+
+eqRational : Rational -> Rational -> Bool;
+eqRational x y = error Bool "Unimplemented: (==) Rational";
+
+ltRational : Rational -> Rational -> Bool;
+ltRational x y = error Bool "Unimplemented: (<) Rational";
+
+addRational : Rational -> Rational -> Rational;
+addRational x y = error Rational "Unimplemented: (+) Rational";
+
+subRational : Rational -> Rational -> Rational;
+subRational x y = error Rational "Unimplemented: (-) Rational";
+
+mulRational : Rational -> Rational -> Rational;
+mulRational x y = error Rational "Unimplemented: (*) Rational";
+
+negRational : Rational -> Rational;
+negRational x = error Rational "Unimplemented: negate Rational";
+
+integerToRational : Integer -> Rational;
+integerToRational x = error Rational "Unimplemented: fromInteger Rational";
+
+--------------------------------------------------------------------------------
+-- Parmap (Experimental)
+--
+-- This is implemented here as a bog-standard sequential `map`
+
+-- parmap : {a, b, n} (fin n) => (a -> b) -> [n]a -> [n]b
+ecParmap : (a:sort 0) -> (b:sort 0) -> (n: Num) -> (a -> b) -> seq n a -> seq n b;
+ecParmap a b n =
+  Num#rec (\ (n:Num) -> (a -> b) -> seq n a -> seq n b)
+    ( \ (n:Nat) -> \ (f: a -> b) -> \ (xs: Vec n a) -> map a b f n xs )
+    ( \ (f: a -> b) -> \ (xs:Stream a) -> error (Stream b) "Unexpected infinite stream in parmap" )
+    n;
+
+--------------------------------------------------------------------------------
+-- Type coercions
+
+seq_cong : (m : Num) -> (n : Num) -> (a : sort 0) -> (b : sort 0) ->
+  Eq Num m n -> Eq (sort 0) a b -> Eq (sort 0) (seq m a) (seq n b);
+seq_cong m n a b eq_mn eq_ab =
+  trans
+    (sort 0) (seq m a) (seq n a) (seq n b)
+    (eq_cong Num m n eq_mn (sort 0) (\ (x:Num) -> seq x a))
+    (eq_cong (sort 0) a b eq_ab (sort 0) (\ (x:sort 0) -> seq n x));
+
+seq_cong1 : (m : Num) -> (n : Num) -> (a : sort 0) ->
+  Eq Num m n -> Eq (sort 0) (seq m a) (seq n a);
+seq_cong1 m n a eq_mn =
+  eq_cong Num m n eq_mn (sort 0) (\ (x:Num) -> seq x a);
+
+fun_cong : (a : sort 0) -> (b : sort 0) -> (c : sort 0) -> (d : sort 0) ->
+  Eq (sort 0) a b -> Eq (sort 0) c d -> Eq (sort 0) (a -> c) (b -> d);
+fun_cong a b c d eq_ab eq_cd =
+  trans
+    (sort 0) (a -> c) (b -> c) (b -> d)
+    (eq_cong (sort 0) a b eq_ab (sort 0) (\ (x:sort 0) -> (x -> c)))
+    (eq_cong (sort 0) c d eq_cd (sort 0) (\ (x:sort 0) -> (b -> x)));
+
+pair_cong : (a : sort 0) -> (a' : sort 0) -> (b : sort 0) -> (b' : sort 0) ->
+  Eq (sort 0) a a' -> Eq (sort 0) b b' -> Eq (sort 0) (a * b) (a' * b');
+pair_cong a a' b b' eq_a eq_b =
+  trans
+    (sort 0) (a * b) (a' * b) (a' * b')
+    (eq_cong (sort 0) a a' eq_a (sort 0) (\ (x:sort 0) -> (x * b)))
+    (eq_cong (sort 0) b b' eq_b (sort 0) (\ (x:sort 0) -> (a' * x)));
+
+pair_cong1 : (a : sort 0) -> (a' : sort 0) -> (b : sort 0) ->
+  Eq (sort 0) a a' -> Eq (sort 0) (a * b) (a' * b);
+pair_cong1 a a' b eq_a =
+  (eq_cong (sort 0) a a' eq_a (sort 0) (\ (x:sort 0) -> (x * b)));
+
+pair_cong2 : (a : sort 0) -> (b : sort 0) -> (b' : sort 0) ->
+  Eq (sort 0) b b' -> Eq (sort 0) (a * b) (a * b');
+pair_cong2 a b b' eq_b =
+  (eq_cong (sort 0) b b' eq_b (sort 0) (\ (x:sort 0) -> (a * x)));
+
+axiom unsafeAssert_same_Num :
+  (n : Num) -> Eq (Eq Num n n) (unsafeAssert Num n n) (Refl Num n);
+
+--------------------------------------------------------------------------------
+-- Auxiliary functions
+
+eListSel : (a : sort 0) -> (n : Num) -> seq n a -> Nat -> a;
+eListSel a n =
+  Num#rec (\ (num:Num) -> seq num a -> Nat -> a)
+          (\ (n:Nat) -> at n a) (streamGet a) n;
+
+
+--------------------------------------------------------------------------------
+-- List comprehensions
+
+from : (a b : sort 0) -> (m n : Num) -> seq m a -> (a -> seq n b) ->
+        seq (tcMul m n) (a * b);
+from a b m n =
+  Num#rec
+    (\ (m:Num) -> seq m a -> (a -> seq n b) -> seq (tcMul m n) (a * b))
+    (\ (m:Nat) ->
+       Num#rec
+         (\ (n:Num) -> Vec m a -> (a -> seq n b) ->
+                        seq (tcMul (TCNum m) n) (a * b))
+         -- Case 1: (TCNum m, TCNum n)
+         (\ (n:Nat) ->
+            \ (xs : Vec m a) ->
+            \ (k : a -> Vec n b) ->
+              join m n (a * b)
+                   (map a (Vec n (a * b))
+                        (\ (x : a) ->
+                           map b (a * b) (\ (y : b) -> (x, y)) n (k x))
+                        m xs))
+         -- Case 2: n = (TCNum m, TCInf)
+         (natCase
+            (\ (m':Nat) -> (Vec m' a -> (a -> Stream b) ->
+               seq (if0Nat Num m' (TCNum 0) TCInf) (a * b)))
+            (\ (xs : Vec 0 a) ->
+             \ (k : a -> Stream b) -> EmptyVec (a * b))
+            (\ (m' : Nat) ->
+             \ (xs : Vec (Succ m') a) ->
+             \ (k : a -> Stream b) ->
+               (\ (x : a) -> streamMap b (a * b) (\ (y:b) -> (x, y)) (k x))
+               (at (Succ m') a xs 0))
+            m)
+         n)
+    (Num#rec
+       (\ (n:Num) -> Stream a -> (a -> seq n b) -> seq (tcMul TCInf n) (a * b))
+       -- Case 3: (TCInf, TCNum n)
+       (\ (n:Nat) ->
+          natCase
+            (\ (n':Nat) -> (Stream a -> (a -> Vec n' b) ->
+                seq (if0Nat Num n' (TCNum 0) TCInf) (a * b)))
+            (\ (xs : Stream a) ->
+             \ (k : a -> Vec 0 b) -> EmptyVec (a * b))
+            (\ (n' : Nat) ->
+             \ (xs : Stream a) ->
+             \ (k : a -> Vec (Succ n') b) ->
+               streamJoin
+                 (a * b) n'
+                 (streamMap
+                    a (Vec (Succ n') (a * b))
+                    (\ (x:a) ->
+                       map b (a * b) (\ (y:b) -> (x, y)) (Succ n') (k x))
+                    xs))
+            n)
+       -- Case 4: (TCInf, TCInf)
+       (\ (xs : Stream a) ->
+        \ (k : a -> Stream b) ->
+          (\ (x : a) -> streamMap b (a * b) (\ (y : b) -> (x, y)) (k x))
+          (streamGet a xs 0))
+       n)
+    m;
+
+
+mlet : (a b : sort 0) -> (n : Num) -> a -> (a -> seq n b) -> seq n (a * b);
+mlet a b n =
+  Num#rec
+    (\ (n:Num) -> a -> (a -> seq n b) -> seq n (a * b))
+    (\ (n:Nat) -> \ (x:a) -> \ (f:a -> Vec n b) ->
+       map b (a * b) (\ (y : b) -> (x, y)) n (f x))
+    (\ (x:a) -> \ (f:a -> Stream b) ->
+       streamMap b (a * b) (\ (y : b) -> (x, y)) (f x))
+    n;
+
+seqZip : (a b : sort 0) -> (m n : Num) -> seq m a -> seq n b ->
+          seq (tcMin m n) (a * b);
+seqZip a b m n =
+  Num#rec
+    (\ (m:Num) -> seq m a -> seq n b -> seq (tcMin m n) (a * b))
+    (\ (m : Nat) ->
+       Num#rec
+         (\ (n:Num) -> Vec m a -> seq n b -> seq (tcMin (TCNum m) n) (a * b))
+         (\ (n:Nat) -> zip a b m n)
+         (\ (xs:Vec m a) -> \ (ys:Stream b) ->
+            gen m (a * b) (\ (i : Nat) -> (at m a xs i, streamGet b ys i)))
+         n)
+    (Num#rec
+       (\ (n:Num) -> Stream a -> seq n b -> seq (tcMin TCInf n) (a * b))
+       (\ (n:Nat) ->
+        \ (xs:Stream a) -> \ (ys:Vec n b) ->
+          gen n (a * b) (\ (i : Nat) -> (streamGet a xs i, at n b ys i)))
+       (streamMap2 a b (a * b) (\ (x:a) -> \ (y:b) -> (x, y)))
+       n)
+    m;
+
+
+--------------------------------------------------------------------------------
+-- Ring and Logic functions
+
+seqBinary : (n : Num) -> (a : sort 0) -> (a -> a -> a) ->
+             seq n a -> seq n a -> seq n a;
+seqBinary num a f =
+  Num#rec
+    (\ (n:Num) -> seq n a -> seq n a -> seq n a)
+    (\ (n:Nat) -> zipWith a a a f n)
+    (streamMap2 a a a f)
+    num;
+
+unitUnary : #() -> #();
+unitUnary _ = ();
+
+unitBinary : #() -> #() -> #();
+unitBinary _ _ = ();
+
+pairUnary : (a b : sort 0) -> (a -> a) -> (b -> b) -> (a * b) -> (a * b);
+pairUnary a b f g xy = (f (fst a b xy), g (snd a b xy));
+
+pairBinary : (a b : sort 0) -> (a -> a -> a) -> (b -> b -> b)
+           -> (a * b) -> (a * b) -> (a * b);
+pairBinary a b f g x12 y12 = (f (fst a b x12) (fst a b y12),
+                              g (snd a b x12) (snd a b y12));
+
+funBinary : (a b : sort 0) -> (b -> b -> b) -> (a -> b) -> (a -> b) -> (a -> b);
+funBinary a b op f g x = op (f x) (g x);
+
+errorUnary : (s : String) -> (a : sort 0) -> a -> a;
+errorUnary s a _ = error a s;
+
+errorBinary : (s : String) -> (a : sort 0) -> a -> a -> a;
+errorBinary s a _ _ = error a s;
+
+--------------------------------------------------------------------------------
+-- Comparisons
+
+boolCmp : Bool -> Bool -> Bool -> Bool;
+boolCmp x y k = ite Bool x (and y k) (or y k);
+
+integerCmp : Integer -> Integer -> Bool -> Bool;
+integerCmp x y k = or (intLt x y) (and (intEq x y) k);
+
+rationalCmp : Rational -> Rational -> Bool -> Bool;
+rationalCmp x y k = or (ltRational x y) (and (eqRational x y) k);
+
+bvCmp : (n : Nat) -> bitvector n -> bitvector n -> Bool -> Bool;
+bvCmp n x y k = or (bvult n x y) (and (bvEq n x y) k);
+
+bvSCmp : (n : Nat) -> bitvector n -> bitvector n -> Bool -> Bool;
+bvSCmp n x y k = or (bvslt n x y) (and (bvEq n x y) k);
+
+vecCmp : (n : Nat) -> (a : sort 0) -> (a -> a -> Bool -> Bool)
+       -> (Vec n a -> Vec n a -> Bool -> Bool);
+vecCmp n a f xs ys k =
+  foldr (Bool -> Bool) Bool n (\ (f : Bool -> Bool) -> f) k
+    (zipWith a a (Bool -> Bool) f n xs ys);
+
+unitCmp : #() -> #() -> Bool -> Bool;
+unitCmp _ _ _ = False;
+
+pairEq : (a b : sort 0) -> (a -> a -> Bool) -> (b -> b -> Bool) ->
+  a * b -> a * b -> Bool;
+pairEq a b f g x y =
+  and (f (fst a b x) (fst a b y)) (g (snd a b x) (snd a b y));
+
+pairCmp : (a b : sort 0) -> (a -> a -> Bool -> Bool) -> (b -> b -> Bool -> Bool)
+        -> a * b -> a * b -> Bool -> Bool;
+pairCmp a b f g x12 y12 k =
+  f (fst a b x12) (fst a b y12) (g (snd a b x12) (snd a b y12) k);
+
+--------------------------------------------------------------------------------
+-- Dictionaries and overloading
+
+-- Eq class
+
+PEq : sort 0 -> sort 1;
+PEq a = #{ eq : a -> a -> Bool };
+
+PEqBit : PEq Bool;
+PEqBit = { eq = boolEq };
+
+PEqInteger : PEq Integer;
+PEqInteger = { eq = intEq };
+
+PEqRational : PEq Rational;
+PEqRational = { eq = eqRational };
+
+PEqIntMod : (n : Nat) -> PEq (IntMod n);
+PEqIntMod n = { eq = intModEq n };
+
+PEqIntModNum : (num : Num) -> PEq (IntModNum num);
+PEqIntModNum num =
+  Num#rec (\ (n : Num) -> PEq (IntModNum n)) PEqIntMod PEqInteger num;
+
+PEqVec : (n : Nat) -> (a : sort 0) -> PEq a -> PEq (Vec n a);
+PEqVec n a pa = { eq = vecEq n a pa.eq };
+
+PEqSeq : (n : Num) -> (a : sort 0) -> PEq a -> PEq (seq n a);
+PEqSeq n =
+  Num#rec (\ (n:Num) -> (a : sort 0) -> PEq a -> PEq (seq n a))
+          (\ (n:Nat) -> PEqVec n)
+          (\ (a:sort 0) (pa : PEq a) -> error (PEq (Stream a)) "invalid Eq instance")
+          n;
+
+PEqWord : (n : Nat) -> PEq (Vec n Bool);
+PEqWord n = { eq = bvEq n };
+
+PEqSeqBool : (n : Num) -> PEq (seq n Bool);
+PEqSeqBool n =
+  Num#rec (\ (n : Num) -> PEq (seq n Bool))
+          (\ (n:Nat) -> PEqWord n)
+          (error (PEq (Stream Bool)) "invalid Eq instance")
+          n;
+
+PEqUnit : PEq #();
+PEqUnit = { eq = \ (x y : #()) -> True };
+
+PEqPair : (a b : sort 0) -> PEq a -> PEq b -> PEq (a * b);
+PEqPair a b pa pb = { eq = pairEq a b pa.eq pb.eq };
+
+
+-- Cmp class
+
+PCmp : sort 0 -> sort 1;
+PCmp a =
+  #{ cmpEq : PEq a
+   , cmp : a -> a -> Bool -> Bool
+   };
+
+PCmpBit : PCmp Bool;
+PCmpBit = { cmpEq = PEqBit, cmp = boolCmp };
+
+PCmpInteger : PCmp Integer;
+PCmpInteger = { cmpEq = PEqInteger, cmp = integerCmp };
+
+PCmpRational : PCmp Rational;
+PCmpRational = { cmpEq = PEqRational, cmp = rationalCmp };
+
+PCmpVec : (n : Nat) -> (a : sort 0) -> PCmp a -> PCmp (Vec n a);
+PCmpVec n a pa = { cmpEq = PEqVec n a pa.cmpEq, cmp = vecCmp n a pa.cmp };
+
+PCmpSeq : (n : Num) -> (a : sort 0) -> PCmp a -> PCmp (seq n a);
+PCmpSeq n =
+  Num#rec (\ (n:Num) -> (a : sort 0) -> PCmp a -> PCmp (seq n a))
+          (\ (n:Nat) -> PCmpVec n)
+          (\ (a:sort 0) (pa : PCmp a) -> error (PCmp (Stream a)) "invalid Cmp instance")
+          n;
+
+PCmpWord : (n : Nat) -> PCmp (Vec n Bool);
+PCmpWord n = { cmpEq = PEqWord n, cmp = bvCmp n };
+
+PCmpSeqBool : (n : Num) -> PCmp (seq n Bool);
+PCmpSeqBool n =
+  Num#rec (\ (n : Num) -> PCmp (seq n Bool))
+          (\ (n:Nat) -> PCmpWord n)
+          (error (PCmp (Stream Bool)) "invalid Cmp instance")
+          n;
+
+PCmpUnit : PCmp #();
+PCmpUnit = { cmpEq = PEqUnit, cmp = unitCmp };
+
+PCmpPair : (a b : sort 0) -> PCmp a -> PCmp b -> PCmp (a * b);
+PCmpPair a b pa pb =
+  { cmpEq  = PEqPair a b pa.cmpEq pb.cmpEq
+  , cmp = pairCmp a b pa.cmp pb.cmp
+  };
+
+-- SignedCmp class
+
+PSignedCmp : sort 0 -> sort 1;
+PSignedCmp a =
+   #{ signedCmpEq : PEq a
+    , scmp : a -> a -> Bool -> Bool
+    };
+
+PSignedCmpVec : (n : Nat) -> (a : sort 0) -> PSignedCmp a -> PSignedCmp (Vec n a);
+PSignedCmpVec n a pa =
+   { signedCmpEq = PEqVec n a pa.signedCmpEq
+   , scmp = vecCmp n a pa.scmp
+   };
+
+PSignedCmpSeq : (n : Num) -> (a : sort 0) -> PSignedCmp a -> PSignedCmp (seq n a);
+PSignedCmpSeq n =
+  Num#rec (\ (n:Num) -> (a : sort 0) -> PSignedCmp a -> PSignedCmp (seq n a))
+          (\ (n:Nat) -> PSignedCmpVec n)
+          (\ (a:sort 0) (pa : PSignedCmp a) -> error (PSignedCmp (Stream a)) "invalid SignedCmp instance")
+          n;
+
+PSignedCmpWord : (n : Nat) -> PSignedCmp (Vec n Bool);
+PSignedCmpWord n = { signedCmpEq = PEqWord n, scmp = bvSCmp n };
+
+PSignedCmpSeqBool : (n : Num) -> PSignedCmp (seq n Bool);
+PSignedCmpSeqBool n =
+  Num#rec (\ (n : Num) -> PSignedCmp (seq n Bool))
+          (\ (n:Nat) -> PSignedCmpWord n)
+          (error (PSignedCmp (Stream Bool)) "invalid SignedCmp instance")
+          n;
+
+PSignedCmpUnit : PSignedCmp #();
+PSignedCmpUnit = { signedCmpEq = PEqUnit, scmp = unitCmp };
+
+PSignedCmpPair : (a b : sort 0) -> PSignedCmp a -> PSignedCmp b -> PSignedCmp (a * b);
+PSignedCmpPair a b pa pb =
+  { signedCmpEq = PEqPair a b pa.signedCmpEq pb.signedCmpEq
+  , scmp = pairCmp a b pa.scmp pb.scmp
+  };
+
+
+-- Zero class
+
+PZero : sort 0 -> sort 0;
+PZero a = a;
+
+PZeroBit : PZero Bool;
+PZeroBit = False;
+
+PZeroInteger : PZero Integer;
+PZeroInteger = natToInt 0;
+
+PZeroIntMod : (n : Nat) -> PZero (IntMod n);
+PZeroIntMod n = toIntMod n (natToInt 0);
+
+PZeroRational : PZero Rational;
+PZeroRational = integerToRational (natToInt 0);
+
+PZeroIntModNum : (num : Num) -> PZero (IntModNum num);
+PZeroIntModNum num = Num#rec (\ (n : Num) -> PZero (IntModNum n)) PZeroIntMod PZeroInteger num;
+
+PZeroSeq : (n : Num) -> (a : sort 0) -> PZero a -> PZero (seq n a);
+PZeroSeq n a pa = seqConst n a pa;
+
+PZeroSeqBool : (n : Num) -> PZero (seq n Bool);
+PZeroSeqBool n =
+  Num#rec (\ (n:Num) -> PZero (seq n Bool))
+          (\ (n:Nat) -> bvNat n 0)
+          (streamConst Bool False)
+          n;
+
+PZeroFun : (a b : sort 0) -> PZero b -> PZero (a -> b);
+PZeroFun a b pb = (\(_ : a) -> pb);
+
+-- Logic class
+
+PLogic : sort 0 -> sort 1;
+PLogic a =
+  #{ logicZero : PZero a
+   , and  : a -> a -> a
+   , or   : a -> a -> a
+   , xor  : a -> a -> a
+   , not  : a -> a
+   };
+
+PLogicBit : PLogic Bool;
+PLogicBit =
+  { logicZero = PZeroBit
+  , and  = and
+  , or   = or
+  , xor  = xor
+  , not  = not
+  };
+
+PLogicVec : (n : Nat) -> (a : sort 0) -> PLogic a -> PLogic (Vec n a);
+PLogicVec n a pa =
+  { logicZero = replicate n a pa.logicZero
+  , and  = zipWith a a a pa.and n
+  , or   = zipWith a a a pa.or  n
+  , xor  = zipWith a a a pa.xor n
+  , not  = map a a pa.not n
+  };
+
+PLogicStream : (a : sort 0) -> PLogic a -> PLogic (Stream a);
+PLogicStream a pa =
+  { logicZero = streamConst a pa.logicZero
+  , and  = streamMap2 a a a pa.and
+  , or   = streamMap2 a a a pa.or
+  , xor  = streamMap2 a a a pa.xor
+  , not  = streamMap a a pa.not
+  };
+
+PLogicSeq : (n : Num) -> (a : sort 0) -> PLogic a -> PLogic (seq n a);
+PLogicSeq n =
+  Num#rec (\ (n:Num) -> (a:sort 0) -> PLogic a -> PLogic (seq n a))
+          (\ (n:Nat) -> PLogicVec n) PLogicStream n;
+
+PLogicWord : (n : Nat) -> PLogic (Vec n Bool);
+PLogicWord n =
+  { logicZero = bvNat n 0
+  , and  = bvAnd n
+  , or   = bvOr  n
+  , xor  = bvXor n
+  , not  = bvNot n
+  };
+
+PLogicSeqBool : (n : Num) -> PLogic (seq n Bool);
+PLogicSeqBool n =
+  Num#rec (\ (n:Num) -> PLogic (seq n Bool))
+          (\ (n:Nat) -> PLogicWord n) (PLogicStream Bool PLogicBit) n;
+
+PLogicFun : (a b : sort 0) -> PLogic b -> PLogic (a -> b);
+PLogicFun a b pb =
+  { logicZero = PZeroFun a b pb.logicZero
+  , and  = funBinary a b pb.and
+  , or   = funBinary a b pb.or
+  , xor  = funBinary a b pb.xor
+  , not  = compose a b b pb.not
+  };
+
+PLogicUnit : PLogic #();
+PLogicUnit =
+  { logicZero = ()
+  , and  = unitBinary
+  , or   = unitBinary
+  , xor  = unitBinary
+  , not  = unitUnary
+  };
+
+PLogicPair : (a b : sort 0) -> PLogic a -> PLogic b -> PLogic (a * b);
+PLogicPair a b pa pb =
+  { logicZero = (pa.logicZero, pb.logicZero)
+  , and  = pairBinary a b pa.and pb.and
+  , or   = pairBinary a b pa.or  pb.or
+  , xor  = pairBinary a b pa.xor pb.xor
+  , not  = pairUnary a b pa.not pb.not
+  };
+
+-- Ring class
+
+PRing : sort 0 -> sort 1;
+PRing a =
+  #{ ringZero : PZero a
+   , add  : a -> a -> a
+   , sub  : a -> a -> a
+   , mul  : a -> a -> a
+   , neg  : a -> a
+   , int  : Integer -> a
+   };
+
+PRingInteger : PRing Integer;
+PRingInteger =
+  { ringZero = PZeroInteger
+  , add = intAdd
+  , sub = intSub
+  , mul = intMul
+  , neg = intNeg
+  , int = \ (i : Integer) -> i
+  };
+
+PRingIntMod : (n : Nat) -> PRing (IntMod n);
+PRingIntMod n =
+  { ringZero = PZeroIntMod n
+  , add = intModAdd n
+  , sub = intModSub n
+  , mul = intModMul n
+  , neg = intModNeg n
+  , int = toIntMod n
+  };
+
+PRingIntModNum : (num : Num) -> PRing (IntModNum num);
+PRingIntModNum num =
+  Num#rec (\ (n : Num) -> PRing (IntModNum n)) PRingIntMod PRingInteger num;
+
+PRingRational : PRing Rational;
+PRingRational =
+  { ringZero = PZeroRational
+  , add = addRational
+  , sub = subRational
+  , mul = mulRational
+  , neg = negRational
+  , int = integerToRational
+  };
+
+PRingVec : (n : Nat) -> (a : sort 0) -> PRing a -> PRing (Vec n a);
+PRingVec n a pa =
+  { ringZero = replicate n a pa.ringZero
+  , add = zipWith a a a pa.add n
+  , sub = zipWith a a a pa.sub n
+  , mul = zipWith a a a pa.mul n
+  , neg = map a a pa.neg n
+  , int = \ (i : Integer) -> replicate n a (pa.int i)
+  };
+
+PRingStream : (a : sort 0) -> PRing a -> PRing (Stream a);
+PRingStream a pa =
+  { ringZero = streamConst a pa.ringZero
+  , add = streamMap2 a a a pa.add
+  , sub = streamMap2 a a a pa.sub
+  , mul = streamMap2 a a a pa.mul
+  , neg = streamMap a a pa.neg
+  , int = \ (i : Integer) -> streamConst a (pa.int i)
+  };
+
+PRingSeq : (n : Num) -> (a : sort 0) -> PRing a -> PRing (seq n a);
+PRingSeq n =
+  Num#rec (\ (n : Num) -> (a : sort 0) -> PRing a -> PRing (seq n a))
+          (\ (n:Nat) -> PRingVec n)
+          PRingStream
+          n;
+
+PRingWord : (n : Nat) -> PRing (Vec n Bool);
+PRingWord n =
+  { ringZero = bvNat n 0
+  , add = bvAdd n
+  , sub = bvSub n
+  , mul = bvMul n
+  , neg = bvNeg n
+  , int = intToBv n
+  };
+
+PRingSeqBool : (n : Num) -> PRing (seq n Bool);
+PRingSeqBool n =
+  Num#rec (\ (n:Num) -> PRing (seq n Bool))
+          (\ (n:Nat) -> PRingWord n)
+          (error (PRing (Stream Bool)) "PRingSeqBool: no instance for streams")
+          n;
+
+PRingFun : (a b : sort 0) -> PRing b -> PRing (a -> b);
+PRingFun a b pb =
+  { ringZero = PZeroFun a b pb.ringZero
+  , add = funBinary a b pb.add
+  , sub = funBinary a b pb.sub
+  , mul = funBinary a b pb.mul
+  , neg = compose a b b pb.neg
+  , int = \ (i : Integer) -> \ (_ : a) -> pb.int i
+  };
+
+PRingUnit : PRing #();
+PRingUnit =
+  { ringZero = ()
+  , add = unitBinary
+  , sub = unitBinary
+  , mul = unitBinary
+  , neg = unitUnary
+  , int = \ (i : Integer) -> ()
+  };
+
+PRingPair : (a b : sort 0) -> PRing a -> PRing b -> PRing (a * b);
+PRingPair a b pa pb =
+  { ringZero = (pa.ringZero, pb.ringZero)
+  , add = pairBinary a b pa.add pb.add
+  , sub = pairBinary a b pa.sub pb.sub
+  , mul = pairBinary a b pa.mul pb.mul
+  , neg = pairUnary a b pa.neg pb.neg
+  , int = \ (i : Integer) -> (pa.int i, pb.int i)
+  };
+
+-- Integral class
+
+PIntegral : sort 0 -> sort 1;
+PIntegral a =
+  #{ integralRing : PRing a
+   , div  : a -> a -> a
+   , mod  : a -> a -> a
+   , toInt : a -> Integer
+   , posNegCases :
+        (r : sort 0) ->
+	(Nat -> r) ->
+	(Nat -> r) ->
+	a -> r
+   };
+
+PIntegralInteger : PIntegral Integer;
+PIntegralInteger =
+   { integralRing = PRingInteger
+   , div = intDiv
+   , mod = intMod
+   , toInt = \(i:Integer) -> i
+   , posNegCases = \ (r:sort 0) -> \ (pos neg:Nat -> r) -> \ (i:Integer) ->
+        ite r (intLe (natToInt 0) i) (pos (intToNat i)) (neg (intToNat (intNeg i)))
+   };
+
+PIntegralWord : (n : Nat) -> PIntegral (Vec n Bool);
+PIntegralWord n =
+   { integralRing = PRingWord n
+   , div = bvUDiv n
+   , mod = bvURem n
+   , toInt = bvToInt n
+
+     -- words are always considered non-negative
+   , posNegCases = \ (r:sort 0) -> \ (pos neg:Nat -> r) -> \(i:Vec n Bool) -> pos (bvToNat n i)
+   };
+
+PIntegralSeqBool : (n : Num) -> PIntegral (seq n Bool);
+PIntegralSeqBool n =
+  Num#rec (\ (n:Num) -> PIntegral (seq n Bool))
+          (\ (n:Nat) -> PIntegralWord n)
+          (error (PIntegral (Stream Bool)) "PIntegralSeqBool: no instance for streams")
+	  n;
+
+
+-- Field class
+
+PField : sort 0 -> sort 1;
+PField a =
+  #{ fieldRing : PRing a
+   , recip     : a -> a
+   , fieldDiv  : a -> a -> a
+   };
+
+PFieldRational : PField Rational;
+PFieldRational =
+  { fieldRing = PRingRational
+  , recip     = \(x : Rational) -> error Rational "Unimplemented: recip Rational"
+  , fieldDiv  = \(x y : Rational) -> error Rational "Unimplemented: (/.) Rational"
+  };
+
+
+-- Round class
+
+PRound : sort 0 -> sort 1;
+PRound a =
+  #{ roundField  : PField a
+   , roundCmp    : PCmp a
+   , floor       : a -> Integer
+   , ceiling     : a -> Integer
+   , trunc       : a -> Integer
+   , roundAway   : a -> Integer
+   , roundToEven : a -> Integer
+   };
+
+PRoundRational : PRound Rational;
+PRoundRational =
+  { roundField	= PFieldRational
+  , roundCmp	= PCmpRational
+  , floor	= \(x : Rational) -> error Integer "Unimplemented: floor Rational"
+  , ceiling	= \(x : Rational) -> error Integer "Unimplemented: ceiling Rational"
+  , trunc	= \(x : Rational) -> error Integer "Unimplemented: trunc Rational"
+  , roundAway	= \(x : Rational) -> error Integer "Unimplemented: roundAway Rational"
+  , roundToEven = \(x : Rational) -> error Integer "Unimplemented: roundToEven Rational"
+  };
+
+
+-- Literal class
+
+-- Compared to Cryptol class 'Literal val a', we omit the 'val' parameter here.
+
+PLiteral : (a : sort 0) -> sort 0;
+PLiteral a = Nat -> a;
+
+PLiteralSeqBool : (n : Num) -> PLiteral (seq n Bool);
+PLiteralSeqBool n =
+  Num#rec (\ (n : Num) -> PLiteral (seq n Bool)) bvNat
+          (error (PLiteral (Stream Bool)) "PLiteralSeqBool: no instance for streams") n;
+
+PLiteralInteger : PLiteral Integer;
+PLiteralInteger = natToInt;
+
+PLiteralIntMod : (n : Nat) -> PLiteral (IntMod n);
+PLiteralIntMod n = \ (x : Nat) -> toIntMod n (natToInt x);
+
+PLiteralIntModNum : (num : Num) -> PLiteral (IntModNum num);
+PLiteralIntModNum num =
+  Num#rec (\ (n : Num) -> PLiteral (IntModNum n)) PLiteralIntMod PLiteralInteger num;
+
+PLiteralRational : PLiteral Rational;
+PLiteralRational = \ (x : Nat) -> error Rational "Unimplemented: Literal Rational";
+
+-- TODO: FLiteral class
+
+
+--------------------------------------------------------------------------------
+-- Primitive Cryptol functions
+
+ecNumber : (val : Num) -> (a : sort 0) -> PLiteral a -> a;
+ecNumber val a pa =
+  Num#rec (\ (_ : Num) -> a) pa (pa 0) val;
+  -- Dummy case: treat `inf as `0 (this never happens anyway)
+
+ecFromZ : (n : Num) -> IntModNum n -> Integer;
+ecFromZ n =
+  Num#rec (\ (n : Num) -> IntModNum n -> Integer)
+          fromIntMod
+	  (\ (x : Integer) -> x)
+	  n;
+
+-- Ring
+ecFromInteger : (a : sort 0) -> PRing a -> Integer -> a;
+ecFromInteger a pa = pa.int;
+
+ecPlus : (a : sort 0) -> PRing a -> a -> a -> a;
+ecPlus a pa = pa.add;
+
+ecMinus : (a : sort 0) -> PRing a -> a -> a -> a;
+ecMinus a pa = pa.sub;
+
+ecMul : (a : sort 0) -> PRing a -> a -> a -> a;
+ecMul a pa = pa.mul;
+
+ecNeg : (a : sort 0) -> PRing a -> a -> a;
+ecNeg a pa = pa.neg;
+
+-- Integral
+ecToInteger : (a : sort 0) -> PIntegral a -> a -> Integer;
+ecToInteger a pa = pa.toInt;
+
+ecDiv : (a : sort 0) -> PIntegral a -> a -> a -> a;
+ecDiv a pi = pi.div;
+
+ecMod : (a : sort 0) -> PIntegral a -> a -> a -> a;
+ecMod a pi = pi.mod;
+
+ecExp : (a b: sort 0) -> PRing a -> PIntegral b -> a -> b -> a;
+ecExp a b pa pi x =
+  pi.posNegCases a
+    (expByNat a (pa.int (natToInt 1)) pa.mul x)
+    (\ (_:Nat) -> pa.int (natToInt 1));
+    -- (error (Nat -> a) "ecExp : negative exponent");
+
+-- Field
+
+ecRecip : (a: sort 0) -> PField a -> a -> a;
+ecRecip a pf = pf.recip;
+
+ecFieldDiv : (a: sort 0) -> PField a -> a -> a -> a;
+ecFieldDiv a pf = pf.fieldDiv;
+
+-- Round
+
+ecCeiling : (a: sort 0) -> PRound a -> a -> Integer;
+ecCeiling a pr = pr.ceiling;
+
+ecFloor : (a: sort 0) -> PRound a -> a -> Integer;
+ecFloor a pr = pr.floor;
+
+ecTruncate : (a: sort 0) -> PRound a -> a -> Integer;
+ecTruncate a pr = pr.trunc;
+
+ecRoundAway : (a: sort 0) -> PRound a -> a -> Integer;
+ecRoundAway a pr = pr.roundAway;
+
+ecRoundToEven : (a: sort 0) -> PRound a -> a -> Integer;
+ecRoundToEven a pr = pr.roundToEven;
+
+-- Bitvector ops
+
+ecLg2 : (n : Num) -> seq n Bool -> seq n Bool;
+ecLg2 n =
+  Num#rec (\ (n:Num) -> seq n Bool -> seq n Bool)
+    bvLg2
+    (error (Stream Bool -> Stream Bool) "ecLg2: expected finite word")
+    n;
+
+ecSDiv : (n : Num) -> seq n Bool -> seq n Bool -> seq n Bool;
+ecSDiv n =
+  Num#rec (\ (n:Num) -> seq n Bool -> seq n Bool -> seq n Bool)
+    (Nat__rec (\ (n:Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool)
+      (error (Vec 0 Bool -> Vec 0 Bool -> Vec 0 Bool) "ecSDiv: illegal 0-width word")
+      (\ (n':Nat) -> \ (_:Vec n' Bool -> Vec n' Bool -> Vec n' Bool) -> bvSDiv n'))
+    (error (Stream Bool -> Stream Bool -> Stream Bool) "ecSDiv: expected finite word")
+    n;
+
+ecSMod : (n : Num) -> seq n Bool -> seq n Bool -> seq n Bool;
+ecSMod n =
+  Num#rec (\ (n:Num) -> seq n Bool -> seq n Bool -> seq n Bool)
+    (Nat__rec (\ (n:Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool)
+      (error (Vec 0 Bool -> Vec 0 Bool -> Vec 0 Bool) "ecSMod: illegal 0-width word")
+      (\ (n':Nat) -> \ (_:Vec n' Bool -> Vec n' Bool -> Vec n' Bool) -> bvSRem n'))
+    (error (Stream Bool -> Stream Bool -> Stream Bool) "ecSMod: expected finite word")
+    n;
+
+
+-- Eq
+ecEq : (a : sort 0) -> PEq a -> a -> a -> Bool;
+ecEq a pa = pa.eq;
+
+ecNotEq : (a : sort 0) -> PEq a -> a -> a -> Bool;
+ecNotEq a pa x y = not (ecEq a pa x y);
+
+-- Cmp
+ecLt : (a : sort 0) -> PCmp a -> a -> a -> Bool;
+ecLt a pa x y = pa.cmp x y False;
+
+ecGt : (a : sort 0) -> PCmp a -> a -> a -> Bool;
+ecGt a pa x y = ecLt a pa y x;
+
+ecLtEq  : (a : sort 0) -> PCmp a -> a -> a -> Bool;
+ecLtEq a pa x y = not (ecLt a pa y x);
+
+ecGtEq  : (a : sort 0) -> PCmp a -> a -> a -> Bool;
+ecGtEq a pa x y = not (ecLt a pa x y);
+
+-- SignedCmp
+ecSLt : (a : sort 0) -> PSignedCmp a -> a -> a -> Bool;
+ecSLt a pa x y = pa.scmp x y False;
+
+-- Logic
+ecAnd : (a : sort 0) -> PLogic a -> a -> a -> a;
+ecAnd a pa = pa.and;
+
+ecOr : (a : sort 0) -> PLogic a -> a -> a -> a;
+ecOr a pa = pa.or;
+
+ecXor : (a : sort 0) -> PLogic a -> a -> a -> a;
+ecXor a pa = pa.xor;
+
+ecCompl : (a : sort 0) -> PLogic a -> a -> a;
+ecCompl a pa = pa.not;
+
+ecZero : (a : sort 0) -> PZero a -> a;
+ecZero a pa = pa;
+
+-- FLiteral
+
+ecFraction : (a : sort 0) -> a;
+ecFraction a = error a "Unimplemented: fraction";
+
+
+-- Sequences
+ecShiftL : (m : Num) -> (ix a : sort 0) -> PIntegral ix -> PZero a ->
+            seq m a -> ix -> seq m a;
+ecShiftL m =
+  Num#rec
+    (\ (m:Num) -> (ix a : sort 0) -> PIntegral ix -> PZero a -> seq m a -> ix -> seq m a)
+
+    -- Case for (TCNum m)
+    (\ (m:Nat) -> \ (ix:sort 0) -> \ (a:sort 0) -> \ (pix : PIntegral ix) -> \ (pz:PZero a) -> \ (xs:Vec m a) ->
+        pix.posNegCases (Vec m a)
+	  (shiftL m a (ecZero a pz) xs)
+	  (shiftR m a (ecZero a pz) xs))
+
+    -- Case for (infinity)
+    (\ (ix:sort 0) -> \ (a:sort 0) -> \ (pix : PIntegral ix) -> \ (pz:PZero a) ->
+       \ (xs:Stream a) ->
+        pix.posNegCases (Stream a)
+	  (streamShiftL a xs)
+	  (streamShiftR a pz xs))
+    m;
+
+ecShiftR : (m : Num) -> (ix a : sort 0) -> PIntegral ix -> PZero a ->
+            seq m a -> ix -> seq m a;
+ecShiftR m =
+  Num#rec
+    (\ (m : Num) -> (ix a : sort 0) -> PIntegral ix -> PZero a -> seq m a -> ix -> seq m a)
+
+    -- Case for (TCNum m)
+    (\ (m:Nat) -> \ (ix:sort 0) -> \ (a:sort 0) -> \ (pix : PIntegral ix) -> \ (pz:PZero a) -> \ (xs:Vec m a) ->
+        pix.posNegCases (Vec m a)
+	  (shiftR m a (ecZero a pz) xs)
+	  (shiftL m a (ecZero a pz) xs))
+
+    -- Case for (infinity)
+    (\ (ix:sort 0) -> \ (a:sort 0) -> \ (pix : PIntegral ix) -> \ (pz:PZero a) -> \ (xs:Stream a) ->
+        pix.posNegCases (Stream a)
+	  (streamShiftR a pz xs)
+	  (streamShiftL a xs))
+    m;
+
+ecSShiftR : (n : Num) -> (ix : sort 0) -> PIntegral ix -> seq n Bool -> ix -> seq n Bool;
+ecSShiftR =
+  finNumRec
+    (\ (n:Num) -> (ix : sort 0) -> PIntegral ix -> seq n Bool -> ix -> seq n Bool)
+    (\ (n:Nat) ->
+         (\ (ix : sort 0) -> \ (pix : PIntegral ix) ->
+            natCase
+              (\ (w : Nat) -> bitvector w -> ix -> bitvector w)
+              (\ (xs : bitvector 0) -> \ (_ : ix) -> xs)
+              (\ (w : Nat) -> \ (xs : bitvector (Succ w)) ->
+                   pix.posNegCases (bitvector (Succ w))
+		     (bvSShr w xs)
+		     (bvShl (Succ w) xs))
+              n));
+
+ecRotL : (m : Num) -> (ix a : sort 0) -> PIntegral ix -> seq m a -> ix -> seq m a;
+ecRotL =
+  finNumRec
+    (\ (m:Num) -> (ix a : sort 0) -> PIntegral ix -> seq m a -> ix -> seq m a)
+    (\ (m:Nat) -> \ (ix:sort 0) -> \ (a:sort 0) -> \ (pix:PIntegral ix) -> \ (xs:Vec m a) ->
+      pix.posNegCases (Vec m a)
+        (rotateL m a xs)
+	(rotateR m a xs));
+
+ecRotR : (m : Num) -> (ix a : sort 0) -> PIntegral ix -> seq m a -> ix -> seq m a;
+ecRotR =
+  finNumRec
+    (\ (m:Num) -> (ix a : sort 0) -> PIntegral ix -> seq m a -> ix -> seq m a)
+    (\ (m:Nat) -> \ (ix:sort 0) -> \ (a:sort 0) -> \ (pix:PIntegral ix) -> \ (xs:Vec m a) ->
+      pix.posNegCases (Vec m a)
+        (rotateR m a xs)
+	(rotateL m a xs));
+
+ecCat : (m n : Num) -> (a : sort 0) -> seq m a -> seq n a -> seq (tcAdd m n) a;
+ecCat =
+  finNumRec
+    (\ (m:Num) -> (n:Num) -> (a:sort 0) -> seq m a -> seq n a ->
+       seq (tcAdd m n) a)
+    (\ (m:Nat) ->
+       Num_rec
+         (\ (n:Num) -> (a:sort 0) -> Vec m a -> seq n a ->
+            seq (tcAdd (TCNum m) n) a)
+         -- Case for (TCNum m, TCNum n)
+         (\ (n:Nat) -> \ (a:sort 0) -> append m n a)
+         -- Case for (TCNum m, TCInf)
+         (\ (a:sort 0) -> streamAppend a m));
+
+ecSplitAt : (m n : Num) -> (a : sort 0) -> seq (tcAdd m n) a ->
+             #(seq m a, seq n a);
+ecSplitAt =
+  finNumRec
+    (\ (m:Num) -> (n:Num) -> (a:sort 0) -> seq (tcAdd m n) a ->
+       #(seq m a, seq n a))
+    (\ (m:Nat) ->
+       Num_rec
+         (\ (n:Num) -> (a:sort 0) -> seq (tcAdd (TCNum m) n) a ->
+            #(Vec m a, seq n a))
+         -- The case (TCNum n, TCNum m)
+         (\ (n:Nat) -> \ (a:sort 0) -> \ (xs: Vec (addNat m n) a) ->
+            (take a m n xs, drop a m n xs))
+         -- The case (TCNum m, infinity)
+         (\ (a:sort 0) -> \ (xs: Stream a) ->
+            (streamTake a m xs, streamDrop a m xs)));
+
+ecJoin : (m n : Num) -> (a : sort 0) -> seq m (seq n a) -> seq (tcMul m n) a;
+ecJoin m =
+  Num#rec
+    (\ (m:Num) -> (n:Num) -> (a:sort 0) -> seq m (seq n a) ->
+       seq (tcMul m n) a)
+    (\ (m:Nat) ->
+       finNumRec
+         (\ (n:Num) -> (a:sort 0) -> Vec m (seq n a) ->
+            seq (tcMul (TCNum m) n) a)
+         -- Case for (TCNum m, TCNum n)
+         (\ (n:Nat) -> \ (a:sort 0) -> join m n a)
+         -- No case for (TCNum m, TCInf)
+         )
+    (finNumRec
+       (\ (n:Num) -> (a:sort 0) -> Stream (seq n a) ->
+          seq (tcMul TCInf n) a)
+       -- Case for (TCInf, TCNum n)
+       (\ (n:Nat) -> \ (a:sort 0) ->
+          natCase
+            (\ (n':Nat) -> Stream (Vec n' a) ->
+               seq (if0Nat Num n' (TCNum 0) TCInf) a)
+            (\ (s:Stream (Vec 0 a)) -> EmptyVec a)
+            (\ (n':Nat) -> \ (s:Stream (Vec (Succ n') a)) ->
+               streamJoin a n' s)
+            n)
+       -- No case for (TCInf, TCInf)
+       )
+    m;
+
+ecSplit : (m n : Num) -> (a : sort 0) -> seq (tcMul m n) a ->
+           seq m (seq n a);
+ecSplit m =
+  Num#rec
+    (\ (m:Num) -> (n:Num) -> (a:sort 0) -> seq (tcMul m n) a ->
+       seq m (seq n a))
+    (\ (m:Nat) ->
+       finNumRec
+         (\ (n:Num) -> (a:sort 0) -> seq (tcMul (TCNum m) n) a ->
+            Vec m (seq n a))
+         -- Case for (TCNum m, TCNum n)
+         (\ (n:Nat) -> \ (a:sort 0) -> split m n a)
+         -- No case for (TCNum m, TCInf)
+         )
+    (finNumRec
+       (\ (n:Num) -> (a:sort 0) -> seq (tcMul TCInf n) a -> Stream (seq n a))
+       -- Case for (TCInf, TCNum n)
+       (\ (n:Nat) -> \ (a:sort 0) ->
+          natCase
+            (\ (n':Nat) ->
+               seq (if0Nat Num n' (TCNum 0) TCInf) a ->
+               Stream (Vec n' a))
+            (streamConst (Vec 0 a))
+            (\ (n':Nat) -> streamSplit a (Succ n'))
+            n))
+    m;
+
+ecReverse : (n : Num) -> (a : sort 0) -> seq n a -> seq n a;
+ecReverse =
+  finNumRec
+    (\ (n:Num) -> (a:sort 0) -> seq n a -> seq n a) reverse;
+
+ecTranspose : (m n : Num) -> (a : sort 0) -> seq m (seq n a) ->
+               seq n (seq m a);
+ecTranspose m n a =
+  Num#rec
+    (\ (m : Num) -> seq m (seq n a) -> seq n (seq m a))
+    (\ (m : Nat) ->
+      Num#rec
+        (\ (n : Num) -> Vec m (seq n a) -> seq n (Vec m a))
+        (\ (n : Nat) -> transpose m n a)
+        (\ (xss : Vec m (Stream a)) ->
+          MkStream (Vec m a) (\ (i : Nat) ->
+            gen m a (\ (j : Nat) ->
+              streamGet a (at m (Stream a) xss j) i)))
+        n
+    )
+    ( Num#rec
+        (\ (n : Num) -> Stream (seq n a) -> seq n (Stream a))
+        (\ (n : Nat) -> \ (xss : Stream (Vec n a)) ->
+          gen n (Stream a) (\ (i : Nat) ->
+            MkStream a (\ (j : Nat) ->
+              at n a (streamGet (Vec n a) xss j) i)))
+        (\ (xss : Stream (Stream a)) ->
+          MkStream (Stream a) (\ (i : Nat) ->
+            MkStream a (\ (j : Nat) ->
+              streamGet a (streamGet (Stream a) xss j) i)))
+        n
+    )
+    m;
+
+ecAt : (n : Num) -> (a ix: sort 0) -> PIntegral ix -> seq n a -> ix -> a;
+ecAt n =
+  Num#rec
+    (\ (n:Num) -> (a ix: sort 0) -> PIntegral ix -> seq n a -> ix -> a)
+    (\ (n:Nat) -> \ (a:sort 0) -> \ (ix:sort 0) -> \ (pix:PIntegral ix) -> \ (xs:Vec n a) ->
+          pix.posNegCases a
+	    (at n a xs)
+	    (\ (_:Nat) -> at n a xs 0))
+	    -- (error (Nat -> a) "ecAt : negative index"))
+    (\ (a:sort 0) -> \ (ix:sort 0) -> \ (pix:PIntegral ix) -> \ (xs:Stream a) ->
+          pix.posNegCases a
+	    (streamGet a xs)
+	    (\ (_:Nat) -> streamGet a xs 0))
+--	    (error (Nat -> a) "ecAt : negative index"))
+    n;
+
+ecAtBack : (n : Num) -> (a ix : sort 0) -> PIntegral ix -> seq n a -> ix -> a;
+ecAtBack n a ix pix xs = ecAt n a ix pix (ecReverse n a xs);
+
+ecFromTo : (first last : Num) -> (a : sort 0) -> PLiteral a -> PLiteral a ->
+            seq (tcAdd (TCNum 1) (tcSub last first)) a;
+ecFromTo =
+  finNumRec
+    (\ (first:Num) -> (last:Num) -> (a : sort 0) -> PLiteral a -> PLiteral a ->
+       seq (tcAdd (TCNum 1) (tcSub last first)) a)
+    (\ (first:Nat) ->
+       finNumRec
+         (\ (last:Num) -> (a : sort 0) -> PLiteral a -> PLiteral a ->
+            seq (tcAdd (TCNum 1) (tcSub last (TCNum first))) a)
+         (\ (last:Nat) -> \ (a : sort 0) -> \ (pa : PLiteral a) -> \ (_ : PLiteral a) ->
+            gen (addNat 1 (subNat last first)) a
+                (\ (i : Nat) -> pa (addNat i first))));
+
+ecFromThenTo :
+  (first next last : Num) -> (a : sort 0) -> (len : Num) ->
+  PLiteral a -> PLiteral a -> PLiteral a -> seq len a;
+ecFromThenTo first next _ a =
+  finNumRec
+    (\ (len:Num) -> PLiteral a -> PLiteral a -> PLiteral a -> seq len a)
+    (\ (len:Nat) -> \ (pa : PLiteral a) -> \ (_ : PLiteral a) -> \ (_ : PLiteral a) ->
+       gen len a
+           (\ (i : Nat) ->
+              pa (subNat (addNat (getFinNat first)
+                                 (mulNat i (getFinNat next)))
+                         (mulNat i (getFinNat first)))));
+
+-- Infinite word sequences
+ecInfFrom : (a : sort 0) -> PIntegral a -> a -> seq TCInf a;
+ecInfFrom a pa x =
+  MkStream a (\ (i : Nat) -> pa.integralRing.add x (pa.integralRing.int (natToInt i)));
+
+ecInfFromThen : (a : sort 0) -> PIntegral a -> a -> a -> seq TCInf a;
+ecInfFromThen a pa x y =
+  MkStream a (\ (i : Nat) ->
+    pa.integralRing.add x (pa.integralRing.mul (pa.integralRing.sub y x) (pa.integralRing.int (natToInt i))));
+
+
+-- Run-time error
+ecError : (a : sort 0) -> (len : Num) -> seq len (bitvector 8) -> a;
+ecError a len msg = error a "encountered call to the Cryptol 'error' function"; -- FIXME: don't throw away message
+{-
+primitive cryError : (a : sort 0) -> (n : Nat) -> Vec n (bitvector 8) -> a;
+
+ecError : (a : sort 0) -> (len : Num) -> seq len (bitvector 8) -> a;
+ecError a =
+  finNumRec
+    (\ (len:Num) -> seq len (bitvector 8) -> a)
+    (\ (len:Nat) -> cryError a len);
+-}
+
+-- Random values
+ecRandom : (a : sort 0) -> bitvector 32 -> a;
+ecRandom a _ = error a "Cryptol.random";
+
+-- Trace function; simply return the final argument
+ecTrace : (n : Num) -> (a b : sort 0) -> seq n (bitvector 8) -> a -> b -> b;
+ecTrace _ _ _ _ _ x = x;
+
+
+--------------------------------------------------------------------------------
+-- Floating point primitives (TODO)
+
+TCFloat : Num -> Num -> sort 0;
+TCFloat _ _ = #();
+
+PEqFloat : (e p : Num) -> PEq (TCFloat e p);
+PEqFloat e p = { eq = \(x y : TCFloat e p) -> error Bool "Unimplemented: (==) Float" };
+
+PCmpFloat : (e p : Num) -> PCmp (TCFloat e p);
+PCmpFloat e p =
+  { cmpEq = PEqFloat e p
+  , cmp = \(x y : TCFloat e p) (k : Bool) -> error Bool "Unimplemented: Cmp Float"
+  };
+
+PZeroFloat : (e p : Num) -> PZero (TCFloat e p);
+PZeroFloat e p = error (TCFloat e p) "Unimplemented: Zero Float";
+
+PRingFloat : (e p : Num) -> PRing (TCFloat e p);
+PRingFloat e p =
+  { ringZero = PZeroFloat e p
+  , add = \(x y : TCFloat e p) -> error (TCFloat e p) "Unimplemented: (+) Float"
+  , sub = \(x y : TCFloat e p) -> error (TCFloat e p) "Unimplemented: (-) Float"
+  , mul = \(x y : TCFloat e p) -> error (TCFloat e p) "Unimplemented: (*) Float"
+  , neg = \(x : TCFloat e p) -> error (TCFloat e p) "Unimplemented: neg Float"
+  , int = \ (i : Integer) -> error (TCFloat e p) "Unimplemented: toInteger Float"
+  };
+
+PFieldFloat : (e p : Num) -> PField (TCFloat e p);
+PFieldFloat e p =
+  { fieldRing = PRingFloat e p
+  , recip     = \(x : TCFloat e p) -> error (TCFloat e p) "Unimplemented: recip Float"
+  , fieldDiv  = \(x y : TCFloat e p) -> error (TCFloat e p) "Unimplemented: (/.) Float"
+  };
+
+PRoundFloat : (e p : Num) -> PRound (TCFloat e p);
+PRoundFloat e p =
+  { roundField  = PFieldFloat e p
+  , roundCmp    = PCmpFloat e p
+  , floor       = \(x : TCFloat e p) -> error Integer "Unimplemented: floor Float"
+  , ceiling     = \(x : TCFloat e p) -> error Integer "Unimplemented: ceiling Float"
+  , trunc       = \(x : TCFloat e p) -> error Integer "Unimplemented: trunc Float"
+  , roundAway   = \(x : TCFloat e p) -> error Integer "Unimplemented: roundAway Float"
+  , roundToEven = \(x : TCFloat e p) -> error Integer "Unimplemented: roundToEven Float"
+  };
+
+ecFpNaN : (e : Num) -> (p : Num) -> TCFloat e p;
+ecFpNaN e p = error (TCFloat e p) "Unimplemented: fpNaN";
+
+ecFpPosInf : (e : Num) -> (p : Num) -> TCFloat e p;
+ecFpPosInf e p = error (TCFloat e p) "Unimplemented: fpPosInf";
+
+ecFpFromBits : (e : Num) -> (p : Num) -> seq (tcAdd e p) Bool -> TCFloat e p;
+ecFpFromBits e p _ = error (TCFloat e p) "Unimplemented: fpFromBits";
+
+ecFpToBits : (e : Num) -> (p : Num) -> TCFloat e p -> seq (tcAdd e p) Bool;
+ecFpToBits e p _ = error (seq (tcAdd e p) Bool) "Unimplemented: fpToBits";
+
+ecFpEq : (e : Num) -> (p : Num) -> TCFloat e p -> TCFloat e p -> Bool;
+ecFpEq e p _ _ = error Bool "Unimplemented: =.=";
+
+ecFpAdd : (e : Num) -> (p : Num) -> bitvector 3 -> TCFloat e p -> TCFloat e p -> TCFloat e p;
+ecFpAdd e p _ _ _ = error (TCFloat e p) "Unimplemented: fpAdd";
+
+ecFpSub : (e : Num) -> (p : Num) -> bitvector 3 -> TCFloat e p -> TCFloat e p -> TCFloat e p;
+ecFpSub e p _ _ _ = error (TCFloat e p) "Unimplemented: fpSub";
+
+ecFpMul : (e : Num) -> (p : Num) -> bitvector 3 -> TCFloat e p -> TCFloat e p -> TCFloat e p;
+ecFpMul e p _ _ _ = error (TCFloat e p) "Unimplemented: fpMul";
+
+ecFpDiv : (e : Num) -> (p : Num) -> bitvector 3 -> TCFloat e p -> TCFloat e p -> TCFloat e p;
+ecFpDiv e p _ _ _ = error (TCFloat e p) "Unimplemented: fpDiv";
+
+ecFpIsFinite : (e : Num) -> (p : Num) -> TCFloat e p -> Bool;
+ecFpIsFinite e p _ = error Bool "Unimplemented: fpIsFinite";
+
+ecFpToRational : (e : Num) -> (p : Num) -> TCFloat e p -> Rational;
+ecFpToRational e p _ = error Rational "Unimplemented: fpToRational";
+
+ecFpFromRational : (e : Num) -> (p : Num) -> bitvector 3 -> Rational -> TCFloat e p;
+ecFpFromRational e p _ _ = error (TCFloat e p) "Unimplemented: fpFromRational";
+
+
+--------------------------------------------------------------------------------
+-- Extra primitives
+
+-- Array update
+ecUpdate : (n : Num) -> (a ix: sort 0) -> PIntegral ix -> seq n a -> ix -> a -> seq n a;
+ecUpdate n =
+  Num#rec
+    (\ (n:Num) -> (a ix : sort 0) -> PIntegral ix -> seq n a -> ix -> a -> seq n a)
+    (\ (n:Nat) -> \ (a:sort 0) -> \ (ix : sort 0) -> \ (pix:PIntegral ix) -> \ (xs : Vec n a) ->
+       -- Case for (TCNum n, TCNum w)
+       pix.posNegCases (a -> Vec n a)
+         (upd n a xs)
+	 (\ (_:Nat) -> \ (_:a) -> xs))
+	 -- (error (Nat -> a -> Vec n a) "ecUpdate: negative index"))
+    (\ (a:sort 0) -> \ (ix:sort 0) -> \ (pix:PIntegral ix) -> \ (xs : Stream a) ->
+       pix.posNegCases (a -> Stream a)
+         (streamUpd a xs)
+	 (\ (_:Nat) -> \ (_:a) -> xs))
+	 --(error (Nat -> a -> Stream a) "ecUpdate: negative index"))
+    n;
+
+
+ecUpdateEnd : (n : Num) -> (a ix: sort 0) -> PIntegral ix -> seq n a -> ix -> a -> seq n a;
+ecUpdateEnd =
+  finNumRec
+    (\ (n:Num) -> (a ix: sort 0) -> PIntegral ix -> seq n a -> ix -> a -> seq n a)
+    (\ (n:Nat) -> \ (a:sort 0) -> \ (ix:sort 0) -> \ (pix:PIntegral ix) -> \ (xs:Vec n a) ->
+       pix.posNegCases (a -> Vec n a)
+         (\ (i:Nat) -> upd n a xs (subNat (subNat n 1) i))
+	 (\ (_:Nat) -> \ (_:a) -> xs));
+	 -- (error (Nat -> a -> Vec n a) "ecUpdateEnd: negative index"));
+
+
+-- Bitvector truncation
+ecTrunc : (m n : Num) -> seq (tcAdd m n) Bool -> seq n Bool;
+ecTrunc =
+  finNumRec2
+    (\ (m:Num) -> \ (n:Num) -> seq (tcAdd m n) Bool -> seq n Bool)
+    bvTrunc;
+
+-- Zero extension
+ecUExt : (m n : Num) -> seq n Bool -> seq (tcAdd m n) Bool;
+ecUExt =
+  finNumRec2 (\ (m:Num) -> \ (n:Num) -> seq n Bool -> seq (tcAdd m n) Bool)
+             bvUExt;
+
+ecSExt : (m n : Num) -> seq n Bool -> seq (tcAdd m n) Bool;
+ecSExt =
+  finNumRec2
+    (\ (m n : Num) -> seq n Bool -> seq (tcAdd m n) Bool)
+    (\ (m n : Nat) ->
+       natCase
+         (\ (n' : Nat) -> bitvector n' -> bitvector (addNat m n'))
+         (\ (_ : bitvector 0) -> bvNat (addNat m 0) 0)
+         (bvSExt m)
+         n);
+
+-- Signed greater-than
+ecSgt : (n : Num) -> seq n Bool -> seq n Bool -> Bool;
+ecSgt =
+  finNumRec (\ (n : Num) -> seq n Bool -> seq n Bool -> Bool) bvsgt;
+
+-- Signed greater-or-equal
+ecSge : (n : Num) -> seq n Bool -> seq n Bool -> Bool;
+ecSge =
+  finNumRec (\ (n : Num) -> seq n Bool -> seq n Bool -> Bool) bvsge;
+
+-- Signed less-than
+ecSlt : (n : Num) -> seq n Bool -> seq n Bool -> Bool;
+ecSlt =
+  finNumRec (\ (n : Num) -> seq n Bool -> seq n Bool -> Bool) bvslt;
+
+-- Signed less-or-equal
+ecSle : (n : Num) -> seq n Bool -> seq n Bool -> Bool;
+ecSle =
+  finNumRec (\ (n : Num) -> seq n Bool -> seq n Bool -> Bool) bvsle;
+
+-- Array operations
+ecArrayConstant : (a b : sort 0) -> b -> Array a b;
+ecArrayConstant = arrayConstant;
+
+ecArrayLookup : (a b : sort 0) -> (Array a b) -> a -> b;
+ecArrayLookup = arrayLookup;
+
+ecArrayUpdate : (a b : sort 0) -> (Array a b) -> a -> b -> (Array a b);
+ecArrayUpdate = arrayUpdate;
+
+--------------------------------------------------------------------------------
+-- Rewrite rules
+
+axiom replicate_False : (n : Nat) -> Eq (bitvector n) (replicate n Bool False) (bvNat n 0);
+
+axiom subNat_0 : (n : Nat) -> Eq Nat (subNat n 0) n;
+
+{-
+axiom demote_add_distr
+  : (w : Nat)
+  -> (x y : Num)
+  -> Eq (bitvector w)
+        (ecNumber (tcAdd x y) (TCNum w))
+        (bvAdd w (ecNumber x (TCNum w)) (ecNumber y (TCNum w)));
+-}
+
+--------------------------------------------------------------------------------

--- a/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
@@ -1,0 +1,1555 @@
+{-# OPTIONS_GHC -Wall #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE TupleSections #-}
+
+{- |
+Module      : Verifier.SAW.Cryptol
+Copyright   : Galois, Inc. 2012-2015
+License     : BSD3
+Maintainer  : huffman@galois.com
+Stability   : experimental
+Portability : non-portable (language extensions)
+-}
+
+module Verifier.SAW.Cryptol where
+
+import Control.Monad (foldM, join, unless)
+import Data.Bifunctor (first)
+import qualified Data.Foldable as Fold
+import Data.List
+import qualified Data.IntTrie as IntTrie
+import Data.Map (Map)
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import qualified Data.Vector as Vector
+import Prelude ()
+import Prelude.Compat
+
+import qualified Cryptol.Eval.Type as TV
+import qualified Cryptol.Eval.Monad as V
+import qualified Cryptol.Eval.Value as V
+import qualified Cryptol.Eval.Concrete.Value as V
+import Cryptol.Eval.Type (evalValType)
+import qualified Cryptol.TypeCheck.AST as C
+import qualified Cryptol.TypeCheck.Subst as C (Subst, apSubst, singleTParamSubst)
+import qualified Cryptol.ModuleSystem.Name as C (asPrim, nameIdent)
+import qualified Cryptol.Utils.Ident as C (Ident, PrimIdent(..), packIdent, unpackIdent, prelPrim, floatPrim, arrayPrim)
+import qualified Cryptol.Utils.Logger as C (quietLogger)
+import qualified Cryptol.Utils.RecordMap as C
+import Cryptol.TypeCheck.TypeOf (fastTypeOf, fastSchemaOf)
+import Cryptol.Utils.PP (pretty)
+
+import Verifier.SAW.Cryptol.Panic
+import Verifier.SAW.Conversion
+import Verifier.SAW.FiniteValue (FirstOrderType(..), FirstOrderValue(..))
+import qualified Verifier.SAW.Simulator.Concrete as SC
+import Verifier.SAW.Prim (BitVector(..))
+import Verifier.SAW.Rewriter
+import Verifier.SAW.SharedTerm
+import Verifier.SAW.Simulator.MonadLazy (force)
+import Verifier.SAW.TypedAST (mkSort, mkModuleName, FieldName)
+
+import GHC.Stack
+
+--------------------------------------------------------------------------------
+-- Type Environments
+
+-- | SharedTerms are paired with a deferred shift amount for loose variables
+data Env = Env
+  { envT :: Map Int    (Term, Int) -- ^ Type variables are referenced by unique id
+  , envE :: Map C.Name (Term, Int) -- ^ Term variables are referenced by name
+  , envP :: Map C.Prop (Term, [FieldName], Int)
+              -- ^ Bound propositions are referenced implicitly by their types
+              --   The actual class dictionary we need is obtained by applying the
+              --   given field selectors (in reverse order!) to the term.
+  , envC :: Map C.Name C.Schema    -- ^ Cryptol type environment
+  , envS :: [Term]                 -- ^ SAW-Core bound variable environment (for type checking)
+  }
+
+emptyEnv :: Env
+emptyEnv = Env Map.empty Map.empty Map.empty Map.empty []
+
+liftTerm :: (Term, Int) -> (Term, Int)
+liftTerm (t, j) = (t, j + 1)
+
+liftProp :: (Term, [FieldName], Int) -> (Term, [FieldName], Int)
+liftProp (t, fns, j) = (t, fns, j + 1)
+
+-- | Increment dangling bound variables of all types in environment.
+liftEnv :: Env -> Env
+liftEnv env =
+  Env { envT = fmap liftTerm (envT env)
+      , envE = fmap liftTerm (envE env)
+      , envP = fmap liftProp (envP env)
+      , envC = envC env
+      , envS = envS env
+      }
+
+bindTParam :: SharedContext -> C.TParam -> Env -> IO Env
+bindTParam sc tp env = do
+  let env' = liftEnv env
+  v <- scLocalVar sc 0
+  k <- importKind sc (C.tpKind tp)
+  return $ env' { envT = Map.insert (C.tpUnique tp) (v, 0) (envT env')
+                , envS = k : envS env }
+
+bindName :: SharedContext -> C.Name -> C.Schema -> Env -> IO Env
+bindName sc name schema env = do
+  let env' = liftEnv env
+  v <- scLocalVar sc 0
+  t <- importSchema sc env schema
+  return $ env' { envE = Map.insert name (v, 0) (envE env')
+                , envC = Map.insert name schema (envC env')
+                , envS = t : envS env' }
+
+bindProp :: SharedContext -> C.Prop -> Env -> IO Env
+bindProp sc prop env = do
+  let env' = liftEnv env
+  v <- scLocalVar sc 0
+  k <- scSort sc (mkSort 0)
+  return $ env' { envP = insertSupers prop [] v (envP env')
+                , envS = k : envS env'
+                }
+
+-- | When we insert a nonerasable prop into the environment, make
+--   sure to also insert all its superclasses.  We arrange it so
+--   that every class dictionary contains the implementation of its
+--   superclass dictionaries, which can be extracted via field projections.
+insertSupers ::
+  C.Prop ->
+  [FieldName] {- Field names to project the associated class (in reverse order) -} ->
+  Term ->
+  Map C.Prop (Term, [FieldName], Int) ->
+  Map C.Prop (Term, [FieldName], Int)
+insertSupers prop fs v m
+  -- If the prop is already in the map, stop
+  | Just _ <- Map.lookup prop m = m
+
+  -- Insert the prop and check if it has any superclasses that also need to be added
+  | otherwise = Map.insert (normalizeProp prop) (v, fs, 0) $ go prop
+
+ where
+ super p f t = insertSupers (C.TCon (C.PC p) [t]) (f:fs) v
+
+ go (C.TCon (C.PC p) [t]) =
+    case p of
+      C.PRing      -> super C.PZero "ringZero" t m
+      C.PLogic     -> super C.PZero "logicZero" t m
+      C.PField     -> super C.PRing "fieldRing" t m
+      C.PIntegral  -> super C.PRing "integralRing" t m
+      C.PRound     -> super C.PField "roundField" t . super C.PCmp "roundCmp" t $ m
+      C.PCmp       -> super C.PEq "cmpEq" t m
+      C.PSignedCmp -> super C.PEq "signedCmpEq" t m
+      _ -> m
+ go _ = m
+
+
+-- | We normalize the first argument of 'Literal' class constraints
+-- arbitrarily to 'inf', so that we can ignore that parameter when
+-- matching dictionaries.
+normalizeProp :: C.Prop -> C.Prop
+normalizeProp prop =
+  case C.pIsLiteral prop of
+    Just (_, a) -> C.pLiteral C.tInf a
+    Nothing -> prop
+
+--------------------------------------------------------------------------------
+
+importKind :: SharedContext -> C.Kind -> IO Term
+importKind sc kind =
+  case kind of
+    C.KType       -> scSort sc (mkSort 0)
+    C.KNum        -> scDataTypeApp sc "Cryptol.Num" []
+    C.KProp       -> scSort sc (mkSort 0)
+    (C.:->) k1 k2 -> join $ scFun sc <$> importKind sc k1 <*> importKind sc k2
+
+importTFun :: SharedContext -> C.TFun -> IO Term
+importTFun sc tf =
+  case tf of
+    C.TCWidth         -> scGlobalDef sc "Cryptol.tcWidth"
+    C.TCAdd           -> scGlobalDef sc "Cryptol.tcAdd"
+    C.TCSub           -> scGlobalDef sc "Cryptol.tcSub"
+    C.TCMul           -> scGlobalDef sc "Cryptol.tcMul"
+    C.TCDiv           -> scGlobalDef sc "Cryptol.tcDiv"
+    C.TCMod           -> scGlobalDef sc "Cryptol.tcMod"
+    C.TCExp           -> scGlobalDef sc "Cryptol.tcExp"
+    C.TCMin           -> scGlobalDef sc "Cryptol.tcMin"
+    C.TCMax           -> scGlobalDef sc "Cryptol.tcMax"
+    C.TCCeilDiv       -> scGlobalDef sc "Cryptol.tcCeilDiv"
+    C.TCCeilMod       -> scGlobalDef sc "Cryptol.tcCeilMod"
+    C.TCLenFromThenTo -> scGlobalDef sc "Cryptol.tcLenFromThenTo"
+
+-- | Precondition: @not ('isErasedProp' pc)@.
+importPC :: SharedContext -> C.PC -> IO Term
+importPC sc pc =
+  case pc of
+    C.PEqual     -> panic "importPC PEqual" []
+    C.PNeq       -> panic "importPC PNeq" []
+    C.PGeq       -> panic "importPC PGeq" []
+    C.PFin       -> panic "importPC PFin" []
+    C.PHas _     -> panic "importPC PHas" []
+    C.PZero      -> scGlobalDef sc "Cryptol.PZero"
+    C.PLogic     -> scGlobalDef sc "Cryptol.PLogic"
+    C.PRing      -> scGlobalDef sc "Cryptol.PRing"
+    C.PIntegral  -> scGlobalDef sc "Cryptol.PIntegral"
+    C.PField     -> scGlobalDef sc "Cryptol.PField"
+    C.PRound     -> scGlobalDef sc "Cryptol.PRound"
+    C.PEq        -> scGlobalDef sc "Cryptol.PEq"
+    C.PCmp       -> scGlobalDef sc "Cryptol.PCmp"
+    C.PSignedCmp -> scGlobalDef sc "Cryptol.PSignedCmp"
+    C.PLiteral   -> scGlobalDef sc "Cryptol.PLiteral"
+    C.PAnd       -> panic "importPC PAnd" []
+    C.PTrue      -> panic "importPC PTrue" []
+    C.PFLiteral  -> panic "importPC PFLiteral" []
+    C.PValidFloat -> panic "importPC PValidFloat" []
+
+-- | Translate size types to SAW values of type Num, value types to SAW types of sort 0.
+importType :: SharedContext -> Env -> C.Type -> IO Term
+importType sc env ty =
+  case ty of
+    C.TVar tvar ->
+      case tvar of
+        C.TVFree{} {- Int Kind (Set TVar) Doc -} -> unimplemented "TVFree"
+        C.TVBound v -> case Map.lookup (C.tpUnique v) (envT env) of
+                         Just (t, j) -> incVars sc 0 j t
+                         Nothing -> panic "importType TVBound" []
+    C.TUser _ _ t  -> go t
+    C.TRec fm ->
+      importType sc env (C.tTuple (map snd (C.canonicalFields fm)))
+
+    C.TCon tcon tyargs ->
+      case tcon of
+        C.TC tc ->
+          case tc of
+            C.TCNum n    -> scCtorApp sc "Cryptol.TCNum" =<< sequence [scNat sc (fromInteger n)]
+            C.TCInf      -> scCtorApp sc "Cryptol.TCInf" []
+            C.TCBit      -> scBoolType sc
+            C.TCInteger  -> scIntegerType sc
+            C.TCIntMod   -> scGlobalApply sc "Cryptol.IntModNum" =<< traverse go tyargs
+            C.TCFloat    -> scGlobalApply sc "Cryptol.TCFloat" =<< traverse go tyargs
+            C.TCArray    -> do a <- go (tyargs !! 0)
+                               b <- go (tyargs !! 1)
+                               scArrayType sc a b
+            C.TCRational -> scGlobalApply sc "Cryptol.Rational" []
+            C.TCSeq      -> scGlobalApply sc "Cryptol.seq" =<< traverse go tyargs
+            C.TCFun      -> do a <- go (tyargs !! 0)
+                               b <- go (tyargs !! 1)
+                               scFun sc a b
+            C.TCTuple _n -> scTupleType sc =<< traverse go tyargs
+            C.TCNewtype (C.UserTC _qn _k) -> unimplemented "TCNewtype" -- user-defined, @T@
+            C.TCAbstract{} -> panic "importType TODO: abstract type" []
+        C.PC pc ->
+          case pc of
+            C.PLiteral -> -- we omit first argument to class Literal
+              do a <- go (tyargs !! 1)
+                 scGlobalApply sc "Cryptol.PLiteral" [a]
+            _ ->
+              do pc' <- importPC sc pc
+                 tyargs' <- traverse go tyargs
+                 scApplyAll sc pc' tyargs'
+        C.TF tf ->
+          do tf' <- importTFun sc tf
+             tyargs' <- traverse go tyargs
+             scApplyAll sc tf' tyargs'
+        C.TError _k _msg ->
+          panic "importType TError" []
+  where
+    go = importType sc env
+
+isErasedProp :: C.Prop -> Bool
+isErasedProp prop =
+  case prop of
+    C.TCon (C.PC C.PZero     ) _ -> False
+    C.TCon (C.PC C.PLogic    ) _ -> False
+    C.TCon (C.PC C.PRing     ) _ -> False
+    C.TCon (C.PC C.PIntegral ) _ -> False
+    C.TCon (C.PC C.PField    ) _ -> False
+    C.TCon (C.PC C.PRound    ) _ -> False
+    C.TCon (C.PC C.PEq       ) _ -> False
+    C.TCon (C.PC C.PCmp      ) _ -> False
+    C.TCon (C.PC C.PSignedCmp) _ -> False
+    C.TCon (C.PC C.PLiteral  ) _ -> False
+    _ -> True
+
+importPropsType :: SharedContext -> Env -> [C.Prop] -> C.Type -> IO Term
+importPropsType sc env [] ty = importType sc env ty
+importPropsType sc env (prop : props) ty
+  | isErasedProp prop = importPropsType sc env props ty
+  | otherwise =
+    do p <- importType sc env prop
+       t <- importPropsType sc env props ty
+       scFun sc p t
+
+nameToString :: C.Name -> String
+nameToString = C.unpackIdent . C.nameIdent
+
+tparamToString :: C.TParam -> String
+--tparamToString tp = maybe "_" nameToString (C.tpName tp)
+tparamToString tp = maybe ("u" ++ show (C.tpUnique tp)) nameToString (C.tpName tp)
+
+importPolyType :: SharedContext -> Env -> [C.TParam] -> [C.Prop] -> C.Type -> IO Term
+importPolyType sc env [] props ty = importPropsType sc env props ty
+importPolyType sc env (tp : tps) props ty =
+  do k <- importKind sc (C.tpKind tp)
+     env' <- bindTParam sc tp env
+     t <- importPolyType sc env' tps props ty
+     scPi sc (tparamToString tp) k t
+
+importSchema :: SharedContext -> Env -> C.Schema -> IO Term
+importSchema sc env (C.Forall tparams props ty) = importPolyType sc env tparams props ty
+
+proveProp :: HasCallStack => SharedContext -> Env -> C.Prop -> IO Term
+proveProp sc env prop =
+  case Map.lookup (normalizeProp prop) (envP env) of
+
+    -- Class dictionary was provided as an argument
+    Just (prf, fs, j) ->
+       do -- shift deBruijn indicies by j
+          v <- incVars sc 0 j prf
+          -- apply field projections as necessary to compute superclasses
+          -- NB: reverse the order of the fields
+          foldM (scRecordSelect sc) v (reverse fs)
+
+    -- Class dictionary not provided, compute it from the structure of types
+    Nothing ->
+      case prop of
+        -- instance Zero Bit
+        (C.pIsZero -> Just (C.tIsBit -> True))
+          -> do scGlobalApply sc "Cryptol.PZeroBit" []
+        -- instance Zero Integer
+        (C.pIsZero -> Just (C.tIsInteger -> True))
+          -> do scGlobalApply sc "Cryptol.PZeroInteger" []
+        -- instance Zero (Z n)
+        (C.pIsZero -> Just (C.tIsIntMod -> Just n))
+          -> do n' <- importType sc env n
+                scGlobalApply sc "Cryptol.PZeroIntModNum" [n']
+        -- instance Zero Rational
+        (C.pIsZero -> Just (C.tIsRational -> True))
+          -> do scGlobalApply sc "Cryptol.PZeroRational" []
+        -- instance Zero [n]
+        (C.pIsZero -> Just (C.tIsSeq -> Just (n, C.tIsBit -> True)))
+          -> do n' <- importType sc env n
+                scGlobalApply sc "Cryptol.PZeroSeqBool" [n']
+        -- instance ValidFloat e p => Zero (Float e p)
+        (C.pIsZero -> Just (C.tIsFloat -> Just (e, p)))
+          -> do e' <- importType sc env e
+                p' <- importType sc env p
+                scGlobalApply sc "Cryptol.PZeroFloat" [e', p']
+        -- instance (Zero a) => Zero [n]a
+        (C.pIsZero -> Just (C.tIsSeq -> Just (n, a)))
+          -> do n' <- importType sc env n
+                a' <- importType sc env a
+                pa <- proveProp sc env (C.pZero a)
+                scGlobalApply sc "Cryptol.PZeroSeq" [n', a', pa]
+        -- instance (Zero b) => Zero (a -> b)
+        (C.pIsZero -> Just (C.tIsFun -> Just (a, b)))
+          -> do a' <- importType sc env a
+                b' <- importType sc env b
+                pb <- proveProp sc env (C.pZero b)
+                scGlobalApply sc "Cryptol.PZeroFun" [a', b', pb]
+        -- instance (Zero a, Zero b, ...) => Zero (a, b, ...)
+        (C.pIsZero -> Just (C.tIsTuple -> Just ts))
+          -> do ps <- traverse (proveProp sc env . C.pZero) ts
+                scTuple sc ps
+        -- instance (Zero a, Zero b, ...) => Zero { x : a, y : b, ... }
+        (C.pIsZero -> Just (C.tIsRec -> Just fm))
+          -> do proveProp sc env (C.pZero (C.tTuple (map snd (C.canonicalFields fm))))
+
+        -- instance Logic Bit
+        (C.pIsLogic -> Just (C.tIsBit -> True))
+          -> do scGlobalApply sc "Cryptol.PLogicBit" []
+        -- instance Logic [n]
+        (C.pIsLogic -> Just (C.tIsSeq -> Just (n, C.tIsBit -> True)))
+          -> do n' <- importType sc env n
+                scGlobalApply sc "Cryptol.PLogicSeqBool" [n']
+        -- instance (Logic a) => Logic [n]a
+        (C.pIsLogic -> Just (C.tIsSeq -> Just (n, a)))
+          -> do n' <- importType sc env n
+                a' <- importType sc env a
+                pa <- proveProp sc env (C.pLogic a)
+                scGlobalApply sc "Cryptol.PLogicSeq" [n', a', pa]
+        -- instance (Logic b) => Logic (a -> b)
+        (C.pIsLogic -> Just (C.tIsFun -> Just (a, b)))
+          -> do a' <- importType sc env a
+                b' <- importType sc env b
+                pb <- proveProp sc env (C.pLogic b)
+                scGlobalApply sc "Cryptol.PLogicFun" [a', b', pb]
+        -- instance Logic ()
+        (C.pIsLogic -> Just (C.tIsTuple -> Just []))
+          -> do scGlobalApply sc "Cryptol.PLogicUnit" []
+        -- instance (Logic a, Logic b) => Logic (a, b)
+        (C.pIsLogic -> Just (C.tIsTuple -> Just [t]))
+          -> do proveProp sc env (C.pLogic t)
+        (C.pIsLogic -> Just (C.tIsTuple -> Just (t : ts)))
+          -> do a <- importType sc env t
+                b <- importType sc env (C.tTuple ts)
+                pa <- proveProp sc env (C.pLogic t)
+                pb <- proveProp sc env (C.pLogic (C.tTuple ts))
+                scGlobalApply sc "Cryptol.PLogicPair" [a, b, pa, pb]
+        -- instance (Logic a, Logic b, ...) => instance Logic { x : a, y : b, ... }
+        (C.pIsLogic -> Just (C.tIsRec -> Just fm))
+          -> do proveProp sc env (C.pLogic (C.tTuple (map snd (C.canonicalFields fm))))
+
+        -- instance Ring Integer
+        (C.pIsRing -> Just (C.tIsInteger -> True))
+          -> do scGlobalApply sc "Cryptol.PRingInteger" []
+        -- instance Ring (Z n)
+        (C.pIsRing -> Just (C.tIsIntMod -> Just n))
+          -> do n' <- importType sc env n
+                scGlobalApply sc "Cryptol.PRingIntModNum" [n']
+        -- instance Ring Rational
+        (C.pIsRing -> Just (C.tIsRational -> True))
+          -> do scGlobalApply sc "Cryptol.PRingRational" []
+        -- instance (fin n) => Ring [n]
+        (C.pIsRing -> Just (C.tIsSeq -> Just (n, C.tIsBit -> True)))
+          -> do n' <- importType sc env n
+                scGlobalApply sc "Cryptol.PRingSeqBool" [n']
+        -- instance ValidFloat e p => Ring (Float e p)
+        (C.pIsRing -> Just (C.tIsFloat -> Just (e, p)))
+          -> do e' <- importType sc env e
+                p' <- importType sc env p
+                scGlobalApply sc "Cryptol.PRingFloat" [e', p']
+        -- instance (Ring a) => Ring [n]a
+        (C.pIsRing -> Just (C.tIsSeq -> Just (n, a)))
+          -> do n' <- importType sc env n
+                a' <- importType sc env a
+                pa <- proveProp sc env (C.pRing a)
+                scGlobalApply sc "Cryptol.PRingSeq" [n', a', pa]
+        -- instance (Ring b) => Ring (a -> b)
+        (C.pIsRing -> Just (C.tIsFun -> Just (a, b)))
+          -> do a' <- importType sc env a
+                b' <- importType sc env b
+                pb <- proveProp sc env (C.pRing b)
+                scGlobalApply sc "Cryptol.PRingFun" [a', b', pb]
+        -- instance Ring ()
+        (C.pIsRing -> Just (C.tIsTuple -> Just []))
+          -> do scGlobalApply sc "Cryptol.PRingUnit" []
+        -- instance (Ring a, Ring b) => Ring (a, b)
+        (C.pIsRing -> Just (C.tIsTuple -> Just [t]))
+          -> do proveProp sc env (C.pRing t)
+        (C.pIsRing -> Just (C.tIsTuple -> Just (t : ts)))
+          -> do a <- importType sc env t
+                b <- importType sc env (C.tTuple ts)
+                pa <- proveProp sc env (C.pRing t)
+                pb <- proveProp sc env (C.pRing (C.tTuple ts))
+                scGlobalApply sc "Cryptol.PRingPair" [a, b, pa, pb]
+        -- instance (Ring a, Ring b, ...) => instance Ring { x : a, y : b, ... }
+        (C.pIsRing -> Just (C.tIsRec -> Just fm))
+          -> do proveProp sc env (C.pRing (C.tTuple (map snd (C.canonicalFields fm))))
+
+        -- instance Integral Integer
+        (C.pIsIntegral -> Just (C.tIsInteger -> True))
+          -> do scGlobalApply sc "Cryptol.PIntegralInteger" []
+        -- instance Integral [n]
+        (C.pIsIntegral -> Just (C.tIsSeq -> (Just (n, C.tIsBit -> True))))
+          -> do n' <- importType sc env n
+                scGlobalApply sc "Cryptol.PIntegralSeqBool" [n']
+
+        -- instance Field Rational
+        (C.pIsField -> Just (C.tIsRational -> True))
+          -> do scGlobalApply sc "Cryptol.PFieldRational" []
+        -- instance (ValidFloat e p) => Field (Float e p)
+        (C.pIsField -> Just (C.tIsFloat -> Just (e, p)))
+          -> do e' <- importType sc env e
+                p' <- importType sc env p
+                scGlobalApply sc "Cryptol.PFieldFloat" [e', p']
+
+        -- instance Round Rational
+        (C.pIsRound -> Just (C.tIsRational -> True))
+          -> do scGlobalApply sc "Cryptol.PRoundRational" []
+        -- instance (ValidFloat e p) => Round (Float e p)
+        (C.pIsRound -> Just (C.tIsFloat -> Just (e, p)))
+          -> do e' <- importType sc env e
+                p' <- importType sc env p
+                scGlobalApply sc "Cryptol.PRoundFloat" [e', p']
+
+        -- instance Eq Bit
+        (C.pIsEq -> Just (C.tIsBit -> True))
+          -> do scGlobalApply sc "Cryptol.PEqBit" []
+        -- instance Eq Integer
+        (C.pIsEq -> Just (C.tIsInteger -> True))
+          -> do scGlobalApply sc "Cryptol.PEqInteger" []
+        -- instance Eq (Z n)
+        (C.pIsEq -> Just (C.tIsIntMod -> Just n))
+          -> do n' <- importType sc env n
+                scGlobalApply sc "Cryptol.PEqIntModNum" [n']
+        -- instance Eq Rational
+        (C.pIsEq -> Just (C.tIsRational -> True))
+          -> do scGlobalApply sc "Cryptol.PEqRational" []
+        -- instance Eq (Float e p)
+        (C.pIsEq -> Just (C.tIsFloat -> Just (e, p)))
+          -> do e' <- importType sc env e
+                p' <- importType sc env p
+                scGlobalApply sc "Cryptol.PEqFloat" [e', p']
+        -- instance (fin n) => Eq [n]
+        (C.pIsEq -> Just (C.tIsSeq -> Just (n, C.tIsBit -> True)))
+          -> do n' <- importType sc env n
+                scGlobalApply sc "Cryptol.PEqSeqBool" [n']
+        -- instance (fin n, Eq a) => Eq [n]a
+        (C.pIsEq -> Just (C.tIsSeq -> Just (n, a)))
+          -> do n' <- importType sc env n
+                a' <- importType sc env a
+                pa <- proveProp sc env (C.pEq a)
+                scGlobalApply sc "Cryptol.PEqSeq" [n', a', pa]
+        -- instance Eq ()
+        (C.pIsEq -> Just (C.tIsTuple -> Just []))
+          -> do scGlobalApply sc "Cryptol.PEqUnit" []
+        -- instance (Eq a, Eq b) => Eq (a, b)
+        (C.pIsEq -> Just (C.tIsTuple -> Just [t]))
+          -> do proveProp sc env (C.pEq t)
+        (C.pIsEq -> Just (C.tIsTuple -> Just (t : ts)))
+          -> do a <- importType sc env t
+                b <- importType sc env (C.tTuple ts)
+                pa <- proveProp sc env (C.pEq t)
+                pb <- proveProp sc env (C.pEq (C.tTuple ts))
+                scGlobalApply sc "Cryptol.PEqPair" [a, b, pa, pb]
+        -- instance (Eq a, Eq b, ...) => instance Eq { x : a, y : b, ... }
+        (C.pIsEq -> Just (C.tIsRec -> Just fm))
+          -> do proveProp sc env (C.pEq (C.tTuple (map snd (C.canonicalFields fm))))
+
+        -- instance Cmp Bit
+        (C.pIsCmp -> Just (C.tIsBit -> True))
+          -> do scGlobalApply sc "Cryptol.PCmpBit" []
+        -- instance Cmp Integer
+        (C.pIsCmp -> Just (C.tIsInteger -> True))
+          -> do scGlobalApply sc "Cryptol.PCmpInteger" []
+        -- instance Cmp Rational
+        (C.pIsCmp -> Just (C.tIsRational -> True))
+          -> do scGlobalApply sc "Cryptol.PCmpRational" []
+        -- instance Cmp (Float e p)
+        (C.pIsCmp -> Just (C.tIsFloat -> Just (e, p)))
+          -> do e' <- importType sc env e
+                p' <- importType sc env p
+                scGlobalApply sc "Cryptol.PCmpFloat" [e', p']
+        -- instance (fin n) => Cmp [n]
+        (C.pIsCmp -> Just (C.tIsSeq -> Just (n, C.tIsBit -> True)))
+          -> do n' <- importType sc env n
+                scGlobalApply sc "Cryptol.PCmpSeqBool" [n']
+        -- instance (fin n, Cmp a) => Cmp [n]a
+        (C.pIsCmp -> Just (C.tIsSeq -> Just (n, a)))
+          -> do n' <- importType sc env n
+                a' <- importType sc env a
+                pa <- proveProp sc env (C.pCmp a)
+                scGlobalApply sc "Cryptol.PCmpSeq" [n', a', pa]
+        -- instance Cmp ()
+        (C.pIsCmp -> Just (C.tIsTuple -> Just []))
+          -> do scGlobalApply sc "Cryptol.PCmpUnit" []
+        -- instance (Cmp a, Cmp b) => Cmp (a, b)
+        (C.pIsCmp -> Just (C.tIsTuple -> Just [t]))
+          -> do proveProp sc env (C.pCmp t)
+        (C.pIsCmp -> Just (C.tIsTuple -> Just (t : ts)))
+          -> do a <- importType sc env t
+                b <- importType sc env (C.tTuple ts)
+                pa <- proveProp sc env (C.pCmp t)
+                pb <- proveProp sc env (C.pCmp (C.tTuple ts))
+                scGlobalApply sc "Cryptol.PCmpPair" [a, b, pa, pb]
+        -- instance (Cmp a, Cmp b, ...) => instance Cmp { x : a, y : b, ... }
+        (C.pIsCmp -> Just (C.tIsRec -> Just fm))
+          -> do proveProp sc env (C.pCmp (C.tTuple (map snd (C.canonicalFields fm))))
+
+        -- instance (fin n) => SignedCmp [n]
+        (C.pIsSignedCmp -> Just (C.tIsSeq -> Just (n, C.tIsBit -> True)))
+          -> do n' <- importType sc env n
+                scGlobalApply sc "Cryptol.PSignedCmpSeqBool" [n']
+        -- instance (fin n, SignedCmp a) => SignedCmp [n]a
+        (C.pIsSignedCmp -> Just (C.tIsSeq -> Just (n, a)))
+          -> do n' <- importType sc env n
+                a' <- importType sc env a
+                pa <- proveProp sc env (C.pSignedCmp a)
+                scGlobalApply sc "Cryptol.PSignedCmpSeq" [n', a', pa]
+        -- instance SignedCmp ()
+        (C.pIsSignedCmp -> Just (C.tIsTuple -> Just []))
+          -> do scGlobalApply sc "Cryptol.PSignedCmpUnit" []
+        -- instance (SignedCmp a, SignedCmp b) => SignedCmp (a, b)
+        (C.pIsSignedCmp -> Just (C.tIsTuple -> Just [t]))
+          -> do proveProp sc env (C.pSignedCmp t)
+        (C.pIsSignedCmp -> Just (C.tIsTuple -> Just (t : ts)))
+          -> do a <- importType sc env t
+                b <- importType sc env (C.tTuple ts)
+                pa <- proveProp sc env (C.pSignedCmp t)
+                pb <- proveProp sc env (C.pSignedCmp (C.tTuple ts))
+                scGlobalApply sc "Cryptol.PSignedCmpPair" [a, b, pa, pb]
+        -- instance (SignedCmp a, SignedCmp b, ...) => instance SignedCmp { x : a, y : b, ... }
+        (C.pIsSignedCmp -> Just (C.tIsRec -> Just fm))
+          -> do proveProp sc env (C.pSignedCmp (C.tTuple (map snd (C.canonicalFields fm))))
+
+        -- instance Literal val Integer
+        (C.pIsLiteral -> Just (_, C.tIsInteger -> True))
+          -> do scGlobalApply sc "Cryptol.PLiteralInteger" []
+        -- instance Literal val (Z n)
+        (C.pIsLiteral -> Just (_, C.tIsIntMod -> Just n))
+          -> do n' <- importType sc env n
+                scGlobalApply sc "Cryptol.PLiteralIntModNum" [n']
+        -- instance Literal val Rational
+        (C.pIsLiteral -> Just (_, C.tIsRational -> True))
+          -> do scGlobalApply sc "Cryptol.PLiteralRational" []
+        -- instance (fin n, n >= width val) => Literal val [n]
+        (C.pIsLiteral -> Just (_, C.tIsSeq -> Just (n, C.tIsBit -> True)))
+          -> do n' <- importType sc env n
+                scGlobalApply sc "Cryptol.PLiteralSeqBool" [n']
+
+        _ -> do panic "proveProp" [pretty prop]
+
+
+importPrimitive :: SharedContext -> C.Name -> IO Term
+importPrimitive sc n
+  | Just nm <- C.asPrim n, Just term <- Map.lookup nm (prelPrims <> arrayPrims <> floatPrims) = term sc
+  | Just nm <- C.asPrim n = panic "Unknown Cryptol primitive name" [show nm]
+  | otherwise = panic "Improper Cryptol primitive name" [show n]
+
+prelPrims :: Map C.PrimIdent (SharedContext -> IO Term)
+prelPrims =
+  Map.fromList $
+  first C.prelPrim <$>
+  [ ("True",         flip scBool True)
+  , ("False",        flip scBool False)
+  , ("number",       flip scGlobalDef "Cryptol.ecNumber")      -- Converts a numeric type into its corresponding value.
+     --                                                        -- {val, a} (Literal val a) => a
+
+  , ("fromZ",        flip scGlobalDef "Cryptol.ecFromZ")       -- {n} (fin n, n >= 1) => Z n -> Integer
+
+    -- -- Zero
+  , ("zero",         flip scGlobalDef "Cryptol.ecZero")        -- {a} (Zero a) => a
+
+    -- -- Logic
+  , ("&&",           flip scGlobalDef "Cryptol.ecAnd")         -- {a} (Logic a) => a -> a -> a
+  , ("||",           flip scGlobalDef "Cryptol.ecOr")          -- {a} (Logic a) => a -> a -> a
+  , ("^",            flip scGlobalDef "Cryptol.ecXor")         -- {a} (Logic a) => a -> a -> a
+  , ("complement",   flip scGlobalDef "Cryptol.ecCompl")       -- {a} (Logic a) => a -> a
+
+    -- -- Ring
+  , ("fromInteger",  flip scGlobalDef "Cryptol.ecFromInteger") -- {a} (Ring a) => Integer -> a
+  , ("+",            flip scGlobalDef "Cryptol.ecPlus")        -- {a} (Ring a) => a -> a -> a
+  , ("-",            flip scGlobalDef "Cryptol.ecMinus")       -- {a} (Ring a) => a -> a -> a
+  , ("*",            flip scGlobalDef "Cryptol.ecMul")         -- {a} (Ring a) => a -> a -> a
+  , ("negate",       flip scGlobalDef "Cryptol.ecNeg")         -- {a} (Ring a) => a -> a
+
+    -- -- Integral
+  , ("toInteger",    flip scGlobalDef "Cryptol.ecToInteger")   -- {a} (Integral a) => a -> Integer
+  , ("/",            flip scGlobalDef "Cryptol.ecDiv")         -- {a} (Integral a) => a -> a -> a
+  , ("%",            flip scGlobalDef "Cryptol.ecMod")         -- {a} (Integral a) => a -> a -> a
+  , ("^^",           flip scGlobalDef "Cryptol.ecExp")         -- {a} (Ring a, Integral b) => a -> b -> a
+  , ("infFrom",      flip scGlobalDef "Cryptol.ecInfFrom")     -- {a} (Integral a) => a -> [inf]a
+  , ("infFromThen",  flip scGlobalDef "Cryptol.ecInfFromThen") -- {a} (Integral a) => a -> a -> [inf]a
+
+    -- -- Field
+  , ("recip",        flip scGlobalDef "Cryptol.ecRecip")       -- {a} (Field a) => a -> a
+  , ("/.",           flip scGlobalDef "Cryptol.ecFieldDiv")    -- {a} (Field a) => a -> a -> a
+
+    -- -- Round
+  , ("ceiling",      flip scGlobalDef "Cryptol.ecCeiling")     -- {a} (Round a) => a -> Integer
+  , ("floor",        flip scGlobalDef "Cryptol.ecFloor")       -- {a} (Round a) => a -> Integer
+  , ("trunc",        flip scGlobalDef "Cryptol.ecTruncate")    -- {a} (Round a) => a -> Integer
+  , ("roundAway",    flip scGlobalDef "Cryptol.ecRoundAway")   -- {a} (Round a) => a -> Integer
+  , ("roundToEven",  flip scGlobalDef "Cryptol.ecRoundToEven") -- {a} (Round a) => a -> Integer
+
+    -- -- Eq
+  , ("==",           flip scGlobalDef "Cryptol.ecEq")          -- {a} (Eq a) => a -> a -> Bit
+  , ("!=",           flip scGlobalDef "Cryptol.ecNotEq")       -- {a} (Eq a) => a -> a -> Bit
+
+    -- -- Cmp
+  , ("<",            flip scGlobalDef "Cryptol.ecLt")          -- {a} (Cmp a) => a -> a -> Bit
+  , (">",            flip scGlobalDef "Cryptol.ecGt")          -- {a} (Cmp a) => a -> a -> Bit
+  , ("<=",           flip scGlobalDef "Cryptol.ecLtEq")        -- {a} (Cmp a) => a -> a -> Bit
+  , (">=",           flip scGlobalDef "Cryptol.ecGtEq")        -- {a} (Cmp a) => a -> a -> Bit
+
+    -- -- SignedCmp
+  , ("<$",           flip scGlobalDef "Cryptol.ecSLt")         -- {a} (SignedCmp a) => a -> a -> Bit
+
+    -- -- Bitvector primitives
+  , ("/$",           flip scGlobalDef "Cryptol.ecSDiv")        -- {n} (fin n, n>=1) => [n] -> [n] -> [n]
+  , ("%$",           flip scGlobalDef "Cryptol.ecSMod")        -- {n} (fin n, n>=1) => [n] -> [n] -> [n]
+  , ("lg2",          flip scGlobalDef "Cryptol.ecLg2")         -- {n} (fin n) => [n] -> [n]
+  , (">>$",          flip scGlobalDef "Cryptol.ecSShiftR")     -- {n, ix} (fin n, n >= 1, Integral ix) => [n] -> ix -> [n]
+
+    -- -- Rational primitives
+  , ("ratio",        flip scGlobalDef "Cryptol.ecRatio")       -- Integer -> Integer -> Rational
+
+    -- -- FLiteral
+  , ("fraction",     flip scGlobalDef "Cryptol.ecFraction")    -- {m, n, r, a} FLiteral m n r a => a
+
+    -- -- Shifts/rotates
+  , ("<<",           flip scGlobalDef "Cryptol.ecShiftL")      -- {n, ix, a} (Integral ix, Zero a) => [n]a -> ix -> [n]a
+  , (">>",           flip scGlobalDef "Cryptol.ecShiftR")      -- {n, ix, a} (Integral ix, Zero a) => [n]a -> ix -> [n]a
+  , ("<<<",          flip scGlobalDef "Cryptol.ecRotL")        -- {n, ix, a} (fin n, Integral ix) => [n]a -> ix -> [n]a
+  , (">>>",          flip scGlobalDef "Cryptol.ecRotR")        -- {n, ix, a} (fin n, Integral ix) => [n]a -> ix -> [n]a
+
+    -- -- Sequences primitives
+  , ("#",            flip scGlobalDef "Cryptol.ecCat")         -- {a,b,d} (fin a) => [a] d -> [b] d -> [a + b] d
+  , ("splitAt",      flip scGlobalDef "Cryptol.ecSplitAt")     -- {a,b,c} (fin a) => [a+b] c -> ([a]c,[b]c)
+  , ("join",         flip scGlobalDef "Cryptol.ecJoin")        -- {a,b,c} (fin b) => [a][b]c -> [a * b]c
+  , ("split",        flip scGlobalDef "Cryptol.ecSplit")       -- {a,b,c} (fin b) => [a * b] c -> [a][b] c
+  , ("reverse",      flip scGlobalDef "Cryptol.ecReverse")     -- {a,b} (fin a) => [a] b -> [a] b
+  , ("transpose",    flip scGlobalDef "Cryptol.ecTranspose")   -- {a,b,c} [a][b]c -> [b][a]c
+  , ("@",            flip scGlobalDef "Cryptol.ecAt")          -- {n, a, ix} (Integral ix) => [n]a -> ix -> a
+  , ("!",            flip scGlobalDef "Cryptol.ecAtBack")      -- {n, a, ix} (fin n, Integral ix) => [n]a -> ix -> a
+  , ("update",       flip scGlobalDef "Cryptol.ecUpdate")      -- {n, a, ix} (Integral ix) => [n]a -> ix -> a -> [n]a
+  , ("updateEnd",    flip scGlobalDef "Cryptol.ecUpdateEnd")   -- {n, a, ix} (fin n, Integral ix) => [n]a -> ix -> a -> [n]a
+
+    -- -- Enumerations
+  , ("fromTo",       flip scGlobalDef "Cryptol.ecFromTo")
+    --                            -- fromTo : {first, last, bits, a}
+    --                            --           ( fin last, fin bits, last >== first,
+    --                            --             Literal first a, Literal last a)
+    --                            --        => [1 + (last - first)]a
+  , ("fromThenTo",   flip scGlobalDef "Cryptol.ecFromThenTo")
+    --                            -- fromThenTo : {first, next, last, a, len}
+    --                            --              ( fin first, fin next, fin last
+    --                            --              , Literal first a, Literal next a, Literal last a
+    --                            --              , first != next
+    --                            --              , lengthFromThenTo first next last == len) => [len]a
+
+    -- Experimental: parmap
+  , ("parmap",       flip scGlobalDef "Cryptol.ecParmap")      -- {a, b, n} (fin n) => (a -> b) -> [n]a -> [n]b
+
+  , ("error",        flip scGlobalDef "Cryptol.ecError")       -- {at,len} (fin len) => [len][8] -> at -- Run-time error
+  , ("random",       flip scGlobalDef "Cryptol.ecRandom")      -- {a} => [32] -> a -- Random values
+  , ("trace",        flip scGlobalDef "Cryptol.ecTrace")       -- {n,a,b} [n][8] -> a -> b -> b
+  ]
+
+arrayPrims :: Map C.PrimIdent (SharedContext -> IO Term)
+arrayPrims =
+  Map.fromList $
+  first C.arrayPrim <$>
+  [ ("arrayConstant", flip scGlobalDef "Cryptol.ecArrayConstant") -- {a,b} b -> Array a b
+  , ("arrayLookup",   flip scGlobalDef "Cryptol.ecArrayLookup") -- {a,b} Array a b -> a -> b
+  , ("arrayUpdate",   flip scGlobalDef "Cryptol.ecArrayUpdate") -- {a,b} Array a b -> a -> b -> Array a b
+  ]
+
+floatPrims :: Map C.PrimIdent (SharedContext -> IO Term)
+floatPrims =
+  Map.fromList $
+  first C.floatPrim <$>
+  [ ("fpNaN",          flip scGlobalDef "Cryptol.ecFpNaN")
+  , ("fpPosInf",       flip scGlobalDef "Cryptol.ecFpPosInf")
+  , ("fpFromBits",     flip scGlobalDef "Cryptol.ecFpFromBits")
+  , ("fpToBits",       flip scGlobalDef "Cryptol.ecFpToBits")
+  , ("=.=",            flip scGlobalDef "Cryptol.ecFpEq")
+  , ("fpAdd",          flip scGlobalDef "Cryptol.ecFpAdd")
+  , ("fpSub",          flip scGlobalDef "Cryptol.ecFpSub")
+  , ("fpMul",          flip scGlobalDef "Cryptol.ecFpMul")
+  , ("fpDiv",          flip scGlobalDef "Cryptol.ecFpDiv")
+  , ("fpIsFinite",     flip scGlobalDef "Cryptol.ecFpIsFinite")
+  , ("fpToRational",   flip scGlobalDef "Cryptol.ecFpToRational")
+  , ("fpFromRational", flip scGlobalDef "Cryptol.ecFpFromRational")
+  ]
+
+
+-- | Convert a Cryptol expression to a SAW-Core term. Calling
+-- 'scTypeOf' on the result of @'importExpr' sc env expr@ must yield a
+-- type that is equivalent (i.e. convertible) with the one returned by
+-- @'importSchema' sc env ('fastTypeOf' ('envC' env) expr)@.
+importExpr :: SharedContext -> Env -> C.Expr -> IO Term
+importExpr sc env expr =
+  case expr of
+    C.EList es t ->
+      do t' <- importType sc env t
+         es' <- traverse (importExpr' sc env (C.tMono t)) es
+         scVector sc t' es'
+
+    C.ETuple es ->
+      do es' <- traverse (importExpr sc env) es
+         scTuple sc es'
+
+    C.ERec fm ->
+      do es' <- traverse (importExpr sc env . snd) (C.canonicalFields fm)
+         scTuple sc es'
+
+    C.ESel e sel ->
+      -- Elimination for tuple/record/list
+      case sel of
+        C.TupleSel i _maybeLen ->
+          do e' <- importExpr sc env e
+             let t = fastTypeOf (envC env) e
+             case C.tIsTuple t of
+               Just ts ->
+                 do scTupleSelector sc e' (i+1) (length ts)
+               Nothing ->
+                 do f <- mapTupleSelector sc env i t
+                    scApply sc f e'
+        C.RecordSel x _ ->
+          do e' <- importExpr sc env e
+             let t = fastTypeOf (envC env) e
+             case C.tIsRec t of
+               Just fm ->
+                 do i <- the (elemIndex x (map fst (C.canonicalFields fm)))
+                    scTupleSelector sc e' (i+1) (length (C.canonicalFields fm))
+               Nothing ->
+                 do f <- mapRecordSelector sc env x t
+                    scApply sc f e'
+        C.ListSel i _maybeLen ->
+          do let t = fastTypeOf (envC env) e
+             (n, a) <-
+               case C.tIsSeq t of
+                 Just (n, a) -> return (n, a)
+                 Nothing -> panic "importExpr" ["ListSel: not a list type"]
+             a' <- importType sc env a
+             n' <- importType sc env n
+             e' <- importExpr sc env e
+             i' <- scNat sc (fromIntegral i)
+             scGlobalApply sc "Cryptol.eListSel" [a', n', e', i']
+
+    C.ESet e1 sel e2 ->
+      case sel of
+        C.TupleSel i _maybeLen ->
+          do e1' <- importExpr sc env e1
+             e2' <- importExpr sc env e2
+             let t1 = fastTypeOf (envC env) e1
+             case C.tIsTuple t1 of
+               Nothing -> panic "importExpr" ["ESet/TupleSel: not a tuple type"]
+               Just ts ->
+                 do ts' <- traverse (importType sc env) ts
+                    let t2' = ts' !! i
+                    f <- scGlobalApply sc "Cryptol.const" [t2', t2', e2']
+                    g <- tupleUpdate sc f i ts'
+                    scApply sc g e1'
+        C.RecordSel x _ ->
+          do e1' <- importExpr sc env e1
+             e2' <- importExpr sc env e2
+             let t1 = fastTypeOf (envC env) e1
+             case C.tIsRec t1 of
+               Nothing -> panic "importExpr" ["ESet/TupleSel: not a tuple type"]
+               Just tm ->
+                 do i <- the (elemIndex x (map fst (C.canonicalFields tm)))
+                    ts' <- traverse (importType sc env . snd) (C.canonicalFields tm)
+                    let t2' = ts' !! i
+                    f <- scGlobalApply sc "Cryptol.const" [t2', t2', e2']
+                    g <- tupleUpdate sc f i ts'
+                    scApply sc g e1'
+        C.ListSel _i _maybeLen ->
+          panic "importExpr" ["ESet/ListSel: unsupported"]
+
+    C.EIf e1 e2 e3 ->
+      do let ty = fastTypeOf (envC env) e2
+         ty' <- importType sc env ty
+         e1' <- importExpr sc env e1
+         e2' <- importExpr sc env e2
+         e3' <- importExpr' sc env (C.tMono ty) e3
+         scGlobalApply sc "Prelude.ite" [ty', e1', e2', e3']
+
+    C.EComp len eltty e mss ->
+      importComp sc env len eltty e mss
+
+    C.EVar qname ->
+      case Map.lookup qname (envE env) of
+        Just (e', j) -> incVars sc 0 j e'
+        Nothing      -> panic "importExpr" ["unknown variable: " ++ show qname]
+
+    C.ETAbs tp e ->
+      do env' <- bindTParam sc tp env
+         k <- importKind sc (C.tpKind tp)
+         e' <- importExpr sc env' e
+         scLambda sc (tparamToString tp) k e'
+
+    C.ETApp e t ->
+      do e' <- importExpr sc env e
+         t' <- importType sc env t
+         scApply sc e' t'
+
+    C.EApp e1 e2 ->
+      do e1' <- importExpr sc env e1
+         let t1 = fastTypeOf (envC env) e1
+         t1a <-
+           case C.tIsFun t1 of
+             Just (a, _) -> return a
+             Nothing -> panic "importExpr" ["expected function type"]
+         e2' <- importExpr' sc env (C.tMono t1a) e2
+         scApply sc e1' e2'
+
+    C.EAbs x t e ->
+      do t' <- importType sc env t
+         env' <- bindName sc x (C.tMono t) env
+         e' <- importExpr sc env' e
+         scLambda sc (nameToString x) t' e'
+
+    C.EProofAbs prop e
+      | isErasedProp prop -> importExpr sc env e
+      | otherwise ->
+        do p' <- importType sc env prop
+           env' <- bindProp sc prop env
+           e' <- importExpr sc env' e
+           scLambda sc "_P" p' e'
+
+    C.EProofApp e ->
+      case fastSchemaOf (envC env) e of
+        C.Forall [] (p : _ps) _ty
+          | isErasedProp p -> importExpr sc env e
+          | otherwise ->
+            do e' <- importExpr sc env e
+               prf <- proveProp sc env p
+               scApply sc e' prf
+        s -> panic "importExpr" ["EProofApp: invalid type: " ++ show (e, s)]
+
+    C.EWhere e dgs ->
+      do env' <- importDeclGroups sc env dgs
+         importExpr sc env' e
+
+  where
+    the :: Maybe a -> IO a
+    the = maybe (panic "importExpr" ["internal type error"]) return
+
+
+-- | Convert a Cryptol expression with the given type schema to a
+-- SAW-Core term. Calling 'scTypeOf' on the result of @'importExpr''
+-- sc env schema expr@ must yield a type that is equivalent (i.e.
+-- convertible) with the one returned by @'importSchema' sc env
+-- schema@.
+importExpr' :: SharedContext -> Env -> C.Schema -> C.Expr -> IO Term
+importExpr' sc env schema expr =
+  case expr of
+    C.ETuple es ->
+      do ty <- the (C.isMono schema)
+         ts <- the (C.tIsTuple ty)
+         es' <- sequence (zipWith go ts es)
+         scTuple sc es'
+
+    C.ERec fm ->
+      do ty <- the (C.isMono schema)
+         tm <- the (C.tIsRec ty)
+         es' <- sequence (zipWith go (map snd (C.canonicalFields tm)) (map snd (C.canonicalFields fm)))
+         scTuple sc es'
+
+    C.EIf e1 e2 e3 ->
+      do ty <- the (C.isMono schema)
+         ty' <- importType sc env ty
+         e1' <- importExpr sc env e1
+         e2' <- importExpr' sc env schema e2
+         e3' <- importExpr' sc env schema e3
+         scGlobalApply sc "Prelude.ite" [ty', e1', e2', e3']
+
+    C.ETAbs tp e ->
+      do schema' <-
+           case schema of
+             C.Forall (tp1 : tparams) props ty ->
+               let s = C.singleTParamSubst tp1 (C.TVar (C.TVBound tp))
+               in return (C.Forall tparams (map (plainSubst s) props) (plainSubst s ty))
+             C.Forall [] _ _ -> panic "importExpr'" ["internal error: unexpected type abstraction"]
+         env' <- bindTParam sc tp env
+         k <- importKind sc (C.tpKind tp)
+         e' <- importExpr' sc env' schema' e
+         scLambda sc (tparamToString tp) k e'
+
+    C.EAbs x _ e ->
+      do ty <- the (C.isMono schema)
+         (a, b) <- the (C.tIsFun ty)
+         a' <- importType sc env a
+         env' <- bindName sc x (C.tMono a) env
+         e' <- importExpr' sc env' (C.tMono b) e
+         scLambda sc (nameToString x) a' e'
+
+    C.EProofAbs _ e ->
+      do (prop, schema') <-
+           case schema of
+             C.Forall [] (p : ps) ty -> return (p, C.Forall [] ps ty)
+             C.Forall _ _ _ -> panic "importExpr" ["internal type error"]
+         if isErasedProp prop
+           then importExpr' sc env schema' e
+           else do p' <- importType sc env prop
+                   env' <- bindProp sc prop env
+                   e' <- importExpr' sc env' schema' e
+                   scLambda sc "_P" p' e'
+
+    C.EWhere e dgs ->
+      do env' <- importDeclGroups sc env dgs
+         importExpr' sc env' schema e
+
+    C.EList     {} -> fallback
+    C.ESel      {} -> fallback
+    C.ESet      {} -> fallback
+    C.EComp     {} -> fallback
+    C.EVar      {} -> fallback
+    C.EApp      {} -> fallback
+    C.ETApp     {} -> fallback
+    C.EProofApp {} -> fallback
+
+  where
+    go :: C.Type -> C.Expr -> IO Term
+    go t = importExpr' sc env (C.tMono t)
+
+    the :: Maybe a -> IO a
+    the = maybe (panic "importExpr" ["internal type error"]) return
+
+    fallback :: IO Term
+    fallback =
+      do let t1 = fastTypeOf (envC env) expr
+         t2 <- the (C.isMono schema)
+         expr' <- importExpr sc env expr
+         coerceTerm sc env t1 t2 expr'
+
+mapTupleSelector :: SharedContext -> Env -> Int -> C.Type -> IO Term
+mapTupleSelector sc env i = fmap fst . go
+  where
+    go :: C.Type -> IO (Term, C.Type)
+    go t =
+      case C.tNoUser t of
+        (C.tIsSeq -> Just (n, a)) -> do
+          (f, b) <- go a
+          a' <- importType sc env a
+          b' <- importType sc env b
+          n' <- importType sc env n
+          g <- scGlobalApply sc "Cryptol.seqMap" [a', b', n', f]
+          return (g, C.tSeq n b)
+        (C.tIsFun -> Just (n, a)) -> do
+          (f, b) <- go a
+          a' <- importType sc env a
+          b' <- importType sc env b
+          n' <- importType sc env n
+          g <- scGlobalApply sc "Cryptol.compose" [n', a', b', f]
+          return (g, C.tFun n b)
+        (C.tIsTuple -> Just ts) -> do
+          x <- scLocalVar sc 0
+          y <- scTupleSelector sc x (i+1) (length ts)
+          t' <- importType sc env t
+          f <- scLambda sc "x" t' y
+          return (f, ts !! i)
+        _ -> panic "importExpr" ["invalid tuple selector", show i, show t]
+
+mapRecordSelector :: SharedContext -> Env -> C.Ident -> C.Type -> IO Term
+mapRecordSelector sc env i = fmap fst . go
+  where
+    go :: C.Type -> IO (Term, C.Type)
+    go t =
+      case C.tNoUser t of
+        (C.tIsSeq -> Just (n, a)) ->
+          do (f, b) <- go a
+             a' <- importType sc env a
+             b' <- importType sc env b
+             n' <- importType sc env n
+             g <- scGlobalApply sc "Cryptol.seqMap" [a', b', n', f]
+             return (g, C.tSeq n b)
+        (C.tIsFun -> Just (n, a)) ->
+          do (f, b) <- go a
+             a' <- importType sc env a
+             b' <- importType sc env b
+             n' <- importType sc env n
+             g <- scGlobalApply sc "Cryptol.compose" [n', a', b', f]
+             return (g, C.tFun n b)
+        (C.tIsRec -> Just tm) | Just k <- elemIndex i (map fst (C.canonicalFields tm)) ->
+          do x <- scLocalVar sc 0
+             y <- scTupleSelector sc x (k+1) (length (C.canonicalFields tm))
+             t' <- importType sc env t
+             f <- scLambda sc "x" t' y
+             return (f, snd (C.canonicalFields tm !! k))
+        _ -> panic "importExpr" ["invalid record selector", show i, show t]
+
+tupleUpdate :: SharedContext -> Term -> Int -> [Term] -> IO Term
+tupleUpdate _ f 0 [_] = return f
+tupleUpdate sc f 0 (a : ts) =
+  do b <- scTupleType sc ts
+     scGlobalApply sc "Cryptol.updFst" [a, b, f]
+tupleUpdate sc f n (a : ts) =
+  do g <- tupleUpdate sc f (n - 1) ts
+     b <- scTupleType sc ts
+     scGlobalApply sc "Cryptol.updSnd" [a, b, g]
+tupleUpdate _ _ _ [] = panic "tupleUpdate" ["empty tuple"]
+
+-- | Apply a substitution to a type *without* simplifying
+-- constraints like @Ring [n]a@ to @Ring a@. (This is in contrast to
+-- 'apSubst', which performs simplifications wherever possible.)
+plainSubst :: C.Subst -> C.Type -> C.Type
+plainSubst s ty =
+  case ty of
+    C.TCon tc ts   -> C.TCon tc (map (plainSubst s) ts)
+    C.TUser f ts t -> C.TUser f (map (plainSubst s) ts) (plainSubst s t)
+    C.TRec fs      -> C.TRec (fmap (plainSubst s) fs)
+    C.TVar x       -> C.apSubst s (C.TVar x)
+
+-- | Currently this imports declaration groups by inlining all the
+-- definitions. (With subterm sharing, this is not as bad as it might
+-- seem.) We might want to think about generating let or where
+-- expressions instead.
+importDeclGroup :: Bool -> SharedContext -> Env -> C.DeclGroup -> IO Env
+
+importDeclGroup isTopLevel sc env (C.Recursive [decl]) =
+  case C.dDefinition decl of
+    C.DPrim ->
+      panic "importDeclGroup" ["Primitive declarations cannot be recursive:", show (C.dName decl)]
+    C.DExpr expr ->
+      do env1 <- bindName sc (C.dName decl) (C.dSignature decl) env
+         t' <- importSchema sc env (C.dSignature decl)
+         e' <- importExpr' sc env1 (C.dSignature decl) expr
+         let x = nameToString (C.dName decl)
+         f' <- scLambda sc x t' e'
+         rhs <- scGlobalApply sc "Prelude.fix" [t', f']
+         rhs' <- if not isTopLevel then return rhs else scConstant sc x rhs t'
+         let env' = env { envE = Map.insert (C.dName decl) (rhs', 0) (envE env)
+                        , envC = Map.insert (C.dName decl) (C.dSignature decl) (envC env) }
+         return env'
+
+
+-- - A group of mutually-recursive declarations -
+-- We handle this by "tupling up" all the declarations using a record and
+-- taking the fixpoint at this record type.  The desired declarations are then
+-- achieved by projecting the field names from this record.
+importDeclGroup isTopLevel sc env (C.Recursive decls) =
+  do -- build the environment for the declaration bodies
+     let dm = Map.fromList [ (C.dName d, d) | d <- decls ]
+
+     -- grab a reference to the outermost variable; this will be the record in the body
+     -- of the lambda we build later
+     v0 <- scLocalVar sc 0
+
+     -- build a list of projections from a record variable
+     vm <- traverse (scRecordSelect sc v0 . nameToString . C.dName) dm
+
+     -- the types of the declarations
+     tm <- traverse (importSchema sc env . C.dSignature) dm
+     -- the type of the recursive record
+     rect <- scRecordType sc (Map.assocs $ Map.mapKeys nameToString tm)
+
+     let env1 = liftEnv env
+     let env2 = env1 { envE = Map.union (fmap (\v -> (v, 0)) vm) (envE env1)
+                     , envC = Map.union (fmap C.dSignature dm) (envC env1)
+                     , envS = rect : envS env1 }
+
+     let extractDeclExpr decl =
+           case C.dDefinition decl of
+             C.DExpr expr -> importExpr' sc env2 (C.dSignature decl) expr
+             C.DPrim ->
+                panic "importDeclGroup"
+                        [ "Primitive declarations cannot be recursive:"
+                        , show (C.dName decl)
+                        ]
+
+     -- the raw imported bodies of the declarations
+     em <- traverse extractDeclExpr dm
+
+     -- the body of the recursive record
+     recv <- scRecord sc (Map.mapKeys nameToString em)
+
+     -- build a lambda from the record body...
+     f <- scLambda sc "fixRecord" rect recv
+
+     -- and take its fixpoint
+     rhs <- scGlobalApply sc "Prelude.fix" [rect, f]
+
+     -- finally, build projections from the fixed record to shove into the environment
+     -- if toplevel, then wrap each binding with a Constant constructor
+     let mkRhs d t =
+           do let s = nameToString (C.dName d)
+              r <- scRecordSelect sc rhs s
+              if isTopLevel then scConstant sc s r t else return r
+     rhss <- sequence (Map.intersectionWith mkRhs dm tm)
+
+     let env' = env { envE = Map.union (fmap (\v -> (v, 0)) rhss) (envE env)
+                    , envC = Map.union (fmap C.dSignature dm) (envC env)
+                    }
+     return env'
+
+importDeclGroup isTopLevel sc env (C.NonRecursive decl) =
+  case C.dDefinition decl of
+    C.DPrim
+     | isTopLevel -> do
+        rhs <- importPrimitive sc (C.dName decl)
+        let env' = env { envE = Map.insert (C.dName decl) (rhs, 0) (envE env)
+                      , envC = Map.insert (C.dName decl) (C.dSignature decl) (envC env) }
+        return env'
+     | otherwise -> do
+        panic "importDeclGroup" ["Primitive declarations only allowed at top-level:", show (C.dName decl)]
+
+    C.DExpr expr -> do
+     rhs <- importExpr' sc env (C.dSignature decl) expr
+     rhs' <- if not isTopLevel then return rhs else do
+       t <- importSchema sc env (C.dSignature decl)
+       scConstant sc (nameToString (C.dName decl)) rhs t
+     let env' = env { envE = Map.insert (C.dName decl) (rhs', 0) (envE env)
+                    , envC = Map.insert (C.dName decl) (C.dSignature decl) (envC env) }
+     return env'
+
+importDeclGroups :: SharedContext -> Env -> [C.DeclGroup] -> IO Env
+importDeclGroups sc = foldM (importDeclGroup False sc)
+
+importTopLevelDeclGroups :: SharedContext -> Env -> [C.DeclGroup] -> IO Env
+importTopLevelDeclGroups sc = foldM (importDeclGroup True sc)
+
+coerceTerm :: SharedContext -> Env -> C.Type -> C.Type -> Term -> IO Term
+coerceTerm sc env t1 t2 e
+  | t1 == t2 = do return e
+  | otherwise =
+    do t1' <- importType sc env t1
+       t2' <- importType sc env t2
+       q <- proveEq sc env t1 t2
+       scGlobalApply sc "Prelude.coerce" [t1', t2', q, e]
+
+proveEq :: SharedContext -> Env -> C.Type -> C.Type -> IO Term
+proveEq sc env t1 t2
+  | t1 == t2 =
+    do s <- scSort sc (mkSort 0)
+       t' <- importType sc env t1
+       scCtorApp sc "Prelude.Refl" [s, t']
+  | otherwise =
+    case (C.tNoUser t1, C.tNoUser t2) of
+      (C.tIsSeq -> Just (n1, a1), C.tIsSeq -> Just (n2, a2)) ->
+        do n1' <- importType sc env n1
+           n2' <- importType sc env n2
+           a1' <- importType sc env a1
+           a2' <- importType sc env a2
+           num <- scDataTypeApp sc "Cryptol.Num" []
+           nEq <- if n1 == n2
+                  then scGlobalApply sc "Prelude.Refl" [num, n1']
+                  else scGlobalApply sc "Prelude.unsafeAssert" [num, n1', n2']
+           aEq <- proveEq sc env a1 a2
+           if a1 == a2
+             then scGlobalApply sc "Cryptol.seq_cong1" [n1', n2', a1', nEq]
+             else scGlobalApply sc "Cryptol.seq_cong" [n1', n2', a1', a2', nEq, aEq]
+      (C.tIsFun -> Just (a1, b1), C.tIsFun -> Just (a2, b2)) ->
+        do a1' <- importType sc env a1
+           a2' <- importType sc env a2
+           b1' <- importType sc env b1
+           b2' <- importType sc env b2
+           aEq <- proveEq sc env a1 a2
+           bEq <- proveEq sc env b1 b2
+           scGlobalApply sc "Cryptol.fun_cong" [a1', a2', b1', b2', aEq, bEq]
+      (C.tIsTuple -> Just (a1 : ts1), C.tIsTuple -> Just (a2 : ts2))
+        | length ts1 == length ts2 ->
+          do let b1 = C.tTuple ts1
+                 b2 = C.tTuple ts2
+             a1' <- importType sc env a1
+             a2' <- importType sc env a2
+             b1' <- importType sc env b1
+             b2' <- importType sc env b2
+             aEq <- proveEq sc env a1 a2
+             bEq <- proveEq sc env b1 b2
+             if b1 == b2
+               then scGlobalApply sc "Cryptol.pair_cong1" [a1', a2', b1', aEq]
+               else if a1 == a2
+                    then scGlobalApply sc "Cryptol.pair_cong2" [a1', b1', b2', bEq]
+                    else scGlobalApply sc "Cryptol.pair_cong" [a1', a2', b1', b2', aEq, bEq]
+      (C.tIsRec -> Just tm1, C.tIsRec -> Just tm2)
+        | map fst (C.canonicalFields tm1) == map fst (C.canonicalFields tm2) ->
+          proveEq sc env (C.tTuple (map snd (C.canonicalFields tm1))) (C.tTuple (map snd (C.canonicalFields tm2)))
+      (_, _) ->
+        panic "proveEq" ["Internal type error:", pretty t1, pretty t2]
+
+--------------------------------------------------------------------------------
+-- List comprehensions
+
+importComp :: SharedContext -> Env -> C.Type -> C.Type -> C.Expr -> [[C.Match]] -> IO Term
+importComp sc env lenT elemT expr mss =
+  do let zipAll [] = panic "importComp" ["zero-branch list comprehension"]
+         zipAll [branch] =
+           do (xs, len, ty, args) <- importMatches sc env branch
+              m <- importType sc env len
+              a <- importType sc env ty
+              return (xs, m, a, [args], len)
+         zipAll (branch : branches) =
+           do (xs, len, ty, args) <- importMatches sc env branch
+              m <- importType sc env len
+              a <- importType sc env ty
+              (ys, n, b, argss, len') <- zipAll branches
+              zs <- scGlobalApply sc "Cryptol.seqZip" [a, b, m, n, xs, ys]
+              mn <- scGlobalApply sc "Cryptol.tcMin" [m, n]
+              ab <- scTupleType sc [a, b]
+              return (zs, mn, ab, args : argss, C.tMin len len')
+     (xs, n, a, argss, lenT') <- zipAll mss
+     f <- lambdaTuples sc env elemT expr argss
+     b <- importType sc env elemT
+     ys <- scGlobalApply sc "Cryptol.seqMap" [a, b, n, f, xs]
+     -- The resulting type might not match the annotation, so we coerce
+     coerceTerm sc env (C.tSeq lenT' elemT) (C.tSeq lenT elemT) ys
+
+lambdaTuples :: SharedContext -> Env -> C.Type -> C.Expr -> [[(C.Name, C.Type)]] -> IO Term
+lambdaTuples sc env _ty expr [] = importExpr sc env expr
+lambdaTuples sc env ty expr (args : argss) =
+  do f <- lambdaTuple sc env ty expr argss args
+     if null args || null argss
+       then return f
+       else do a <- importType sc env (tNestedTuple (map snd args))
+               b <- importType sc env (tNestedTuple (map (tNestedTuple . map snd) argss))
+               c <- importType sc env ty
+               scGlobalApply sc "Prelude.uncurry" [a, b, c, f]
+
+lambdaTuple :: SharedContext -> Env -> C.Type -> C.Expr -> [[(C.Name, C.Type)]] -> [(C.Name, C.Type)] -> IO Term
+lambdaTuple sc env ty expr argss [] = lambdaTuples sc env ty expr argss
+lambdaTuple sc env ty expr argss ((x, t) : args) =
+  do a <- importType sc env t
+     env' <- bindName sc x (C.Forall [] [] t) env
+     e <- lambdaTuple sc env' ty expr argss args
+     f <- scLambda sc (nameToString x) a e
+     if null args
+        then return f
+        else do b <- importType sc env (tNestedTuple (map snd args))
+                let tuple = tNestedTuple (map (tNestedTuple . map snd) argss)
+                c <- importType sc env (if null argss then ty else C.tFun tuple ty)
+                scGlobalApply sc "Prelude.uncurry" [a, b, c, f]
+
+tNestedTuple :: [C.Type] -> C.Type
+tNestedTuple [] = C.tTuple []
+tNestedTuple [t] = t
+tNestedTuple (t : ts) = C.tTuple [t, tNestedTuple ts]
+
+
+-- | Returns the shared term, length type, element tuple type, bound
+-- variables.
+importMatches :: SharedContext -> Env -> [C.Match]
+              -> IO (Term, C.Type, C.Type, [(C.Name, C.Type)])
+importMatches _sc _env [] = panic "importMatches" ["importMatches: empty comprehension branch"]
+
+importMatches sc env [C.From name _len _eltty expr] = do
+  (len, ty) <- case C.tIsSeq (fastTypeOf (envC env) expr) of
+                 Just x -> return x
+                 Nothing -> panic "importMatches" ["type mismatch from: " ++ show (fastTypeOf (envC env) expr)]
+  xs <- importExpr sc env expr
+  return (xs, len, ty, [(name, ty)])
+
+importMatches sc env (C.From name _len _eltty expr : matches) = do
+  (len1, ty1) <- case C.tIsSeq (fastTypeOf (envC env) expr) of
+                   Just x -> return x
+                   Nothing -> panic "importMatches" ["type mismatch from: " ++ show (fastTypeOf (envC env) expr)]
+  m <- importType sc env len1
+  a <- importType sc env ty1
+  xs <- importExpr sc env expr
+  env' <- bindName sc name (C.Forall [] [] ty1) env
+  (body, len2, ty2, args) <- importMatches sc env' matches
+  n <- importType sc env len2
+  b <- importType sc env ty2
+  f <- scLambda sc (nameToString name) a body
+  result <- scGlobalApply sc "Cryptol.from" [a, b, m, n, xs, f]
+  return (result, C.tMul len1 len2, C.tTuple [ty1, ty2], (name, ty1) : args)
+
+importMatches sc env [C.Let decl]
+  | C.DPrim <- C.dDefinition decl = do
+     panic "importMatches" ["Primitive declarations not allowed in 'let':", show (C.dName decl)]
+  | C.DExpr expr <- C.dDefinition decl = do
+     e <- importExpr sc env expr
+     ty1 <- case C.dSignature decl of
+              C.Forall [] [] ty1 -> return ty1
+              _ -> unimplemented "polymorphic Let"
+     a <- importType sc env ty1
+     result <- scGlobalApply sc "Prelude.single" [a, e]
+     return (result, C.tOne, ty1, [(C.dName decl, ty1)])
+
+importMatches sc env (C.Let decl : matches) =
+  case C.dDefinition decl of
+    C.DPrim -> do
+     panic "importMatches" ["Primitive declarations not allowed in 'let':", show (C.dName decl)]
+    C.DExpr expr -> do
+     e <- importExpr sc env expr
+     ty1 <- case C.dSignature decl of
+              C.Forall [] [] ty1 -> return ty1
+              _ -> unimplemented "polymorphic Let"
+     a <- importType sc env ty1
+     env' <- bindName sc (C.dName decl) (C.dSignature decl) env
+     (body, len, ty2, args) <- importMatches sc env' matches
+     n <- importType sc env len
+     b <- importType sc env ty2
+     f <- scLambda sc (nameToString (C.dName decl)) a body
+     result <- scGlobalApply sc "Cryptol.mlet" [a, b, n, e, f]
+     return (result, len, C.tTuple [ty1, ty2], (C.dName decl, ty1) : args)
+
+pIsNeq :: C.Type -> Maybe (C.Type, C.Type)
+pIsNeq ty = case C.tNoUser ty of
+              C.TCon (C.PC C.PNeq) [t1, t2] -> Just (t1, t2)
+              _                             -> Nothing
+
+--------------------------------------------------------------------------------
+-- Utilities
+
+asCryptolTypeValue :: SC.CValue -> Maybe C.Type
+asCryptolTypeValue v =
+  case v of
+    SC.VBoolType -> return C.tBit
+    SC.VIntType -> return C.tInteger
+    SC.VArrayType v1 v2 -> do
+      t1 <- asCryptolTypeValue v1
+      t2 <- asCryptolTypeValue v2
+      return $ C.tArray t1 t2
+    SC.VVecType (SC.VNat n) v2 -> do
+      t2 <- asCryptolTypeValue v2
+      return (C.tSeq (C.tNum n) t2)
+    SC.VDataType "Prelude.Stream" [v1] -> do
+      t1 <- asCryptolTypeValue v1
+      return (C.tSeq C.tInf t1)
+    SC.VUnitType -> return (C.tTuple [])
+    SC.VPairType v1 v2 -> do
+      t1 <- asCryptolTypeValue v1
+      t2 <- asCryptolTypeValue v2
+      case C.tIsTuple t2 of
+        Just ts -> return (C.tTuple (t1 : ts))
+        Nothing -> return (C.tTuple [t1, t2])
+    SC.VPiType v1 f -> do
+      case v1 of
+        -- if we see that the parameter is a Cryptol.Num, it's a
+        -- pretty good guess that it originally was a
+        -- polymorphic number type.
+        SC.VDataType "Cryptol.Num" [] ->
+          let msg= unwords ["asCryptolTypeValue: can't infer a polymorphic Cryptol"
+                           ,"type. Please, make sure all numeric types are"
+                           ,"specialized before constructing a typed term."
+                           ]
+          in error msg
+            -- otherwise we issue a generic error about dependent type inference
+        _ -> do
+          let msg = unwords ["asCryptolTypeValue: can't infer a Cryptol type"
+                            ,"for a dependent SAW-Core type."
+                            ]
+          let v2 = SC.runIdentity (f (error msg))
+          t1 <- asCryptolTypeValue v1
+          t2 <- asCryptolTypeValue v2
+          return (C.tFun t1 t2)
+    _ -> Nothing
+
+scCryptolType :: SharedContext -> Term -> IO C.Type
+scCryptolType sc t =
+  do modmap <- scGetModuleMap sc
+     case asCryptolTypeValue (SC.evalSharedTerm modmap Map.empty t) of
+       Just ty -> return ty
+       Nothing -> panic "scCryptolType" ["scCryptolType: unsupported type " ++ showTerm t]
+
+scCryptolEq :: SharedContext -> Term -> Term -> IO Term
+scCryptolEq sc x y =
+  do rules <- concat <$> traverse defRewrites (defs1 ++ defs2)
+     let ss = addConvs natConversions (addRules rules emptySimpset)
+     tx <- scTypeOf sc x >>= rewriteSharedTerm sc ss >>= scCryptolType sc
+     ty <- scTypeOf sc y >>= rewriteSharedTerm sc ss >>= scCryptolType sc
+     unless (tx == ty) $
+       panic "scCryptolEq"
+                 [ "scCryptolEq: type mismatch between"
+                 , pretty tx
+                 , "and"
+                 , pretty ty
+                 ]
+
+     -- Actually apply the equality function, along with the Eq class dictionary
+     t <- scTypeOf sc x
+     c <- scCryptolType sc t
+     k <- importType sc emptyEnv c
+     eqPrf <- proveProp sc emptyEnv (C.pEq c)
+     scGlobalApply sc "Cryptol.ecEq" [k, eqPrf, x, y]
+
+  where
+    defs1 = map (mkIdent (mkModuleName ["Prelude"])) ["bitvector"]
+    defs2 = map (mkIdent (mkModuleName ["Cryptol"])) ["seq", "ty"]
+    defRewrites ident =
+      do maybe_def <- scFindDef sc ident
+         case maybe_def of
+           Nothing -> return []
+           Just def -> scDefRewriteRules sc def
+
+-- | Convert from SAWCore's Value type to Cryptol's, guided by the
+-- Cryptol type schema.
+exportValueWithSchema :: C.Schema -> SC.CValue -> V.Value
+exportValueWithSchema (C.Forall [] [] ty) v = exportValue (evalValType Map.empty ty) v
+exportValueWithSchema _ _ = V.VPoly (error "exportValueWithSchema")
+-- TODO: proper support for polymorphic values
+
+exportValue :: TV.TValue -> SC.CValue -> V.Value
+exportValue ty v = case ty of
+
+  TV.TVBit ->
+    V.VBit (SC.toBool v)
+
+  TV.TVInteger ->
+    V.VInteger (case v of SC.VInt x -> x; _ -> error "exportValue: expected integer")
+
+  TV.TVIntMod _modulus ->
+    V.VInteger (case v of SC.VInt x -> x; _ -> error "exportValue: expected integer")
+
+  TV.TVArray{} -> error $ "exportValue: (on array type " ++ show ty ++ ")"
+
+  TV.TVRational -> error "exportValue: Not yet implemented: Rational"
+
+  TV.TVFloat _ _ -> panic "exportValue: Not yet implemented: Float" []
+
+  TV.TVSeq _ e ->
+    case v of
+      SC.VWord w -> V.word V.Concrete (toInteger (width w)) (unsigned w)
+      SC.VVector xs
+        | TV.isTBit e -> V.VWord (toInteger (Vector.length xs)) (V.ready (V.LargeBitsVal (fromIntegral (Vector.length xs))
+                            (V.finiteSeqMap V.Concrete . map (V.ready . V.VBit . SC.toBool . SC.runIdentity . force) $ Fold.toList xs)))
+        | otherwise   -> V.VSeq (toInteger (Vector.length xs)) $ V.finiteSeqMap V.Concrete $
+                            map (V.ready . exportValue e . SC.runIdentity . force) $ Vector.toList xs
+      _ -> error $ "exportValue (on seq type " ++ show ty ++ ")"
+
+  -- infinite streams
+  TV.TVStream e ->
+    case v of
+      SC.VExtra (SC.CStream trie) -> V.VStream (V.IndexSeqMap $ \i -> V.ready $ exportValue e (IntTrie.apply trie i))
+      _ -> error $ "exportValue (on seq type " ++ show ty ++ ")"
+
+  -- tuples
+  TV.TVTuple etys -> V.VTuple (exportTupleValue etys v)
+
+  -- records
+  TV.TVRec fields ->
+      V.VRecord (C.recordFromFieldsWithDisplay (C.displayOrder fields) $ exportRecordValue (C.canonicalFields fields) v)
+
+  -- functions
+  TV.TVFun _aty _bty ->
+    V.VFun (error "exportValue: TODO functions")
+
+  -- abstract types
+  TV.TVAbstract{} ->
+    error "exportValue: TODO abstract types"
+
+exportTupleValue :: [TV.TValue] -> SC.CValue -> [V.Eval V.Value]
+exportTupleValue tys v =
+  case (tys, v) of
+    ([]    , SC.VUnit    ) -> []
+    ([t]   , _           ) -> [V.ready $ exportValue t v]
+    (t : ts, SC.VPair x y) -> (V.ready $ exportValue t (run x)) : exportTupleValue ts (run y)
+    _                      -> error $ "exportValue: expected tuple"
+  where
+    run = SC.runIdentity . force
+
+exportRecordValue :: [(C.Ident, TV.TValue)] -> SC.CValue -> [(C.Ident, V.Eval V.Value)]
+exportRecordValue fields v =
+  case (fields, v) of
+    ([]         , SC.VUnit    ) -> []
+    ([(n, t)]   , _           ) -> [(n, V.ready $ exportValue t v)]
+    ((n, t) : ts, SC.VPair x y) ->
+      (n, V.ready $ exportValue t (run x)) : exportRecordValue ts (run y)
+    (_, SC.VRecordValue (alistAllFields
+                         (map (C.unpackIdent . fst) fields) -> Just ths)) ->
+      zipWith (\(n,t) x -> (n, V.ready $ exportValue t (run x))) fields ths
+    _                              -> error $ "exportValue: expected record"
+  where
+    run = SC.runIdentity . force
+
+fvAsBool :: FirstOrderValue -> Bool
+fvAsBool (FOVBit b) = b
+fvAsBool _ = error "fvAsBool: expected FOVBit value"
+
+exportFirstOrderValue :: FirstOrderValue -> V.Value
+exportFirstOrderValue fv =
+  case fv of
+    FOVBit b    -> V.VBit b
+    FOVInt i    -> V.VInteger i
+    FOVWord w x -> V.word V.Concrete (toInteger w) x
+    FOVVec t vs
+      | t == FOTBit -> V.VWord len (V.ready (V.LargeBitsVal len (V.finiteSeqMap V.Concrete . map (V.ready . V.VBit . fvAsBool) $ vs)))
+      | otherwise   -> V.VSeq  len (V.finiteSeqMap V.Concrete (map (V.ready . exportFirstOrderValue) vs))
+      where len = toInteger (length vs)
+    FOVArray{}  -> error $ "exportFirstOrderValue: unsupported FOT Array"
+    FOVTuple vs -> V.VTuple (map (V.ready . exportFirstOrderValue) vs)
+    FOVRec vm   -> V.VRecord $ C.recordFromFields [ (C.packIdent n, V.ready $ exportFirstOrderValue v) | (n, v) <- Map.assocs vm ]
+
+importFirstOrderValue :: FirstOrderType -> V.Value -> IO FirstOrderValue
+importFirstOrderValue t0 v0 = V.runEval (V.EvalOpts C.quietLogger V.defaultPPOpts) (go t0 v0)
+  where
+  go :: FirstOrderType -> V.Value -> V.Eval FirstOrderValue
+  go t v = case (t,v) of
+    (FOTBit         , V.VBit b)        -> return (FOVBit b)
+    (FOTInt         , V.VInteger i)    -> return (FOVInt i)
+    (FOTVec _ FOTBit, V.VWord w wv)    -> FOVWord (fromIntegral w) . V.bvVal <$> (V.asWordVal V.Concrete =<< wv)
+    (FOTVec _ ty    , V.VSeq len xs)   -> FOVVec ty <$> traverse (go ty =<<) (V.enumerateSeqMap len xs)
+    (FOTTuple tys   , V.VTuple xs)     -> FOVTuple <$> traverse (\(ty, x) -> go ty =<< x) (zip tys xs)
+    (FOTRec fs      , V.VRecord xs)    ->
+        do xs' <- Map.fromList <$> mapM importField (C.canonicalFields xs)
+           let missing = Set.difference (Map.keysSet fs) (Set.fromList (map C.unpackIdent (C.displayOrder xs)))
+           unless (Set.null missing)
+                  (panic "importFirstOrderValue" $
+                         ["Missing fields while importing finite value:"] ++ (map show (Set.toList missing)))
+           return $ FOVRec $ xs'
+      where
+       importField :: (C.Ident, V.Eval V.Value) -> V.Eval (String, FirstOrderValue)
+       importField (C.unpackIdent -> nm,x)
+         | Just ty <- Map.lookup nm fs = do
+                x' <- go ty =<< x
+                return (nm, x')
+         | otherwise = panic "importFirstOrderValue" ["Unexpected field name while importing finite value:", show nm]
+
+    _ -> panic "importFirstOrderValue"
+                ["Expected finite value of type:", show t, "but got", show v]

--- a/cryptol-saw-core/src/Verifier/SAW/Cryptol/Panic.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/Cryptol/Panic.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Verifier.SAW.Cryptol.Panic
+ ( panic, unimplemented )
+ where
+
+import Panic hiding (panic)
+import qualified Panic as Panic
+
+data CryptolSawCore = CryptolSawCore
+
+panic :: HasCallStack => String -> [String] -> a
+panic = Panic.panic CryptolSawCore
+
+instance PanicComponent CryptolSawCore where
+  panicComponentName _ = "cryptol-saw-core"
+  panicComponentIssues _ = "https://github.com/GaloisInc/saw-core/issues"
+
+  {-# Noinline panicComponentRevision #-}
+  panicComponentRevision = $useGitRevision
+
+unimplemented :: HasCallStack => String -> a
+unimplemented name = panic "unimplemented" [name]
+

--- a/cryptol-saw-core/src/Verifier/SAW/Cryptol/Prelude.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/Cryptol/Prelude.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+{- |
+Module      : Verifier.SAW.Cryptol.Prelude
+Copyright   : Galois, Inc. 2012-2015
+License     : BSD3
+Maintainer  : huffman@galois.com
+Stability   : experimental
+Portability : non-portable (language extensions)
+-}
+
+module Verifier.SAW.Cryptol.Prelude
+  ( Module
+  , module Verifier.SAW.Cryptol.Prelude
+  , scLoadPreludeModule
+  ) where
+
+import Verifier.SAW.Prelude
+import Verifier.SAW.ParserUtils
+
+$(defineModuleFromFileWithFns
+  "cryptolModule" "scLoadCryptolModule" "saw/Cryptol.sawcore")

--- a/cryptol-saw-core/src/Verifier/SAW/Cryptol/Simpset.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/Cryptol/Simpset.hs
@@ -1,0 +1,54 @@
+{- |
+Module      : Verifier.SAW.Cryptol.Simpset
+Copyright   : Galois, Inc. 2018
+License     : BSD3
+Maintainer  : huffman@galois.com
+Stability   : experimental
+Portability : non-portable (language extensions)
+-}
+
+{-# LANGUAGE OverloadedStrings #-}
+
+module Verifier.SAW.Cryptol.Simpset
+  ( mkCryptolSimpset
+  ) where
+
+import Verifier.SAW.Module
+import Verifier.SAW.Rewriter
+import Verifier.SAW.SharedTerm
+import Verifier.SAW.Term.Functor
+
+mkCryptolSimpset :: SharedContext -> IO Simpset
+mkCryptolSimpset sc =
+  do m <- scFindModule sc cryptolModuleName
+     scSimpset sc (cryptolDefs m) [] []
+  where
+    cryptolDefs m = filter (not . excluded) $ moduleDefs m
+    excluded d = defIdent d `elem` excludedNames
+
+cryptolModuleName :: ModuleName
+cryptolModuleName = mkModuleName ["Cryptol"]
+
+excludedNames :: [Ident]
+excludedNames =
+  map (mkIdent cryptolModuleName)
+  [ "fix"
+  , "pair_cong"
+  , "seq_cong"
+  , "pair_cong1"
+  , "pair_cong2"
+  , "seq_cong1"
+  , "fun_cong"
+  , "seq_TCNum"
+  , "seq_TCInf"
+  , "PLiteral"
+  , "PLogic"
+  , "PRing"
+  , "PIntegral"
+  , "PField"
+  , "PRound"
+  , "PEq"
+  , "PCmp"
+  , "PSignedCmp"
+  , "ecEq"
+  ]

--- a/cryptol-saw-core/src/Verifier/SAW/CryptolEnv.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/CryptolEnv.hs
@@ -1,0 +1,598 @@
+{- |
+Module      : SAWScript.CryptolEnv
+Description : Context for interpreting Cryptol within SAW-Script.
+License     : BSD3
+Maintainer  : huffman
+Stability   : provisional
+-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Verifier.SAW.CryptolEnv
+  ( CryptolEnv(..)
+  , initCryptolEnv
+  , loadCryptolModule
+  , bindCryptolModule
+  , lookupCryptolModule
+  , importModule
+  , bindTypedTerm
+  , bindType
+  , bindInteger
+  , parseTypedTerm
+  , parseDecls
+  , parseSchema
+  , declareName
+  , typeNoUser
+  , schemaNoUser
+  , translateExpr
+  , getNamingEnv
+  , getAllIfaceDecls
+  , InputText(..)
+  , lookupIn
+  )
+  where
+
+--import qualified Control.Exception as X
+import Data.ByteString (ByteString)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import Data.Maybe (fromMaybe)
+import Data.Text (Text, pack)
+import Control.Monad(when)
+
+#if !MIN_VERSION_base(4,8,0)
+import Data.Monoid
+import Data.Traversable
+#endif
+
+import System.Environment (lookupEnv)
+import System.Environment.Executable (splitExecutablePath)
+import System.FilePath ((</>), normalise, joinPath, splitPath, splitSearchPath)
+
+import Verifier.SAW.SharedTerm (SharedContext, Term, incVars)
+
+import qualified Verifier.SAW.Cryptol as C
+
+import qualified Cryptol.Eval as E
+import qualified Cryptol.Parser as P
+import qualified Cryptol.Parser.AST as P
+import qualified Cryptol.Parser.Position as P
+import qualified Cryptol.TypeCheck as T
+import qualified Cryptol.TypeCheck.AST as T
+import qualified Cryptol.TypeCheck.Infer as TI
+import qualified Cryptol.TypeCheck.Kind as TK
+import qualified Cryptol.TypeCheck.Monad as TM
+--import qualified Cryptol.TypeCheck.PP as TP
+
+import qualified Cryptol.ModuleSystem as M
+import qualified Cryptol.ModuleSystem.Base as MB
+import qualified Cryptol.ModuleSystem.Env as ME
+import qualified Cryptol.ModuleSystem.Exports as MEx
+import qualified Cryptol.ModuleSystem.Interface as MI
+import qualified Cryptol.ModuleSystem.Monad as MM
+import qualified Cryptol.ModuleSystem.NamingEnv as MN
+import qualified Cryptol.ModuleSystem.Name as MN
+import qualified Cryptol.ModuleSystem.Renamer as MR
+
+import Cryptol.Utils.PP
+import Cryptol.Utils.Ident (Ident, preludeName, packIdent, interactiveName
+                           , packModName, textToModName, modNameChunks)
+import Cryptol.Utils.Logger (quietLogger)
+
+--import SAWScript.REPL.Monad (REPLException(..))
+import Verifier.SAW.TypedTerm
+-- import SAWScript.Utils (Pos(..))
+-- import SAWScript.AST (Located(getVal, locatedPos), Import(..))
+
+
+-- | Parse input, together with information about where it came from.
+data InputText = InputText
+  { inpText :: String -- ^ Parse this
+  , inpFile :: String -- ^ It came from this file (or thing)
+  , inpLine :: Int    -- ^ On this line number
+  , inpCol  :: Int    -- ^ On this column number
+  }
+
+
+
+--------------------------------------------------------------------------------
+
+data CryptolEnv = CryptolEnv
+  { eImports    :: [P.Import]           -- ^ Declarations of imported Cryptol modules
+  , eModuleEnv  :: ME.ModuleEnv         -- ^ Imported modules, and state for the ModuleM monad
+  , eExtraNames :: MR.NamingEnv         -- ^ Context for the Cryptol renamer
+  , eExtraTypes :: Map T.Name T.Schema  -- ^ Cryptol types for extra names in scope
+  , eExtraTSyns :: Map T.Name T.TySyn   -- ^ Extra Cryptol type synonyms in scope
+  , eTermEnv    :: Map T.Name Term      -- ^ SAWCore terms for *all* names in scope
+  }
+
+
+-- Finding things --------------------------------------------------------------
+
+
+-- | Lookup a name in a map containg Cryptol names.
+-- The string corresponds to the Cryptol name we are looking for.
+-- If it is unqualifed, then we return any entry associated with the given
+-- name.  If the string is qualified (i.e., has @::@), then we only consider
+-- entries from the module in the qualified.
+-- The result is either the corresponding value, or a list of the
+lookupIn :: String -> Map T.Name b -> Either [T.Name] b
+lookupIn nm mp =
+  case [ x | x <- Map.toList mp, matches (fst x) ] of
+    [ (_,v) ] -> Right v
+    opts      -> Left (map fst opts)
+  where
+  matches = nameMatcher nm
+
+
+-- | Parse a string into a function that will match names.
+-- If the string is unqualified (i.e., no `::`), then we match all
+-- names with the given identifier.  Otherwise, we only match the
+-- ones in the module specified by the qualifier.
+nameMatcher :: String -> T.Name -> Bool
+nameMatcher xs =
+    case modNameChunks (textToModName (pack xs)) of
+      []  -> const False
+      [x] -> (packIdent x ==) . MN.nameIdent
+      cs -> let m = MN.Declared (packModName (map pack (init cs))) MN.UserName
+                i = packIdent (last cs)
+             in \n -> MN.nameIdent n == i && MN.nameInfo n == m
+
+
+
+-- Initialize ------------------------------------------------------------------
+
+initCryptolEnv ::
+  (?fileReader :: FilePath -> IO ByteString) =>
+  SharedContext -> IO CryptolEnv
+initCryptolEnv sc = do
+  modEnv0 <- M.initialModuleEnv
+
+  -- Set the Cryptol include path (TODO: we may want to do this differently)
+  (binDir, _) <- splitExecutablePath
+  let instDir = normalise . joinPath . init . splitPath $ binDir
+  mCryptolPath <- lookupEnv "CRYPTOLPATH"
+  let cryptolPaths =
+        case mCryptolPath of
+          Nothing -> []
+          Just path ->
+#if defined(mingw32_HOST_OS) || defined(__MINGW32__)
+            -- Windows paths search from end to beginning
+            reverse (splitSearchPath path)
+#else
+            splitSearchPath path
+#endif
+  let modEnv1 = modEnv0 { ME.meSearchPath = cryptolPaths ++
+                           (instDir </> "lib") : ME.meSearchPath modEnv0 }
+
+  -- Load Cryptol prelude
+  (_, modEnv) <-
+    liftModuleM modEnv1 $
+      MB.loadModuleFrom (MM.FromModule preludeName)
+
+  -- Generate SAWCore translations for all values in scope
+  termEnv <- genTermEnv sc modEnv
+
+  return CryptolEnv
+    { eImports    = [P.Import preludeName Nothing Nothing]
+    , eModuleEnv  = modEnv
+    , eExtraNames = mempty
+    , eExtraTypes = Map.empty
+    , eExtraTSyns = Map.empty
+    , eTermEnv    = termEnv
+    }
+
+-- Parse -----------------------------------------------------------------------
+
+ioParseExpr :: InputText -> IO (P.Expr P.PName)
+ioParseExpr = ioParseGeneric P.parseExprWith
+
+ioParseDecls :: InputText -> IO [P.Decl P.PName]
+ioParseDecls = ioParseGeneric P.parseDeclsWith
+
+ioParseSchema :: InputText -> IO (P.Schema P.PName)
+ioParseSchema = ioParseGeneric P.parseSchemaWith
+
+ioParseGeneric ::
+  (P.Config -> Text -> Either P.ParseError a) -> InputText -> IO a
+ioParseGeneric parse inp = ioParseResult (parse cfg (pack str))
+  where
+  cfg = P.defaultConfig { P.cfgSource = inpFile inp }
+  str = concat [ replicate (inpLine inp - 1) '\n'
+               , replicate (inpCol inp - 1) ' '
+               , inpText inp ]
+
+ioParseResult :: Either P.ParseError a -> IO a
+ioParseResult res = case res of
+  Right a -> return a
+  Left e  -> fail $ "Cryptol parse error:\n" ++ show (P.ppError e) -- X.throwIO (ParseError e)
+
+-- Rename ----------------------------------------------------------------------
+
+getNamingEnv :: CryptolEnv -> MR.NamingEnv
+getNamingEnv env = eExtraNames env `MR.shadowing` nameEnv
+  where
+    nameEnv = mconcat $ fromMaybe [] $ traverse loadImport (eImports env)
+    loadImport i = do
+      lm <- ME.lookupModule (T.iModule i) (eModuleEnv env)
+      return $ MN.interpImport i (MI.ifPublic (ME.lmInterface lm))
+
+getAllIfaceDecls :: ME.ModuleEnv -> M.IfaceDecls
+getAllIfaceDecls me = mconcat (map (both . ME.lmInterface) (ME.getLoadedModules (ME.meLoadedModules me)))
+  where both ifc = M.ifPublic ifc `mappend` M.ifPrivate ifc
+
+-- Typecheck -------------------------------------------------------------------
+
+runInferOutput :: TM.InferOutput a -> MM.ModuleM a
+runInferOutput out =
+  case out of
+
+    TM.InferOK warns seeds supply o ->
+      do MM.setNameSeeds seeds
+         MM.setSupply supply
+         MM.typeCheckWarnings warns
+         return o
+
+    TM.InferFailed warns errs ->
+      do MM.typeCheckWarnings warns
+         MM.typeCheckingFailed errs
+
+-- Translate -------------------------------------------------------------------
+
+mkCryEnv ::
+  (?fileReader :: FilePath -> IO ByteString) =>
+  CryptolEnv -> IO C.Env
+mkCryEnv env =
+  do let modEnv = eModuleEnv env
+     let ifaceDecls = getAllIfaceDecls modEnv
+     (types, _) <-
+       liftModuleM modEnv $
+       do prims <- MB.getPrimMap
+          -- noIfaceParams because we don't support translating functors yet
+          TM.inpVars `fmap` MB.genInferInput P.emptyRange prims
+            MI.noIfaceParams ifaceDecls
+     let types' = Map.union (eExtraTypes env) types
+     let terms = eTermEnv env
+     let cryEnv = C.emptyEnv
+           { C.envE = fmap (\t -> (t, 0)) terms
+           , C.envC = types'
+           }
+     return cryEnv
+
+translateExpr ::
+  (?fileReader :: FilePath -> IO ByteString) =>
+  SharedContext -> CryptolEnv -> T.Expr -> IO Term
+translateExpr sc env expr =
+  do cryEnv <- mkCryEnv env
+     C.importExpr sc cryEnv expr
+
+translateDeclGroups ::
+  (?fileReader :: FilePath -> IO ByteString) =>
+  SharedContext -> CryptolEnv -> [T.DeclGroup] -> IO CryptolEnv
+translateDeclGroups sc env dgs =
+  do cryEnv <- mkCryEnv env
+     cryEnv' <- C.importTopLevelDeclGroups sc cryEnv dgs
+     termEnv' <- traverse (\(t, j) -> incVars sc 0 j t) (C.envE cryEnv')
+
+     let decls = concatMap T.groupDecls dgs
+     let names = map T.dName decls
+     let newTypes = Map.fromList [ (T.dName d, T.dSignature d) | d <- decls ]
+     let addName name = MR.shadowing (MN.singletonE (P.mkUnqual (MN.nameIdent name)) name)
+     return env
+           { eExtraNames = foldr addName (eExtraNames env) names
+           , eExtraTypes = Map.union (eExtraTypes env) newTypes
+           , eTermEnv = termEnv'
+           }
+
+-- | Translate all declarations in all loaded modules to SAWCore terms
+genTermEnv :: SharedContext -> ME.ModuleEnv -> IO (Map T.Name Term)
+genTermEnv sc modEnv = do
+  let declGroups = concatMap T.mDecls
+                 $ filter (not . T.isParametrizedModule)
+                 $ ME.loadedModules modEnv
+  cryEnv <- C.importTopLevelDeclGroups sc C.emptyEnv declGroups
+  traverse (\(t, j) -> incVars sc 0 j t) (C.envE cryEnv)
+
+--------------------------------------------------------------------------------
+
+checkNotParameterized :: T.Module -> IO ()
+checkNotParameterized m =
+  when (T.isParametrizedModule m) $
+    fail $ unlines [ "Cannot load parameterized modules directly."
+                   , "Either use a ` import, or make a module instantiation."
+                   ]
+
+
+loadCryptolModule ::
+  (?fileReader :: FilePath -> IO ByteString) =>
+  SharedContext -> CryptolEnv -> FilePath ->
+  IO (CryptolModule, CryptolEnv)
+loadCryptolModule sc env path = do
+  let modEnv = eModuleEnv env
+  (m, modEnv') <- liftModuleM modEnv (MB.loadModuleByPath path)
+  checkNotParameterized m
+
+  let ifaceDecls = getAllIfaceDecls modEnv'
+  (types, modEnv'') <- liftModuleM modEnv' $ do
+    prims <- MB.getPrimMap
+    TM.inpVars `fmap` MB.genInferInput P.emptyRange prims MI.noIfaceParams ifaceDecls
+
+  -- Regenerate SharedTerm environment.
+  oldCryEnv <- mkCryEnv env
+  let oldModNames = map ME.lmName $ ME.lmLoadedModules $ ME.meLoadedModules modEnv
+  let isNew m' = T.mName m' `notElem` oldModNames
+  let newModules = filter isNew $ map ME.lmModule $ ME.lmLoadedModules $ ME.meLoadedModules modEnv''
+  let newDeclGroups = concatMap T.mDecls newModules
+  newCryEnv <- C.importTopLevelDeclGroups sc oldCryEnv newDeclGroups
+  newTermEnv <- traverse (\(t, j) -> incVars sc 0 j t) (C.envE newCryEnv)
+
+  let names = MEx.eBinds (T.mExports m) -- :: Set T.Name
+  let tm' = Map.filterWithKey (\k _ -> Set.member k names) $
+            Map.intersectionWith TypedTerm types newTermEnv
+  let env' = env { eModuleEnv = modEnv''
+                 , eTermEnv = newTermEnv
+                 }
+  let sm' = Map.filterWithKey (\k _ -> Set.member k (MEx.eTypes (T.mExports m))) (T.mTySyns m)
+  return (CryptolModule sm' tm', env')
+
+bindCryptolModule :: (P.ModName, CryptolModule) -> CryptolEnv -> CryptolEnv
+bindCryptolModule (modName, CryptolModule sm tm) env =
+  env { eExtraNames = flip (foldr addName) (Map.keys tm) $
+                      flip (foldr addTSyn) (Map.keys sm) $ eExtraNames env
+      , eExtraTSyns = Map.union sm (eExtraTSyns env)
+      , eExtraTypes = Map.union (fmap (\(TypedTerm s _) -> s) tm) (eExtraTypes env)
+      , eTermEnv    = Map.union (fmap (\(TypedTerm _ t) -> t) tm) (eTermEnv env)
+      }
+  where
+    addName name = MN.shadowing (MN.singletonE (P.mkQual modName (MN.nameIdent name)) name)
+    addTSyn name = MN.shadowing (MN.singletonT (P.mkQual modName (MN.nameIdent name)) name)
+
+lookupCryptolModule :: CryptolModule -> String -> IO TypedTerm
+lookupCryptolModule (CryptolModule _ tm) name =
+  case Map.lookup (packIdent name) (Map.mapKeys MN.nameIdent tm) of
+    Nothing -> fail $ "Binding not found: " ++ name
+    Just t -> return t
+
+--------------------------------------------------------------------------------
+
+importModule ::
+  (?fileReader :: FilePath -> IO ByteString) =>
+  SharedContext             {- ^ Shared context for creating terms -} ->
+  CryptolEnv                {- ^ Extend this environment -} ->
+  Either FilePath P.ModName {- ^ Where to find the module -} ->
+  Maybe P.ModName           {- ^ Name qualifier -} ->
+  Maybe P.ImportSpec        {- ^ What to import -} ->
+  IO CryptolEnv
+importModule sc env src as imps = do
+  let modEnv = eModuleEnv env
+  (m, modEnv') <-
+    liftModuleM modEnv $
+    case src of
+      Left path -> MB.loadModuleByPath path
+      Right mn -> snd <$> MB.loadModuleFrom (MM.FromModule mn)
+  checkNotParameterized m
+
+  -- Regenerate SharedTerm environment.
+  oldCryEnv <- mkCryEnv env
+  let oldModNames = map ME.lmName $ ME.lmLoadedModules $ ME.meLoadedModules modEnv
+  let isNew m' = T.mName m' `notElem` oldModNames
+  let newModules = filter isNew $ map ME.lmModule $ ME.lmLoadedModules $ ME.meLoadedModules modEnv'
+  let newDeclGroups = concatMap T.mDecls newModules
+  newCryEnv <- C.importTopLevelDeclGroups sc oldCryEnv newDeclGroups
+  newTermEnv <- traverse (\(t, j) -> incVars sc 0 j t) (C.envE newCryEnv)
+
+  return env { eImports = P.Import (T.mName m) as imps : eImports env
+             , eModuleEnv = modEnv'
+             , eTermEnv = newTermEnv }
+
+bindIdent :: Ident -> CryptolEnv -> (T.Name, CryptolEnv)
+bindIdent ident env = (name, env')
+  where
+    modEnv = eModuleEnv env
+    supply = ME.meSupply modEnv
+    fixity = Nothing
+    (name, supply') = MN.mkDeclared interactiveName MN.UserName ident fixity P.emptyRange supply
+    modEnv' = modEnv { ME.meSupply = supply' }
+    env' = env { eModuleEnv = modEnv' }
+
+bindTypedTerm :: (Ident, TypedTerm) -> CryptolEnv -> CryptolEnv
+bindTypedTerm (ident, TypedTerm schema trm) env =
+  env' { eExtraNames = MR.shadowing (MN.singletonE pname name) (eExtraNames env)
+       , eExtraTypes = Map.insert name schema (eExtraTypes env)
+       , eTermEnv    = Map.insert name trm (eTermEnv env)
+       }
+  where
+    pname = P.mkUnqual ident
+    (name, env') = bindIdent ident env
+
+bindType :: (Ident, T.Schema) -> CryptolEnv -> CryptolEnv
+bindType (ident, T.Forall [] [] ty) env =
+  env' { eExtraNames = MR.shadowing (MN.singletonT pname name) (eExtraNames env)
+       , eExtraTSyns = Map.insert name tysyn (eExtraTSyns env)
+       }
+  where
+    pname = P.mkUnqual ident
+    (name, env') = bindIdent ident env
+    tysyn = T.TySyn name [] [] ty Nothing
+bindType _ env = env -- only monomorphic types may be bound
+
+bindInteger :: (Ident, Integer) -> CryptolEnv -> CryptolEnv
+bindInteger (ident, n) env =
+  env' { eExtraNames = MR.shadowing (MN.singletonT pname name) (eExtraNames env)
+       , eExtraTSyns = Map.insert name tysyn (eExtraTSyns env)
+       }
+  where
+    pname = P.mkUnqual ident
+    (name, env') = bindIdent ident env
+    tysyn = T.TySyn name [] [] (T.tNum n) Nothing
+
+--------------------------------------------------------------------------------
+
+parseTypedTerm ::
+  (?fileReader :: FilePath -> IO ByteString) =>
+  SharedContext -> CryptolEnv -> InputText -> IO TypedTerm
+parseTypedTerm sc env input = do
+  let modEnv = eModuleEnv env
+
+  -- Parse
+  pexpr <- ioParseExpr input
+
+  ((expr, schema), modEnv') <- liftModuleM modEnv $ do
+
+    -- Eliminate patterns
+    npe <- MM.interactive (MB.noPat pexpr)
+
+    -- Resolve names
+    let nameEnv = getNamingEnv env
+    re <- MM.interactive (MB.rename interactiveName nameEnv (MR.rename npe))
+
+    -- Infer types
+    let ifDecls = getAllIfaceDecls modEnv
+    let range = fromMaybe P.emptyRange (P.getLoc re)
+    prims <- MB.getPrimMap
+    -- noIfaceParams because we don't support functors yet
+    tcEnv <- MB.genInferInput range prims MI.noIfaceParams ifDecls
+    let tcEnv' = tcEnv { TM.inpVars = Map.union (eExtraTypes env) (TM.inpVars tcEnv)
+                       , TM.inpTSyns = Map.union (eExtraTSyns env) (TM.inpTSyns tcEnv)
+                       }
+
+    out <- MM.io (T.tcExpr re tcEnv')
+    MM.interactive (runInferOutput out)
+
+  let env' = env { eModuleEnv = modEnv' }
+
+  -- Translate
+  trm <- translateExpr sc env' expr
+  return (TypedTerm schema trm)
+
+parseDecls ::
+  (?fileReader :: FilePath -> IO ByteString) =>
+  SharedContext -> CryptolEnv -> InputText -> IO CryptolEnv
+parseDecls sc env input = do
+  let modEnv = eModuleEnv env
+  let ifaceDecls = getAllIfaceDecls modEnv
+
+  -- Parse
+  (decls :: [P.Decl P.PName]) <- ioParseDecls input
+
+  (tmodule, modEnv') <- liftModuleM modEnv $ do
+
+    -- Eliminate patterns
+    (npdecls :: [P.Decl P.PName]) <- MM.interactive (MB.noPat decls)
+
+    -- Convert from 'Decl' to 'TopDecl' so that types will be generalized
+    let topdecls = [ P.Decl (P.TopLevel P.Public Nothing d) | d <- npdecls ]
+
+    -- Label each TopDecl with the "interactive" module for unique name generation
+    let (mdecls :: [MN.InModule (P.TopDecl P.PName)]) = map (MN.InModule interactiveName) topdecls
+    nameEnv1 <- MN.liftSupply (MN.namingEnv' mdecls)
+
+    -- Resolve names
+    let nameEnv = nameEnv1 `MR.shadowing` getNamingEnv env
+    (rdecls :: [P.TopDecl T.Name]) <- MM.interactive (MB.rename interactiveName nameEnv (traverse MR.rename topdecls))
+
+    -- Create a Module to contain the declarations
+    let rmodule = P.Module { P.mName = P.Located P.emptyRange interactiveName
+                           , P.mInstance = Nothing
+                           , P.mImports = []
+                           , P.mDecls = rdecls
+                           }
+
+    -- Infer types
+    let range = fromMaybe P.emptyRange (P.getLoc rdecls)
+    prims <- MB.getPrimMap
+    -- noIfaceParams because we don't support functors yet
+    tcEnv <- MB.genInferInput range prims MI.noIfaceParams ifaceDecls
+    let tcEnv' = tcEnv { TM.inpVars = Map.union (eExtraTypes env) (TM.inpVars tcEnv)
+                       , TM.inpTSyns = Map.union (eExtraTSyns env) (TM.inpTSyns tcEnv)
+                       }
+
+    out <- MM.io (TM.runInferM tcEnv' (TI.inferModule rmodule))
+    tmodule <- MM.interactive (runInferOutput out)
+    return tmodule
+
+  -- Add new type synonyms and their name bindings to the environment
+  let syns' = Map.union (eExtraTSyns env) (T.mTySyns tmodule)
+  let addName name = MR.shadowing (MN.singletonT (P.mkUnqual (MN.nameIdent name)) name)
+  let names' = foldr addName (eExtraNames env) (Map.keys (T.mTySyns tmodule))
+  let env' = env { eModuleEnv = modEnv', eExtraNames = names', eExtraTSyns = syns' }
+
+  -- Translate
+  let dgs = T.mDecls tmodule
+  translateDeclGroups sc env' dgs
+
+parseSchema ::
+  (?fileReader :: FilePath -> IO ByteString) =>
+  CryptolEnv -> InputText -> IO T.Schema
+parseSchema env input = do
+  let modEnv = eModuleEnv env
+
+  -- Parse
+  pschema <- ioParseSchema input
+
+  fmap fst $ liftModuleM modEnv $ do
+
+    -- Resolve names
+    let nameEnv = getNamingEnv env
+    rschema <- MM.interactive (MB.rename interactiveName nameEnv (MR.rename pschema))
+
+    let ifDecls = getAllIfaceDecls modEnv
+    let range = fromMaybe P.emptyRange (P.getLoc rschema)
+    prims <- MB.getPrimMap
+    -- noIfaceParams because we don't support functors yet
+    tcEnv <- MB.genInferInput range prims MI.noIfaceParams ifDecls
+    let tcEnv' = tcEnv { TM.inpTSyns = Map.union (eExtraTSyns env) (TM.inpTSyns tcEnv) }
+    let infer =
+          case rschema of
+            P.Forall [] [] t _ -> do
+              let k = Nothing -- allow either kind KNum or KType
+              (t', goals) <- TM.collectGoals $ TK.checkType t k
+              return (T.Forall [] [] t', goals)
+            _ -> TK.checkSchema TM.AllowWildCards rschema
+    out <- MM.io (TM.runInferM tcEnv' infer)
+    (schema, _goals) <- MM.interactive (runInferOutput out)
+    --mapM_ (MM.io . print . TP.ppWithNames TP.emptyNameMap) goals
+    return (schemaNoUser schema)
+
+declareName ::
+  (?fileReader :: FilePath -> IO ByteString) =>
+  CryptolEnv -> P.ModName -> String -> IO (T.Name, CryptolEnv)
+declareName env mname input = do
+  let pname = P.mkUnqual (packIdent input)
+  let modEnv = eModuleEnv env
+  (cname, modEnv') <-
+    liftModuleM modEnv $ MM.interactive $
+    MN.liftSupply (MN.mkDeclared mname MN.UserName (P.getIdent pname) Nothing P.emptyRange)
+  let env' = env { eModuleEnv = modEnv' }
+  return (cname, env')
+
+typeNoUser :: T.Type -> T.Type
+typeNoUser t =
+  case t of
+    T.TCon tc ts   -> T.TCon tc (map typeNoUser ts)
+    T.TVar {}      -> t
+    T.TUser _ _ ty -> typeNoUser ty
+    T.TRec fields  -> T.TRec (fmap typeNoUser fields)
+
+schemaNoUser :: T.Schema -> T.Schema
+schemaNoUser (T.Forall params props ty) = T.Forall params props (typeNoUser ty)
+
+------------------------------------------------------------
+
+liftModuleM ::
+  (?fileReader :: FilePath -> IO ByteString) =>
+  ME.ModuleEnv -> MM.ModuleM a -> IO (a, ME.ModuleEnv)
+liftModuleM env m =
+  MM.runModuleM (defaultEvalOpts, ?fileReader, env) m >>= moduleCmdResult
+
+defaultEvalOpts :: E.EvalOpts
+defaultEvalOpts = E.EvalOpts quietLogger E.defaultPPOpts
+
+moduleCmdResult :: M.ModuleRes a -> IO (a, ME.ModuleEnv)
+moduleCmdResult (res, ws) = do
+  mapM_ (print . pp) ws
+  case res of
+    Right (a, me) -> return (a, me)
+    Left err      -> fail $ "Cryptol error:\n" ++ show (pp err) -- X.throwIO (ModuleSystemError err)

--- a/cryptol-saw-core/src/Verifier/SAW/TypedTerm.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/TypedTerm.hs
@@ -1,0 +1,61 @@
+{- |
+Module      : SAWScript.TypedTerm
+Description : SAW-Core terms paired with Cryptol types.
+License     : BSD3
+Maintainer  : huffman
+Stability   : provisional
+-}
+module Verifier.SAW.TypedTerm where
+
+import Data.Map (Map)
+import qualified Data.Map as Map
+
+import Cryptol.ModuleSystem.Name (nameIdent)
+import qualified Cryptol.TypeCheck.AST as C
+import Cryptol.Utils.PP (pretty)
+
+import Verifier.SAW.Cryptol (scCryptolType)
+import Verifier.SAW.SharedTerm
+
+-- Typed terms -----------------------------------------------------------------
+
+{- Within SAWScript, we represent an object language term as a SAWCore
+shared term paired with a Cryptol type schema. The Cryptol type is
+used for type inference/checking of inline Cryptol expressions. -}
+
+data TypedTerm =
+  TypedTerm
+  { ttSchema :: C.Schema
+  , ttTerm :: Term
+  }
+  deriving Show
+
+ttTermLens :: Functor f => (Term -> f Term) -> TypedTerm -> f TypedTerm
+ttTermLens f tt = tt `seq` fmap (\x -> tt{ttTerm = x}) (f (ttTerm tt))
+
+mkTypedTerm :: SharedContext -> Term -> IO TypedTerm
+mkTypedTerm sc trm = do
+  ty <- scTypeOf sc trm
+  ct <- scCryptolType sc ty
+  return $ TypedTerm (C.Forall [] [] ct) trm
+
+-- Typed modules ---------------------------------------------------------------
+
+{- In SAWScript, we can refer to a Cryptol module as a first class
+value. These are represented simply as maps from names to typed
+terms. -}
+
+data CryptolModule =
+  CryptolModule (Map C.Name C.TySyn) (Map C.Name TypedTerm)
+
+showCryptolModule :: CryptolModule -> String
+showCryptolModule (CryptolModule sm tm) =
+  unlines $
+    (if Map.null sm then [] else
+       "Type Synonyms" : "=============" : map showTSyn (Map.elems sm) ++ [""]) ++
+    "Symbols" : "=======" : map showBinding (Map.assocs tm)
+  where
+    showTSyn (C.TySyn name params _props rhs _doc) =
+      "    " ++ unwords (pretty (nameIdent name) : map pretty params) ++ " = " ++ pretty rhs
+    showBinding (name, TypedTerm schema _) =
+      "    " ++ pretty (nameIdent name) ++ " : " ++ pretty schema

--- a/cryptol-saw-core/test/CryptolVerifierTC.hs
+++ b/cryptol-saw-core/test/CryptolVerifierTC.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Main where
+
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
+import qualified Data.Map as Map
+
+import Text.Heredoc (there)
+
+import qualified Cryptol.ModuleSystem.Name as N
+import qualified Cryptol.Utils.Ident as N
+
+import qualified Verifier.SAW.Cryptol as C
+import           Verifier.SAW.SharedTerm
+import qualified Verifier.SAW.SCTypeCheck as TC
+import qualified Verifier.SAW.Cryptol.Prelude as C
+import qualified Verifier.SAW.CryptolEnv as CEnv
+
+main :: IO ()
+main =
+  do sc <- mkSharedContext
+     C.scLoadPreludeModule sc
+     C.scLoadCryptolModule sc
+     putStrLn "Loaded Cryptol.sawcore!"
+     let ?fileReader = BS.readFile
+     cenv0 <- CEnv.initCryptolEnv sc
+     putStrLn "Translated Cryptol.cry!"
+     cenv1 <- CEnv.importModule sc cenv0 (Right N.floatName) Nothing Nothing
+     putStrLn "Translated Float.cry!"
+     cenv2 <- CEnv.importModule sc cenv1 (Right N.arrayName) Nothing Nothing
+     putStrLn "Translated Array.cry!"
+     cenv3 <- CEnv.parseDecls sc cenv2 (CEnv.InputText superclassContents "superclass.cry" 1 1)
+     putStrLn "Translated superclass.cry!"
+     cenv4 <- CEnv.parseDecls sc cenv3 (CEnv.InputText instanceContents "instance.cry" 1 1)
+     putStrLn "Translated instance.cry!"
+     mapM_ (checkTranslation sc) $ Map.assocs (CEnv.eTermEnv cenv4)
+     putStrLn "Checked all terms!"
+
+checkTranslation :: SharedContext -> (N.Name, Term) -> IO ()
+checkTranslation sc (name, term) =
+  do result <- TC.scTypeCheck sc Nothing term
+     case result of
+       Right _ -> pure ()
+       Left err ->
+         do putStrLn $ "Type error when checking " ++ show (N.unpackIdent (N.nameIdent name))
+            putStrLn $ unlines $ TC.prettyTCError err
+            fail "internal type error"
+
+superclassContents :: String
+superclassContents = [there|test/superclass.cry|]
+
+instanceContents :: String
+instanceContents = [there|test/instance.cry|]

--- a/cryptol-saw-core/test/instance.cry
+++ b/cryptol-saw-core/test/instance.cry
@@ -1,0 +1,355 @@
+////////////////////////////////////////////////////////////////////////////////
+// Zero
+
+/* instance Zero Bit */
+zeroBit : Bit
+zeroBit = zero
+
+/* instance Zero Integer */
+zeroInteger : Integer
+zeroInteger = zero
+
+/* instance Zero Rational */
+zeroRational : Rational
+zeroRational = zero
+
+/* instance (fin n, n >= 1) => Zero (Z n) */
+zeroZ : {n} (fin n, n >= 1) => Z n
+zeroZ = zero
+
+/* instance Zero [n] */
+zeroWord : {n} [n]
+zeroWord = zero
+
+/* instance (Zero a) => Zero [n]a */
+zeroSeq : {n, a} (Zero a) => [n]a
+zeroSeq = zero
+
+/* instance (ValidFloat e p) => Zero (Float e p) */
+zeroFloat : {e, p} (ValidFloat e p) => Float e p
+zeroFloat = zero
+
+/* instance (Zero b) => Zero (a -> b) */
+zeroFun : {a, b} (Zero b) => a -> b
+zeroFun = zero
+
+/* instance Zero () */
+zeroUnit : ()
+zeroUnit = zero
+
+/* instance (Zero a, Zero b, ...) => Zero (a, b, ...) */
+zeroTuple : {a, b} (Zero a, Zero b) => (a, b)
+zeroTuple = zero
+
+/* instance Zero {} */
+zeroEmpty : {}
+zeroEmpty = zero
+
+/* instance (Zero a, Zero b, ...) => Zero { x : a, y : b, ... } */
+zeroRecord : {a, b} (Zero a, Zero b) => {x : a, y : b}
+zeroRecord = zero
+
+////////////////////////////////////////////////////////////////////////////////
+// Logic
+
+/* instance Logic Bit */
+logicBit : Bit -> Bit
+logicBit = complement
+
+/* instance Logic [n] */
+logicWord : {n} [n] -> [n]
+logicWord = complement
+
+/* instance (Logic a) => Logic [n]a */
+logicSeq : {n, a} (Logic a) => [n]a -> [n]a
+logicSeq = complement
+
+/* instance (Logic b) => Logic (a -> b) */
+logicFun : {a, b} (Logic b) => (a -> b) -> (a -> b)
+logicFun = complement
+
+/* instance Logic () */
+logicUnit : () -> ()
+logicUnit = complement
+
+/* instance (Logic a, Logic b, ...) => Logic (a, b, ...) */
+logicTuple : {a, b} (Logic a, Logic b) => (a, b) -> (a, b)
+logicTuple = complement
+
+/* instance Logic {} */
+logicEmpty : {} -> {}
+logicEmpty = complement
+
+/* instance (Logic a, Logic b, ...) => Logic { x : a, y : b, ... } */
+logicRecord : {a, b} (Logic a, Logic b) => {x : a, y : b} -> {x : a, y : b}
+logicRecord = complement
+
+////////////////////////////////////////////////////////////////////////////////
+// Ring
+
+/* instance Ring Integer */
+ringInteger : Integer -> Integer
+ringInteger = negate
+
+/* instance Ring Rational */
+ringRational : Rational -> Rational
+ringRational = negate
+
+/* instance (fin n, n >= 1) => Ring (Z n) */
+ringZ : {n} (fin n, n >= 1) => Z n -> Z n
+ringZ = negate
+
+/* instance (fin n) => Ring [n] */
+ringWord : {n} (fin n) => [n] -> [n]
+ringWord = negate
+
+// NOTE: 'instance Ring a => Ring [n]a' holds for any type 'a'
+// distinct from 'Bit'.
+
+/* instance Ring [n]Integer */
+ringSeqInteger : {n} [n]Integer -> [n]Integer
+ringSeqInteger = negate
+
+/* instance Ring [n]Rational */
+ringSeqRational : {n} [n]Rational -> [n]Rational
+ringSeqRational = negate
+
+/* instance (fin k, k >= 1) => Ring [n](Z k) */
+ringSeqZ : {n, k} (fin k, k >= 1) => [n](Z k) -> [n](Z k)
+ringSeqZ = negate
+
+/* instance (Ring [k]a) => Ring [n][k]a */
+ringSeqSeq : {n, k, a} (Ring ([k]a)) => [n][k]a -> [n][k]a
+ringSeqSeq = negate
+
+/* instance (Ring b) => Ring [n](a -> b) */
+ringSeqFun : {n, a, b} (Ring b) => [n](a -> b) -> [n](a -> b)
+ringSeqFun = negate
+
+/* instance Ring [n]() */
+ringSeqUnit : {n} [n]() -> [n]()
+ringSeqUnit = negate
+
+/* instance (Ring a, Ring b) => Ring [n](a, b) */
+ringSeqTuple : {n, a, b} (Ring a, Ring b) => [n](a, b) -> [n](a, b)
+ringSeqTuple = negate
+
+/* instance Ring [n]{} */
+ringSeqEmpty : {n} [n]{} -> [n]{}
+ringSeqEmpty = negate
+
+/* instance (Ring a, Ring b) => Ring [n]{x : a, y : b} */
+ringSeqRecord : {n, a, b} (Ring a, Ring b) => [n]{x : a, y : b} -> [n]{x : a, y : b}
+ringSeqRecord = negate
+
+/* instance (ValidFloat e p) => Ring (Float e p) */
+ringFloat : {e, p} (ValidFloat e p) => Float e p -> Float e p
+ringFloat = negate
+
+/* instance (Ring b) => Ring (a -> b) */
+ringFun : {a, b} (Ring b) => (a -> b) -> (a -> b)
+ringFun = negate
+
+/* instance Ring () */
+ringUnit : () -> ()
+ringUnit = negate
+
+/* instance (Ring a, Ring b, ...) => Ring (a, b, ...) */
+ringTuple : {a, b} (Ring a, Ring b) => (a, b) -> (a, b)
+ringTuple = negate
+
+/* instance Ring {} */
+ringEmpty : {} -> {}
+ringEmpty = negate
+
+/* instance (Ring a, Ring b, ...) => Ring { x : a, y : b, ... } */
+ringRecord : {a, b} (Ring a, Ring b) => {x : a, y : b} -> {x : a, y : b}
+ringRecord = negate
+
+////////////////////////////////////////////////////////////////////////////////
+// Integral
+
+/* instance Integral Integer */
+integralInteger : Integer -> Integer -> Integer
+integralInteger = (%)
+
+/* instance (fin n) => Integral [n] */
+integralWord : {n} (fin n) => [n] -> [n] -> [n]
+integralWord = (%)
+
+////////////////////////////////////////////////////////////////////////////////
+// Field
+
+/* instance Field Rational */
+fieldRational : Rational -> Rational
+fieldRational = recip
+
+/* instance (ValidFloat e p) => Field (Float e p) */
+fieldFloat : {e, p} (ValidFloat e p) => Float e p -> Float e p
+fieldFloat = recip
+
+////////////////////////////////////////////////////////////////////////////////
+// Round
+
+/* instance Round Rational */
+roundRational : Rational -> Integer
+roundRational = floor
+
+/* instance (ValidFloat e p) => Round (Float e p) */
+roundFloat : {e, p} (ValidFloat e p) => Float e p -> Integer
+roundFloat = floor
+
+////////////////////////////////////////////////////////////////////////////////
+// Eq
+
+/* instance Eq Bit */
+eqBit : Bit -> Bit -> Bit
+eqBit = (==)
+
+/* instance Eq Integer */
+eqInteger : Integer -> Integer -> Bit
+eqInteger = (==)
+
+/* instance Eq Rational */
+eqRational : Rational -> Rational -> Bit
+eqRational = (==)
+
+/* instance (fin n, n >= 1) => Eq (Z n) */
+eqZ : {n} (fin n, n >= 1) => Z n -> Z n -> Bit
+eqZ = (==)
+
+/* instance (fin n) => Eq [n] */
+eqWord : {n} (fin n) => [n] -> [n] -> Bit
+eqWord = (==)
+
+/* instance (fin n, Eq a) => Eq [n]a */
+eqSeq : {n, a} (fin n, Eq a) => [n]a -> [n]a -> Bit
+eqSeq = (==)
+
+/* instance (ValidFloat e p) => Eq (Float e p) */
+eqFloat : {e, p} (ValidFloat e p) => Float e p -> Float e p -> Bit
+eqFloat = (==)
+
+/* instance Eq () */
+eqUnit : () -> () -> Bit
+eqUnit = (==)
+
+/* instance (Eq a, Eq b, ...) => Eq (a, b, ...) */
+eqTuple : {a, b} (Eq a, Eq b) => (a, b) -> (a, b) -> Bit
+eqTuple = (==)
+
+/* instance Eq {} */
+eqEmpty : {} -> {} -> Bit
+eqEmpty = (==)
+
+/* instance (Eq a, Eq b, ...) => Eq { x : a, y : b, ... } */
+eqRecord : {a, b} (Eq a, Eq b) => {x : a, y : b} ->  {x : a, y : b} -> Bit
+eqRecord = (==)
+
+////////////////////////////////////////////////////////////////////////////////
+// Cmp
+
+/* instance Cmp Bit */
+cmpBit : Bit -> Bit -> Bit
+cmpBit = (<)
+
+/* instance Cmp Integer */
+cmpInteger : Integer -> Integer -> Bit
+cmpInteger = (<)
+
+/* instance Cmp Rational */
+cmpRational : Rational -> Rational -> Bit
+cmpRational = (<)
+
+/* instance (fin n) => Cmp [n] */
+cmpWord : {n} (fin n) => [n] -> [n] -> Bit
+cmpWord = (<)
+
+/* instance (fin n, Cmp a) => Cmp [n]a */
+cmpSeq : {n, a} (fin n, Cmp a) => [n]a -> [n]a -> Bit
+cmpSeq = (<)
+
+/* instance (ValidFloat e p) => Cmp (Float e p) */
+cmpFloat : {e, p} (ValidFloat e p) => Float e p -> Float e p -> Bit
+cmpFloat = (<)
+
+/* instance Cmp () */
+cmpUnit : () -> () -> Bit
+cmpUnit = (<)
+
+/* instance (Cmp a, Cmp b, ...) => Cmp (a, b, ...) */
+cmpTuple : {a, b} (Cmp a, Cmp b) => (a, b) -> (a, b) -> Bit
+cmpTuple = (<)
+
+/* instance Cmp {} */
+cmpEmpty : {} -> {} -> Bit
+cmpEmpty = (<)
+
+/* instance (Cmp a, Cmp b, ...) => Cmp { x : a, y : b, ... } */
+cmpRecord : {a, b} (Cmp a, Cmp b) => {x : a, y : b} ->  {x : a, y : b} -> Bit
+cmpRecord = (<)
+
+////////////////////////////////////////////////////////////////////////////////
+// Cmp
+
+/* instance (fin n, n >= 1) => SignedCmp [n] */
+signedCmpWord : {n} (fin n, n >= 1) => [n] -> [n] -> Bit
+signedCmpWord = (<$)
+
+// NOTE: 'instance (fin n, SignedCmp a) => SignedCmp ([n]a)' holds for
+// any type 'a' distinct from 'Bit'.
+
+/* instance (fin n, SignedCmp [k]a) => SignedCmp [n][k]a */
+signedCmpSeqSeq : {n, k, a} (fin n, SignedCmp ([k]a)) => [n][k]a -> [n][k]a -> Bit
+signedCmpSeqSeq = (<$)
+
+/* instance (fin n) => SignedCmp [n]() */
+signedCmpSeqUnit : {n} (fin n) => [n]() -> [n]() -> Bit
+signedCmpSeqUnit = (<$)
+
+/* instance (SignedCmp a, SignedCmp b) => SignedCmp [n](a, b) */
+signedCmpSeqTuple : {n, a, b} (fin n, SignedCmp a, SignedCmp b) => [n](a, b) -> [n](a, b) -> Bit
+signedCmpSeqTuple = (<$)
+
+/* instance SignedCmp [n]{} */
+signedCmpSeqEmpty : {n} (fin n) => [n]{} -> [n]{} -> Bit
+signedCmpSeqEmpty = (<$)
+
+/* instance (SignedCmp a, SignedCmp b) => SignedCmp [n]{x : a, y : b} */
+signedCmpSeqRecord : {n, a, b} (fin n, SignedCmp a, SignedCmp b) => [n]{x : a, y : b} -> [n]{x : a, y : b} -> Bit
+signedCmpSeqRecord = (<$)
+
+/* instance SignedCmp () */
+signedCmpUnit : () -> () -> Bit
+signedCmpUnit = (<$)
+
+/* instance (SignedCmp a, SignedCmp b, ...) => SignedCmp (a, b, ...) */
+signedCmpTuple : {a, b} (SignedCmp a, SignedCmp b) => (a, b) -> (a, b) -> Bit
+signedCmpTuple = (<$)
+
+/* instance SignedCmp {} */
+signedCmpEmpty : {} -> {} -> Bit
+signedCmpEmpty = (<$)
+
+/* instance (SignedCmp a, SignedCmp b, ...) => SignedCmp { x : a, y : b, ... } */
+signedCmpRecord : {a, b} (SignedCmp a, SignedCmp b) => {x : a, y : b} ->  {x : a, y : b} -> Bit
+signedCmpRecord = (<$)
+
+////////////////////////////////////////////////////////////////////////////////
+// Literal
+
+/* instance (fin val) => Literal val Integer */
+literalInteger : {val} (fin val) => Integer
+literalInteger = `val
+
+/* instance (fin val) => Literal val Rational */
+literalRational : {val} (fin val) => Rational
+literalRational = `val
+
+/* instance (fin val, fin n, n >= 1, n > val) => Literal val (Z n) */
+literalZ : {val, n} (fin val, fin n, n >= 1, n > val) => Z n
+literalZ = `val
+
+/* instance (fin val, fin n, n >= width val) => Literal val [n] */
+literalWord : {val, n} (fin val, fin n, n >= width val) => [n]
+literalWord = `val

--- a/cryptol-saw-core/test/superclass.cry
+++ b/cryptol-saw-core/test/superclass.cry
@@ -1,0 +1,32 @@
+zeroRing : {a} (Ring a) => a
+zeroRing = zero
+
+zeroLogic : {a} (Logic a) => a
+zeroLogic = zero
+
+zeroIntegral : {a} (Integral a) => a
+zeroIntegral = zero
+
+zeroField : {a} (Field a) => a
+zeroField = zero
+
+zeroRound : {a} (Round a) => a
+zeroRound = zero
+
+fromIntIntegral : {a} (Integral a) => a
+fromIntIntegral = fromInteger 42
+
+fromIntField : {a} (Field a) => a
+fromIntField = fromInteger 42
+
+fromIntRound : {a} (Round a) => a
+fromIntRound = fromInteger 42
+
+recipRound : {a} (Round a) => a -> Integer
+recipRound x = trunc (recip x)
+
+compareRound : {a} (Round a) => a -> a -> Bit
+compareRound x y = x < y
+
+eqCmp : {a} (Cmp a) => a -> a -> Bit
+eqCmp x y = x == y


### PR DESCRIPTION
This pull request imports the files and change history of the `cryptol-verifier` repo into the `saw-core` repo, renaming the package to `cryptol-saw-core` in the process, and putting it in the new `cryptol-saw-core` subdirectory.

This is just like what #60 did for a few other saw-core backend packages; the motivation is the same.