### PR TITLE
Additions to Verifier.SAW.TypedTerm library

### DIFF
--- a/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
@@ -1391,6 +1391,7 @@ asCryptolTypeValue v =
           return (C.tFun t1 t2)
     _ -> Nothing
 
+-- | Deprecated.
 scCryptolType :: SharedContext -> Term -> IO C.Type
 scCryptolType sc t =
   do modmap <- scGetModuleMap sc
@@ -1398,6 +1399,7 @@ scCryptolType sc t =
        Just ty -> return ty
        Nothing -> panic "scCryptolType" ["scCryptolType: unsupported type " ++ showTerm t]
 
+-- | Deprecated.
 scCryptolEq :: SharedContext -> Term -> Term -> IO Term
 scCryptolEq sc x y =
   do rules <- concat <$> traverse defRewrites (defs1 ++ defs2)

--- a/cryptol-saw-core/src/Verifier/SAW/TypedTerm.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/TypedTerm.hs
@@ -19,9 +19,10 @@ import Verifier.SAW.SharedTerm
 
 -- Typed terms -----------------------------------------------------------------
 
-{- Within SAWScript, we represent an object language term as a SAWCore
-shared term paired with a Cryptol type schema. The Cryptol type is
-used for type inference/checking of inline Cryptol expressions. -}
+-- | Within SAWScript, we represent an object language term as a
+-- SAWCore shared term paired with a Cryptol type schema. The Cryptol
+-- type is used for type inference/checking of inline Cryptol
+-- expressions.
 
 data TypedTerm =
   TypedTerm
@@ -41,9 +42,9 @@ mkTypedTerm sc trm = do
 
 -- Typed modules ---------------------------------------------------------------
 
-{- In SAWScript, we can refer to a Cryptol module as a first class
-value. These are represented simply as maps from names to typed
-terms. -}
+-- | In SAWScript, we can refer to a Cryptol module as a first class
+-- value. These are represented simply as maps from names to typed
+-- terms.
 
 data CryptolModule =
   CryptolModule (Map C.Name C.TySyn) (Map C.Name TypedTerm)

--- a/cryptol-saw-core/src/Verifier/SAW/TypedTerm.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/TypedTerm.hs
@@ -7,6 +7,7 @@ Stability   : provisional
 -}
 module Verifier.SAW.TypedTerm where
 
+import Control.Monad (foldM)
 import Data.Map (Map)
 import qualified Data.Map as Map
 
@@ -44,6 +45,49 @@ mkTypedTerm sc trm = do
   ty <- scTypeOf sc trm
   ct <- scCryptolType sc ty
   return $ TypedTerm (C.Forall [] [] ct) trm
+
+-- | Apply a function-typed 'TypedTerm' to an argument. This operation
+-- fails if the first 'TypedTerm' does not have a monomorphic function
+-- type.
+applyTypedTerm :: SharedContext -> TypedTerm -> TypedTerm -> IO TypedTerm
+applyTypedTerm sc (TypedTerm schema1 t1) (TypedTerm _schema2 t2) =
+  case C.tIsFun =<< C.isMono schema1 of
+    Nothing -> fail "applyTypedTerm: not a function type"
+    Just (_, cty') -> TypedTerm (C.tMono cty') <$> scApply sc t1 t2
+
+-- | Apply a 'TypedTerm' to a list of arguments. This operation fails
+-- if the first 'TypedTerm' does not have a function type of
+-- sufficient arity.
+applyTypedTerms :: SharedContext -> TypedTerm -> [TypedTerm] -> IO TypedTerm
+applyTypedTerms sc = foldM (applyTypedTerm sc)
+
+-- | Create an abstract defined constant with the specified name and body.
+defineTypedTerm :: SharedContext -> String -> TypedTerm -> IO TypedTerm
+defineTypedTerm sc name (TypedTerm schema t) =
+  do ty <- scTypeOf sc t
+     TypedTerm schema <$> scConstant sc name t ty
+
+-- | Make a tuple value from a list of 'TypedTerm's. This operation
+-- fails if any 'TypedTerm' in the list has a polymorphic type.
+tupleTypedTerm :: SharedContext -> [TypedTerm] -> IO TypedTerm
+tupleTypedTerm sc tts =
+  case traverse (C.isMono . ttSchema) tts of
+    Nothing -> fail "tupleTypedTerm: invalid polymorphic term"
+    Just ctys ->
+      TypedTerm (C.tMono (C.tTuple ctys)) <$> scTuple sc (map ttTerm tts)
+
+-- | Given a 'TypedTerm' with a tuple type, return a list of its
+-- projected components. This operation fails if the 'TypedTerm' does
+-- not have a tuple type.
+destTupleTypedTerm :: SharedContext -> TypedTerm -> IO [TypedTerm]
+destTupleTypedTerm sc (TypedTerm schema t) =
+  case C.tIsTuple =<< C.isMono schema of
+    Nothing -> fail "asTupleTypedTerm: not a tuple type"
+    Just ctys ->
+      do let len = length ctys
+         let idxs = take len [1 ..]
+         ts <- traverse (\i -> scTupleSelector sc t i len) idxs
+         pure $ zipWith TypedTerm (map C.tMono ctys) ts
 
 -- First order types and values ------------------------------------------------
 

--- a/cryptol-saw-core/src/Verifier/SAW/TypedTerm.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/TypedTerm.hs
@@ -87,6 +87,11 @@ asTypedExtCns (TypedTerm schema t) =
      ec <- asExtCns t
      pure $ TypedExtCns cty ec
 
+-- | Make a 'TypedTerm' from a 'TypedExtCns'.
+typedTermOfExtCns :: SharedContext -> TypedExtCns -> IO TypedTerm
+typedTermOfExtCns sc (TypedExtCns cty ec) =
+  TypedTerm (C.tMono cty) <$> scExtCns sc ec
+
 abstractTypedExts :: SharedContext -> [TypedExtCns] -> TypedTerm -> IO TypedTerm
 abstractTypedExts sc tecs (TypedTerm (C.Forall params props ty) trm) =
   do let tys = map tecType tecs

--- a/saw-core/src/Verifier/SAW/SharedTerm.hs
+++ b/saw-core/src/Verifier/SAW/SharedTerm.hs
@@ -54,6 +54,7 @@ module Verifier.SAW.SharedTerm
   , scDefTerm
   , scFreshGlobalVar
   , scFreshGlobal
+  , scExtCns
   , scGlobalDef
     -- ** Recursors and datatypes
   , scRecursorElimTypes
@@ -308,11 +309,15 @@ data SharedContext = SharedContext
 scFlatTermF :: SharedContext -> FlatTermF Term -> IO Term
 scFlatTermF sc ftf = scTermF sc (FTermF ftf)
 
+-- | Create a 'Term' from an 'ExtCns'.
+scExtCns :: SharedContext -> ExtCns Term -> IO Term
+scExtCns sc ec = scFlatTermF sc (ExtCns ec)
+
 -- | Create a global variable with the given identifier (which may be "_") and type.
 scFreshGlobal :: SharedContext -> String -> Term -> IO Term
 scFreshGlobal sc sym tp = do
   i <- scFreshGlobalVar sc
-  scFlatTermF sc (ExtCns (EC i sym tp))
+  scExtCns sc (EC i sym tp)
 
 -- | Returns shared term associated with ident.
 -- Does not check module namespace.


### PR DESCRIPTION
This PR extends the `Verifier.SAW.TypedTerm` module in the `cryptol-saw-core` package with a bunch of new stuff, including a new type `TypedExtCns` (basically the saw-core `ExtCns` type paired with a cryptol type), and also several new operations for creating, combining, and inspecting `TypedTerm` and `TypedExtCns` values.

These additions will be immediately useful for refactoring and simplifying various parts of saw-script.