### PR TITLE
Remove the obsolete `bvForall` SAWCore primitive

### DIFF
--- a/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
+++ b/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
@@ -228,7 +228,6 @@ prims be =
   , Prims.bpBvPopcount = AIG.popCount be
   , Prims.bpBvCountLeadingZeros = AIG.countLeadingZeros be
   , Prims.bpBvCountTrailingZeros = AIG.countTrailingZeros be
-  , Prims.bpBvForall = unsupportedAIGPrimitive "bvForall"
 
     -- Integer operations
   , Prims.bpIntAdd = pure2 (+)

--- a/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
+++ b/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
@@ -156,7 +156,6 @@ prims =
   , Prims.bpBvPopcount = pure1 svPopcount
   , Prims.bpBvCountLeadingZeros = pure1 svCountLeadingZeros
   , Prims.bpBvCountTrailingZeros = pure1 svCountTrailingZeros
-  , Prims.bpBvForall = unsupportedSBVPrimitive "bvForall"
     -- Integer operations
   , Prims.bpIntAdd = pure2 svPlus
   , Prims.bpIntSub = pure2 svMinus

--- a/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
+++ b/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
@@ -212,7 +212,6 @@ prims =
   , Prims.bpBvPopcount = SW.bvPopcount sym
   , Prims.bpBvCountLeadingZeros = SW.bvCountLeadingZeros sym
   , Prims.bpBvCountTrailingZeros = SW.bvCountTrailingZeros sym
-  , Prims.bpBvForall = bvForall sym
     -- Integer operations
   , Prims.bpIntAbs = W.intAbs sym
   , Prims.bpIntAdd = W.intAdd sym
@@ -422,21 +421,6 @@ bvShROp = bvShiftOp (SW.bvLshr given)
 bvSShROp :: forall sym. (Sym sym) => SValue sym
 bvSShROp = bvShiftOp (SW.bvAshr given)
                      (liftShift given (SW.bvAshr given))
-
-bvForall :: W.IsSymExprBuilder sym =>
-  sym -> Natural -> (SWord sym -> IO (Pred sym)) -> IO (Pred sym)
-bvForall sym n f =
-  case W.userSymbol "i" of
-    Left err -> fail $ show err
-    Right indexSymbol ->
-      case mkNatRepr n of
-        Some w
-          | Just LeqProof <- testLeq (knownNat @1) w ->
-            withKnownNat w $ do
-              i <- W.freshBoundVar sym indexSymbol $ W.BaseBVRepr w
-              body <- f . DBV $ W.varExpr sym i
-              W.forallPred sym i body
-          | otherwise -> f ZBV
 
 --
 -- missing integer operations

--- a/saw-core/prelude/Prelude.sawcore
+++ b/saw-core/prelude/Prelude.sawcore
@@ -1093,9 +1093,6 @@ primitive bvPopcount : (n : Nat) -> bitvector n -> bitvector n;
 primitive bvCountLeadingZeros : (n : Nat) -> bitvector n -> bitvector n;
 primitive bvCountTrailingZeros : (n : Nat) -> bitvector n -> bitvector n;
 
--- Universal quantification over bitvectors
-primitive bvForall : (n : Nat) -> (bitvector n -> Bool) -> Bool;
-
 bvCarry : (n : Nat) -> bitvector n -> bitvector n -> Bool;
 bvCarry n x y = bvult n (bvAdd n x y) x;
 

--- a/saw-core/src/Verifier/SAW/SharedTerm.hs
+++ b/saw-core/src/Verifier/SAW/SharedTerm.hs
@@ -186,7 +186,6 @@ module Verifier.SAW.SharedTerm
   , scBvAt
   , scBvConst
   , scFinVal
-  , scBvForall
   , scUpdBvFun
   , scBvNonzero, scBvBool
   , scBvAdd, scBvSub, scBvMul, scBvNeg
@@ -1415,12 +1414,6 @@ scXor sc x y = scGlobalApply sc "Prelude.xor" [x,y]
 -- > boolEq : Bool -> Bool -> Bool;
 scBoolEq :: SharedContext -> Term -> Term -> IO Term
 scBoolEq sc x y = scGlobalApply sc "Prelude.boolEq" [x,y]
-
--- | Create a universally quantified bitvector term.
---
--- > bvForall : (n : Nat) -> (bitvector n -> Bool) -> Bool;
-scBvForall :: SharedContext -> Term -> Term -> IO Term
-scBvForall sc w f = scGlobalApply sc "Prelude.bvForall" [w, f]
 
 -- | Create a non-dependent if-then-else term.
 --

--- a/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
@@ -212,7 +212,6 @@ prims =
   , Prims.bpBvPopcount = pure1 (Prim.bvPopcount undefined)
   , Prims.bpBvCountLeadingZeros = pure1 (Prim.bvCountLeadingZeros undefined)
   , Prims.bpBvCountTrailingZeros = pure1 (Prim.bvCountTrailingZeros undefined)
-  , Prims.bpBvForall = unsupportedConcretePrimitive "bvForall"
 
     -- Integer operations
   , Prims.bpIntAdd = pure2 (+)

--- a/saw-core/src/Verifier/SAW/Simulator/Prims.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Prims.hs
@@ -110,7 +110,6 @@ data BasePrims l =
   , bpBvPopcount           :: VWord l -> MWord l
   , bpBvCountLeadingZeros  :: VWord l -> MWord l
   , bpBvCountTrailingZeros :: VWord l -> MWord l
-  , bpBvForall             :: Natural -> (VWord l -> MBool l) -> MBool l
     -- Integer operations
   , bpIntAdd :: VInt l -> VInt l -> MInt l
   , bpIntSub :: VInt l -> VInt l -> MInt l
@@ -179,16 +178,7 @@ constMap bp = Map.fromList
   , ("Prelude.bvPopcount", wordUnOp (bpPack bp) (bpBvPopcount bp))
   , ("Prelude.bvCountLeadingZeros", wordUnOp (bpPack bp) (bpBvCountLeadingZeros bp))
   , ("Prelude.bvCountTrailingZeros", wordUnOp (bpPack bp) (bpBvCountTrailingZeros bp))
-  , ("Prelude.bvForall", natFun $ \n ->
-        pure . strictFun $ fmap VBool . bpBvForall bp n . toWordPred
-    )
 
-{-
-  -- Shifts
-  , ("Prelude.bvShl" , bvShLOp)
-  , ("Prelude.bvShr" , bvShROp)
-  , ("Prelude.bvSShr", bvSShROp)
--}
   -- Nat
   , ("Prelude.Succ", succOp)
   , ("Prelude.addNat", addNatOp)
@@ -220,8 +210,6 @@ constMap bp = Map.fromList
   , ("Prelude.intToBv" , intToBvOp)
   , ("Prelude.bvToInt" , bvToIntOp)
   , ("Prelude.sbvToInt", sbvToIntOp)
-  --XXX , ("Prelude.intMin"  , Prims.intMinOp)
-  --XXX , ("Prelude.intMax"  , Prims.intMaxOp)
 -}
   , ("Prelude.intMin", intBinOp "intMin" (bpIntMin bp))
   , ("Prelude.intMax", intBinOp "intMax" (bpIntMax bp))

--- a/saw-core/src/Verifier/SAW/Simulator/RME.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/RME.hs
@@ -202,7 +202,6 @@ prims =
   , Prims.bpBvPopcount = pure1 RMEV.popcount
   , Prims.bpBvCountLeadingZeros = pure1 RMEV.countLeadingZeros
   , Prims.bpBvCountTrailingZeros = pure1 RMEV.countTrailingZeros
-  , Prims.bpBvForall = unsupportedRMEPrimitive "bvForall"
     -- Integer operations
   , Prims.bpIntAdd = pure2 (+)
   , Prims.bpIntSub = pure2 (-)


### PR DESCRIPTION
Still investigating the consequences of removing this primitive.