### PR TITLE
Change VNat constructor to use Natural instead of Integer

### DIFF
--- a/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
+++ b/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
@@ -299,10 +299,12 @@ lazyMux muxFn c tm fm =
 
 -- selectV merger maxValue valueFn index returns valueFn v when index has value v
 -- if index is greater than maxValue, it returns valueFn maxValue. Use the ite op from merger.
-selectV :: (Ord a, Num a, Bits a) => (SBool -> b -> b -> b) -> a -> (a -> b) -> SWord -> b
+selectV :: (SBool -> b -> b -> b) -> Natural -> (Natural -> b) -> SWord -> b
 selectV merger maxValue valueFn vx =
   case svAsInteger vx of
-    Just i  -> valueFn (fromIntegral i) -- TODO: dangerous fromIntegral
+    Just i
+      | i >= 0    -> valueFn (fromInteger i)
+      | otherwise -> Prims.panic "selectV" ["expected nonnegative integer", show i]
     Nothing -> impl (intSizeOf vx) 0
   where
     impl _ x | x > maxValue || x < 0 = valueFn maxValue

--- a/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
+++ b/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
@@ -80,7 +80,7 @@ type SValue = Value SBV
 --type SThunk = Thunk SBV
 
 data SbvExtra =
-  SStream (Integer -> IO SValue) (IORef (Map Integer SValue))
+  SStream (Natural -> IO SValue) (IORef (Map Natural SValue))
 
 instance Show SbvExtra where
   show (SStream _ _) = "<SStream>"
@@ -302,7 +302,7 @@ lazyMux muxFn c tm fm =
 selectV :: (Ord a, Num a, Bits a) => (SBool -> b -> b -> b) -> a -> (a -> b) -> SWord -> b
 selectV merger maxValue valueFn vx =
   case svAsInteger vx of
-    Just i  -> valueFn (fromIntegral i)
+    Just i  -> valueFn (fromIntegral i) -- TODO: dangerous fromIntegral
     Nothing -> impl (intSizeOf vx) 0
   where
     impl _ x | x > maxValue || x < 0 = valueFn maxValue
@@ -337,8 +337,8 @@ bvShiftOp bvOp natOp =
   wordFun $ \x -> return $
   strictFun $ \y ->
     case y of
-      VNat i   -> return (vWord (natOp x j))
-        where j = fromInteger (i `min` toInteger (intSizeOf x))
+      VNat i | j < toInteger (maxBound :: Int) -> return (vWord (natOp x (fromInteger j)))
+        where j = toInteger i `min` toInteger (intSizeOf x)
       VToNat v -> fmap (vWord . bvOp x) (toWord v)
       _        -> error $ unwords ["Verifier.SAW.Simulator.SBV.bvShiftOp", show y]
 
@@ -367,7 +367,7 @@ intToNatOp =
   Prims.intFun "intToNat" $ \i ->
     case svAsInteger i of
       Just i'
-        | 0 <= i'   -> pure (VNat i')
+        | 0 <= i'   -> pure (VNat (fromInteger i'))
         | otherwise -> pure (VNat 0)
       Nothing ->
         let z  = svInteger KUnbounded 0
@@ -479,18 +479,18 @@ streamGetOp =
   constFun $
   strictFun $ \xs -> return $
   strictFun $ \case
-    VNat n -> lookupSStream xs (toInteger n)
+    VNat n -> lookupSStream xs n
     VToNat w ->
       do ilv <- toWord w
          selectV (lazyMux muxBVal) ((2 ^ intSizeOf ilv) - 1) (lookupSStream xs) ilv
     v -> Prims.panic "SBV.streamGetOp" ["Expected Nat value", show v]
 
 
-lookupSStream :: SValue -> Integer -> IO SValue
+lookupSStream :: SValue -> Natural -> IO SValue
 lookupSStream (VExtra s) n = lookupSbvExtra s n
 lookupSStream _ _ = fail "expected Stream"
 
-lookupSbvExtra :: SbvExtra -> Integer -> IO SValue
+lookupSbvExtra :: SbvExtra -> Natural -> IO SValue
 lookupSbvExtra (SStream f r) n =
   do m <- readIORef r
      case Map.lookup n m of
@@ -626,7 +626,7 @@ vAsFirstOrderType v =
     VIntType
       -> return FOTInt
     VVecType (VNat n) v2
-      -> FOTVec (fromInteger n) <$> vAsFirstOrderType v2
+      -> FOTVec n <$> vAsFirstOrderType v2
     VUnitType
       -> return (FOTTuple [])
     VPairType v1 v2

--- a/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
+++ b/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
@@ -558,14 +558,14 @@ lazyMux muxFn c tm fm =
 
 -- selectV merger maxValue valueFn index returns valueFn v when index has value v
 -- if index is greater than maxValue, it returns valueFn maxValue. Use the ite op from merger.
-selectV :: forall sym a b. (Sym sym, Ord a, Num a, Bits a) =>
-  (SBool sym -> IO b -> IO b -> IO b) -> a -> (a -> IO b) -> SWord sym -> IO b
+selectV :: forall sym b. Sym sym =>
+  (SBool sym -> IO b -> IO b -> IO b) -> Natural -> (Natural -> IO b) -> SWord sym -> IO b
 selectV merger maxValue valueFn vx =
   case SW.bvAsUnsignedInteger vx of
-    Just i  -> valueFn (fromIntegral i) -- TODO: dangerous fromIntegral
+    Just i  -> valueFn (fromInteger i :: Natural)
     Nothing -> impl (swBvWidth vx) 0
   where
-    impl :: Int -> a -> IO b
+    impl :: Int -> Natural -> IO b
     impl _ x | x > maxValue || x < 0 = valueFn maxValue
     impl 0 y = valueFn y
     impl i y = do

--- a/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
+++ b/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
@@ -137,7 +137,7 @@ type Sym sym = (Given sym, IsSymExprBuilder sym)
 ---------------------------------------------------------------------
 
 data What4Extra sym =
-  SStream (Integer -> IO (SValue sym)) (IORef (Map Integer (SValue sym)))
+  SStream (Natural -> IO (SValue sym)) (IORef (Map Natural (SValue sym)))
 
 instance Show (What4Extra sym) where
   show (SStream _ _) = "<SStream>"
@@ -324,7 +324,7 @@ intToNatOp =
   Prims.intFun "intToNat" $ \i ->
     case W.asInteger i of
       Just i'
-        | 0 <= i'   -> pure (VNat i')
+        | 0 <= i'   -> pure (VNat (fromInteger i'))
         | otherwise -> pure (VNat 0)
       Nothing ->
         do z <- W.intLit (given :: sym) 0
@@ -404,7 +404,7 @@ bvShiftOp bvOp natOp =
   strictFun $ \y ->            -- amount to shift as a nat
     case y of
       VNat i   -> VWord <$> natOp x j
-        where j = i `min` toInteger (SW.bvWidth x)
+        where j = toInteger i `min` SW.bvWidth x
       VToNat v -> VWord <$> (bvOp x =<< toWord v)
       _        -> error $ unwords ["Verifier.SAW.Simulator.What4.bvShiftOp", show y]
 
@@ -512,13 +512,13 @@ streamGetOp =
   constFun $
   strictFun $ \xs -> return $
   strictFun $ \case
-    VNat n -> lookupSStream xs (toInteger n)
+    VNat n -> lookupSStream xs n
     VToNat w ->
       do ilv <- toWord w
          selectV (lazyMux @sym muxBVal) ((2 ^ SW.bvWidth ilv) - 1) (lookupSStream xs) ilv
     v -> Prims.panic "streamGetOp" ["Expected Nat value", show v]
 
-lookupSStream :: SValue sym -> Integer -> IO (SValue sym)
+lookupSStream :: SValue sym -> Natural -> IO (SValue sym)
 lookupSStream (VExtra (SStream f r)) n = do
    m <- readIORef r
    case Map.lookup n m of
@@ -562,7 +562,7 @@ selectV :: forall sym a b. (Sym sym, Ord a, Num a, Bits a) =>
   (SBool sym -> IO b -> IO b -> IO b) -> a -> (a -> IO b) -> SWord sym -> IO b
 selectV merger maxValue valueFn vx =
   case SW.bvAsUnsignedInteger vx of
-    Just i  -> valueFn (fromIntegral i)
+    Just i  -> valueFn (fromIntegral i) -- TODO: dangerous fromIntegral
     Nothing -> impl (swBvWidth vx) 0
   where
     impl :: Int -> a -> IO b
@@ -895,8 +895,8 @@ vAsFirstOrderType v =
       -> return FOTBit
     VIntType
       -> return FOTInt
-    VVecType (VNat n) v2 | n >= 0
-      -> FOTVec (fromInteger n :: Natural) <$> vAsFirstOrderType v2
+    VVecType (VNat n) v2
+      -> FOTVec n <$> vAsFirstOrderType v2
     VArrayType iv ev
       -> FOTArray <$> vAsFirstOrderType iv <*> vAsFirstOrderType ev
     VUnitType
@@ -1112,7 +1112,7 @@ parseUninterpretedSAW sym sc ref trm app ty =
     VVecType (VNat n) ety | n >= 0
       ->  do ety' <- termOfSValue sc ety
              let mkElem i =
-                   do let trm' = ArgTermAt (fromInteger n :: Natural) ety' trm i
+                   do let trm' = ArgTermAt n ety' trm i
                       let app' = suffixUnintApp ("_a" ++ show i) app
                       parseUninterpretedSAW sym sc ref trm' app' ety
              xs <- traverse mkElem (genericTake n [0 ..])
@@ -1274,8 +1274,8 @@ termOfSValue sc val =
     VBoolType -> scBoolType sc
     VIntType -> scIntegerType sc
     VUnitType -> scUnitType sc
-    VVecType (VNat n) a | n >= 0 ->
-      do n' <- scNat sc (fromInteger n :: Natural)
+    VVecType (VNat n) a ->
+      do n' <- scNat sc n
          a' <- termOfSValue sc a
          scVecType sc n' a'
     VPairType a b
@@ -1285,6 +1285,6 @@ termOfSValue sc val =
     VRecordType flds
       -> do flds' <- traverse (traverse (termOfSValue sc)) flds
             scRecordType sc flds'
-    VNat n | n >= 0
-      -> scNat sc (fromInteger n :: Natural)
+    VNat n
+      -> scNat sc n
     _ -> fail $ "termOfSValue: " ++ show val

--- a/saw-core/src/Verifier/SAW/Simulator.hs
+++ b/saw-core/src/Verifier/SAW/Simulator.hs
@@ -166,7 +166,7 @@ evalTermF cfg lam recEval tf env =
           VRecordValue <$> mapM (\(fld,t) -> (fld,) <$> recEvalDelay t) elems
         RecordProj t fld    -> recEval t >>= flip valRecordProj fld
         Sort {}             -> return VType
-        NatLit n            -> return $ VNat (toInteger n)
+        NatLit n            -> return $ VNat n
         ArrayValue _ tv     -> liftM VVector $ mapM recEvalDelay tv
         StringLit s         -> return $ VString s
         ExtCns ec           -> do ec' <- traverse recEval ec

--- a/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
@@ -130,7 +130,7 @@ bvShiftOp natOp =
   wordFun $ \x ->
   pureFun $ \y ->
     case y of
-      VNat n -> vWord (natOp x (fromInteger n))
+      VNat n | toInteger n < toInteger (maxBound :: Int) -> vWord (natOp x (fromIntegral n))
       _      -> error $ unwords ["Verifier.SAW.Simulator.Concrete.shiftOp", show y]
 
 ------------------------------------------------------------
@@ -273,7 +273,7 @@ constMap =
 
 -- primitive bvToNat :: (n::Nat) -> bitvector n -> Nat;
 bvToNatOp :: CValue
-bvToNatOp = constFun $ wordFun $ VNat . unsigned
+bvToNatOp = constFun $ wordFun $ VNat . fromInteger . unsigned
 
 -- primitive bvToInt :: (n::Nat) -> bitvector n -> Integer;
 bvToIntOp :: CValue

--- a/saw-core/src/Verifier/SAW/Simulator/RME.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/RME.hs
@@ -125,7 +125,7 @@ bvShiftOp op =
   wordFun $ \x ->
   pureFun $ \y ->
     case y of
-      VNat n   -> vWord (op x n)
+      VNat n   -> vWord (op x (toInteger n))
       VToNat v -> vWord (genShift muxRMEV op x (toWord v))
       _        -> error $ unwords ["Verifier.SAW.Simulator.RME.shiftOp", show y]
 

--- a/saw-core/src/Verifier/SAW/Simulator/Value.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Value.hs
@@ -29,6 +29,7 @@ import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Vector (Vector)
 import qualified Data.Vector as V
+import Numeric.Natural
 
 import Verifier.SAW.FiniteValue (FiniteType(..))
 import Verifier.SAW.SharedTerm
@@ -55,7 +56,7 @@ data Value l
   | VBoolType
   | VWord (VWord l)
   | VToNat (Value l)
-  | VNat !Integer
+  | VNat !Natural
   | VInt (VInt l)
   | VIntType
   | VArray (VArray l)
@@ -227,7 +228,7 @@ asFiniteTypeValue v =
     VBoolType -> return FTBit
     VVecType (VNat n) v1 -> do
       t1 <- asFiniteTypeValue v1
-      return (FTVec (fromInteger n) t1)
+      return (FTVec n t1)
     VUnitType -> return (FTTuple [])
     VPairType v1 v2 -> do
       t1 <- asFiniteTypeValue v1


### PR DESCRIPTION
Provides more accurate datatype invariants.  This shuffles around the required numeric conversions and makes them somewhat more sensible, in my opinion.  There's much more that could be done to, e.g., replace `Int` arguments in various places.  I've kept this PR rather more self-contained to make it easier to review.