### PR TITLE
Structured names

### DIFF
--- a/cryptol-saw-core/cryptol-saw-core.cabal
+++ b/cryptol-saw-core/cryptol-saw-core.cabal
@@ -31,6 +31,7 @@ library
     cryptol >= 2.3.0,
     data-inttrie >= 0.1.4,
     integer-gmp,
+    modern-uri,
     panic,
     saw-core,
     saw-core-aig,

--- a/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wall #-}
+{-# LANGUAGE DoAndIfThenElse #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -19,13 +20,18 @@ import Control.Monad (foldM, join, unless)
 import Data.Bifunctor (first)
 import qualified Data.Foldable as Fold
 import Data.List
+import Data.List.NonEmpty (NonEmpty(..))
+import Data.Maybe (fromMaybe)
 import qualified Data.IntTrie as IntTrie
 import Data.Map (Map)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
+import Data.Text (Text)
+import qualified Data.Text as Text
 import qualified Data.Vector as Vector
 import Prelude ()
 import Prelude.Compat
+import Text.URI
 
 import qualified Cryptol.Eval.Type as TV
 import qualified Cryptol.Backend.Monad as V
@@ -34,8 +40,11 @@ import qualified Cryptol.Eval.Concrete as V
 import Cryptol.Eval.Type (evalValType)
 import qualified Cryptol.TypeCheck.AST as C
 import qualified Cryptol.TypeCheck.Subst as C (Subst, apSubst, singleTParamSubst)
-import qualified Cryptol.ModuleSystem.Name as C (asPrim, nameIdent)
-import qualified Cryptol.Utils.Ident as C (Ident, PrimIdent(..), packIdent, unpackIdent, prelPrim, floatPrim, arrayPrim)
+import qualified Cryptol.ModuleSystem.Name as C (asPrim, nameIdent, nameInfo, NameInfo(..))
+import qualified Cryptol.Utils.Ident as C
+  ( Ident, PrimIdent(..), packIdent, unpackIdent, prelPrim, floatPrim, arrayPrim
+  , modNameToText, identText
+  )
 import qualified Cryptol.Utils.RecordMap as C
 import Cryptol.TypeCheck.TypeOf (fastTypeOf, fastSchemaOf)
 import Cryptol.Utils.PP (pretty)
@@ -1071,6 +1080,32 @@ plainSubst s ty =
     C.TRec fs      -> C.TRec (fmap (plainSubst s) fs)
     C.TVar x       -> C.apSubst s (C.TVar x)
 
+
+cryptolURI :: [Text] -> URI
+cryptolURI [] = panic "cryptolURI" ["Could not make URI from empty path"]
+cryptolURI (p:ps) = fromMaybe (panic "cryptolURI" ["Could not make URI from the given path", show (p:ps)]) $
+  do sch <- mkScheme "cryptol"
+     path' <- mapM mkPathPiece (p:|ps)
+     pure URI
+       { uriScheme = Just sch
+       , uriAuthority = Left True -- absolute path
+       , uriPath = Just (False, path')
+       , uriQuery = []
+       , uriFragment = Nothing
+       }
+
+importName :: C.Name -> IO NameInfo
+importName cnm =
+  case C.nameInfo cnm of
+    C.Parameter -> fail ("Cannot import non-top-level name: " ++ show cnm)
+    C.Declared modNm _ ->
+      let modNmTxt  = C.modNameToText modNm
+          modNms = Text.splitOn "::" modNmTxt
+          shortNm = C.identText (C.nameIdent cnm)
+          aliases = [shortNm, modNmTxt <> "::" <> shortNm]
+          uri = cryptolURI (modNms ++ [shortNm])
+       in pure (ImportedName uri aliases)
+
 -- | Currently this imports declaration groups by inlining all the
 -- definitions. (With subterm sharing, this is not as bad as it might
 -- seem.) We might want to think about generating let or where
@@ -1088,7 +1123,11 @@ importDeclGroup isTopLevel sc env (C.Recursive [decl]) =
          let x = nameToString (C.dName decl)
          f' <- scLambda sc x t' e'
          rhs <- scGlobalApply sc "Prelude.fix" [t', f']
-         rhs' <- if not isTopLevel then return rhs else scConstant sc x rhs t'
+         rhs' <- if isTopLevel then
+                    do nmi <- importName (C.dName decl)
+                       scConstant' sc nmi rhs t'
+                 else
+                   return rhs
          let env' = env { envE = Map.insert (C.dName decl) (rhs', 0) (envE env)
                         , envC = Map.insert (C.dName decl) (C.dSignature decl) (envC env) }
          return env'
@@ -1145,7 +1184,11 @@ importDeclGroup isTopLevel sc env (C.Recursive decls) =
      let mkRhs d t =
            do let s = nameToString (C.dName d)
               r <- scRecordSelect sc rhs s
-              if isTopLevel then scConstant sc s r t else return r
+              if isTopLevel then
+                do nmi <- importName (C.dName d)
+                   scConstant' sc nmi r t
+              else
+                return r
      rhss <- sequence (Map.intersectionWith mkRhs dm tm)
 
      let env' = env { envE = Map.union (fmap (\v -> (v, 0)) rhss) (envE env)
@@ -1167,8 +1210,9 @@ importDeclGroup isTopLevel sc env (C.NonRecursive decl) =
     C.DExpr expr -> do
      rhs <- importExpr' sc env (C.dSignature decl) expr
      rhs' <- if not isTopLevel then return rhs else do
+       nmi <- importName (C.dName decl)
        t <- importSchema sc env (C.dSignature decl)
-       scConstant sc (nameToString (C.dName decl)) rhs t
+       scConstant' sc nmi rhs t
      let env' = env { envE = Map.insert (C.dName decl) (rhs', 0) (envE env)
                     , envC = Map.insert (C.dName decl) (C.dSignature decl) (envC env) }
      return env'

--- a/saw-core-aig/saw-core-aig.cabal
+++ b/saw-core-aig/saw-core-aig.cabal
@@ -20,6 +20,7 @@ library
     base == 4.*,
     containers,
     saw-core,
+    text,
     vector
   hs-source-dirs: src
   exposed-modules:

--- a/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
+++ b/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
@@ -30,6 +30,7 @@ import Control.Monad ((<=<))
 import Data.IORef
 import Data.Map (Map)
 import qualified Data.Map as Map
+import qualified Data.Text as Text
 import qualified Data.Vector as V
 import Numeric.Natural (Natural)
 
@@ -489,7 +490,7 @@ bitBlastTerm be sc addlPrims t = do
   modmap <- scGetModuleMap sc
   bval <- bitBlastBasic be modmap addlPrims ecMap t
   bval' <- applyAll bval argVars
-  let names =  map fst args ++ map ecName ecs
+  let names =  map fst args ++ map (Text.unpack . toShortName . ecName) ecs
       shapes = argShapes ++ ecShapes
   return (bval', zip names shapes)
 

--- a/saw-core-sbv/saw-core-sbv.cabal
+++ b/saw-core-sbv/saw-core-sbv.cabal
@@ -21,6 +21,7 @@ library
     mtl,
     saw-core,
     sbv >= 8.0,
+    text,
     transformers,
     vector
   hs-source-dirs: src

--- a/saw-core-what4/saw-core-what4.cabal
+++ b/saw-core-what4/saw-core-what4.cabal
@@ -25,6 +25,7 @@ library
     what4,
     crucible-saw,
     panic,
+    text,
     transformers,
     vector,
     parameterized-utils >= 1.0.8 && < 2.2,

--- a/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
+++ b/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
@@ -81,10 +81,8 @@ import qualified Verifier.SAW.Simulator as Sim
 import qualified Verifier.SAW.Simulator.Prims as Prims
 import Verifier.SAW.SharedTerm
 import Verifier.SAW.Simulator.Value
-import Verifier.SAW.TypedAST (FieldName, ModuleMap, identName)
 import Verifier.SAW.FiniteValue (FirstOrderType(..), FirstOrderValue(..))
 import Verifier.SAW.TypedAST (FieldName, ModuleMap, identName, toShortName)
-import Verifier.SAW.FiniteValue (FirstOrderType(..), FirstOrderValue(..))
 
 -- what4
 import qualified What4.Expr.Builder as B

--- a/saw-core/saw-core.cabal
+++ b/saw-core/saw-core.cabal
@@ -35,6 +35,7 @@ library
     filepath,
     hashable >= 1.2,
     lens >= 3.8,
+    modern-uri >= 0.3.2 && < 0.4,
     MonadRandom,
     mtl,
     panic,

--- a/saw-core/src/Verifier/SAW/Conversion.hs
+++ b/saw-core/src/Verifier/SAW/Conversion.hs
@@ -205,7 +205,7 @@ resolveArgs (Matcher p m) (defaultArgsMatcher -> args@(ArgsMatcher pl _)) =
 
 -- | Match a global definition.
 asGlobalDef :: Ident -> Matcher ()
-asGlobalDef ident = Matcher (Net.Atom (identBaseName ident)) f
+asGlobalDef ident = Matcher (Net.Atom (identText ident)) f
   where f (R.asGlobalDef -> Just o) | ident == o = return ()
         f _ = Nothing
 
@@ -262,7 +262,7 @@ asRecordSelector m = asVar $ \t -> _1 (runMatcher m) =<< R.asRecordSelector t
 
 -- | Match a constructor
 asCtor :: ArgsMatchable v a => Ident -> v a -> Matcher a
-asCtor o = resolveArgs $ Matcher (Net.Atom (identBaseName o)) match
+asCtor o = resolveArgs $ Matcher (Net.Atom (identText o)) match
   where match t = do
           CtorApp c params l <- R.asFTermF t
           guard (c == o)
@@ -270,7 +270,7 @@ asCtor o = resolveArgs $ Matcher (Net.Atom (identBaseName o)) match
 
 -- | Match a datatype.
 asDataType :: ArgsMatchable v a => Ident -> v a -> Matcher a
-asDataType o = resolveArgs $ Matcher (Net.Atom (identBaseName o)) match
+asDataType o = resolveArgs $ Matcher (Net.Atom (identText o)) match
   where match t = do
           DataTypeApp dt params l <- R.asFTermF t
           guard (dt == o)

--- a/saw-core/src/Verifier/SAW/ExternalFormat.hs
+++ b/saw-core/src/Verifier/SAW/ExternalFormat.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE RankNTypes #-}
@@ -22,9 +23,11 @@ import Data.Traversable
 import Data.Map (Map)
 import qualified Data.Map as Map
 import qualified Data.Text as Text
+import Data.Text (Text)
 import Data.List (elemIndex)
 import qualified Data.Vector as V
 import Text.Read (readMaybe)
+import Text.URI
 
 import Verifier.SAW.SharedTerm
 import Verifier.SAW.TypedAST
@@ -50,66 +53,114 @@ splitLast :: [a] -> Maybe ([a], a)
 splitLast [] = Nothing
 splitLast xs = Just (take (length xs - 1) xs, last xs)
 
+type WriteM = State.State (Map TermIndex Int, Map VarIndex NameInfo, [String], Int)
+
+renderNames :: Map VarIndex NameInfo -> String
+renderNames nms = show
+  [ (idx, f nmi)
+  | (idx,nmi) <- Map.toList nms
+  ]
+ where
+   f (ModuleIdentifier i)  = Left i
+   f (ImportedName uri as) = Right (render uri, as)
+
+readNames :: String -> Maybe (Map VarIndex NameInfo)
+readNames xs = Map.fromList <$> (mapM readName =<< readMaybe xs)
+ where
+   readName :: (VarIndex, Either Text (Text,[Text])) -> Maybe (VarIndex, NameInfo)
+   readName (idx, Left i) = pure (idx, ModuleIdentifier (parseIdent (Text.unpack i)))
+   readName (idx, Right (uri,as)) =
+       do uri' <- mkURI uri
+          pure (idx, ImportedName uri' as)
+
 -- | Render to external text format
 scWriteExternal :: Term -> String
 scWriteExternal t0 =
-    let (x, (_, output, _)) = State.runState (go t0) (Map.empty, [], 1)
-    in unlines (unwords ["SAWCoreTerm", show x] : reverse output)
+    let (x, (_, nms, lns, _)) = State.runState (go t0) (Map.empty, Map.empty, [], 1)
+    in unlines $
+        [ unwords ["SAWCoreTerm", show x]
+        , renderNames nms
+        ] ++ reverse lns
   where
-    go :: Term -> State.State (Map TermIndex Int, [String], Int) Int
+    nextId :: WriteM Int
+    nextId =
+       do (m, nms, lns, x) <- State.get
+          State.put (m, nms, lns, x+1)
+          return x
+    output :: String -> WriteM ()
+    output l =
+       do (m, nms, lns, x) <- State.get
+          State.put (m, nms, l:lns, x)
+    memoize :: TermIndex -> WriteM Int
+    memoize i =
+       do (m, nms, lns, x) <- State.get
+          State.put (Map.insert i x m, nms, lns, x+1)
+          return x
+    stashName :: ExtCns Int -> WriteM ()
+    stashName ec =
+       do (m, nms, lns, x) <- State.get
+          State.put (m, Map.insert (ecVarIndex ec) (ecName ec) nms, lns, x)
+
+    go :: Term -> WriteM Int
     go (Unshared tf) = do
       tf' <- traverse go tf
-      (m, output, x) <- State.get
-      let s = unwords [show x, writeTermF tf']
-      State.put (m, s : output, x + 1)
+      body <- writeTermF tf'
+      x <- nextId
+      output (unwords [show x, body])
       return x
+
     go STApp{ stAppIndex = i, stAppTermF = tf } = do
-      (memo, _, _) <- State.get
+      (memo, _, _, _) <- State.get
       case Map.lookup i memo of
         Just x -> return x
         Nothing -> do
           tf' <- traverse go tf
-          (m, output, x) <- State.get
-          let s = unwords [show x, writeTermF tf']
-          State.put (Map.insert i x m, s : output, x + 1)
+          body <- writeTermF tf'
+          x <- memoize i
+          output (unwords [show x, body])
           return x
-    writeTermF :: TermF Int -> String
+
+    writeTermF :: TermF Int -> WriteM String
     writeTermF tf =
       case tf of
-        App e1 e2      -> unwords ["App", show e1, show e2]
-        Lambda s t e   -> unwords ["Lam", s, show t, show e]
-        Pi s t e       -> unwords ["Pi", s, show t, show e]
-        LocalVar i     -> unwords ["Var", show i]
-        Constant ec e  -> unwords ["Constant", show (ecVarIndex ec), toShortName (ecName ec), show (ecType ec), show e]
+        App e1 e2      -> pure $ unwords ["App", show e1, show e2]
+        Lambda s t e   -> pure $ unwords ["Lam", s, show t, show e]
+        Pi s t e       -> pure $ unwords ["Pi", s, show t, show e]
+        LocalVar i     -> pure $ unwords ["Var", show i]
+        Constant ec e  ->
+            do stashName ec
+               pure $ unwords ["Constant", show (ecVarIndex ec), show (ecType ec), show e]
         FTermF ftf     ->
           case ftf of
-            GlobalDef ident     -> unwords ["Global", show ident]
-            UnitValue           -> unwords ["Unit"]
-            UnitType            -> unwords ["UnitT"]
-            PairValue x y       -> unwords ["Pair", show x, show y]
-            PairType x y        -> unwords ["PairT", show x, show y]
-            PairLeft e          -> unwords ["ProjL", show e]
-            PairRight e         -> unwords ["ProjR", show e]
-            CtorApp i ps es     ->
+            GlobalDef ident     -> pure $ unwords ["Global", show ident]
+            UnitValue           -> pure $ unwords ["Unit"]
+            UnitType            -> pure $ unwords ["UnitT"]
+            PairValue x y       -> pure $ unwords ["Pair", show x, show y]
+            PairType x y        -> pure $ unwords ["PairT", show x, show y]
+            PairLeft e          -> pure $ unwords ["ProjL", show e]
+            PairRight e         -> pure $ unwords ["ProjR", show e]
+            CtorApp i ps es     -> pure $
               unwords ("Ctor" : show i : map show ps ++ argsep : map show es)
-            DataTypeApp i ps es ->
+            DataTypeApp i ps es -> pure $
               unwords ("Data" : show i : map show ps ++ argsep : map show es)
-            RecursorApp i ps p_ret cs_fs ixs e ->
+            RecursorApp i ps p_ret cs_fs ixs e -> pure $
               unwords (["Recursor" , show i] ++ map show ps ++
                        [argsep, show p_ret, show cs_fs] ++
                        map show ixs ++ [show e])
-            RecordType elem_tps -> unwords ["RecordType", show elem_tps]
-            RecordValue elems   -> unwords ["Record", show elems]
-            RecordProj e prj    -> unwords ["RecordProj", show e, prj]
-            Sort s              ->
+            RecordType elem_tps -> pure $ unwords ["RecordType", show elem_tps]
+            RecordValue elems   -> pure $ unwords ["Record", show elems]
+            RecordProj e prj    -> pure $ unwords ["RecordProj", show e, prj]
+            Sort s              -> pure $
               if s == propSort then unwords ["Prop"] else
                 unwords ["Sort", drop 5 (show s)] -- Ugly hack to drop "sort "
-            NatLit n            -> unwords ["Nat", show n]
-            ArrayValue e v      -> unwords ("Array" : show e :
+            NatLit n            -> pure $ unwords ["Nat", show n]
+            ArrayValue e v      -> pure $ unwords ("Array" : show e :
                                             map show (V.toList v))
-            StringLit s         -> unwords ["String", show s]
-            ExtCns ext          -> unwords ("ExtCns" : writeExtCns ext)
-    writeExtCns ec = [show (ecVarIndex ec), show (ecName ec), show (ecType ec)]
+            StringLit s         -> pure $ unwords ["String", show s]
+            ExtCns ec ->
+               do stashName ec
+                  pure $ unwords ["ExtCns",show (ecVarIndex ec), show (ecType ec)]
+
 
 -- | During parsing, we maintain two maps used for renumbering: The
 -- first is for the 'Int' values that appear in the external core
@@ -117,13 +168,17 @@ scWriteExternal t0 =
 -- inside 'Constant' and 'ExtCns' constructors. We do not reuse any
 -- such numbers that appear in the external file, but generate fresh
 -- ones that are valid in the current 'SharedContext'.
-type ReadM = State.StateT (Map Int Term, Map VarIndex VarIndex) IO
+type ReadM = State.StateT (Map Int Term, Map VarIndex NameInfo, Map VarIndex VarIndex) IO
 
 scReadExternal :: SharedContext -> String -> IO Term
 scReadExternal sc input =
-  case map words (lines input) of
-    (["SAWCoreTerm", final] : rows) ->
-      State.evalStateT (mapM_ go rows >> readIdx final) (Map.empty, Map.empty)
+  case lines input of
+    ( (words -> ["SAWCoreTerm", final]) : nmlist : rows ) ->
+      case readNames nmlist of
+        Nothing -> fail "scReadExternal: failed to parse name table"
+        Just nms ->
+          State.evalStateT (mapM_ (go . words) rows >> readIdx final) (Map.empty, nms, Map.empty)
+
     _ -> fail "scReadExternal: failed to parse input file"
   where
     go :: [String] -> ReadM ()
@@ -131,8 +186,8 @@ scReadExternal sc input =
       do i <- readM tok
          tf <- parse tokens
          t <- lift $ scTermF sc tf
-         (ts, vs) <- State.get
-         put (Map.insert i t ts, vs)
+         (ts, nms, vs) <- State.get
+         put (Map.insert i t ts, nms, vs)
     go [] = pure () -- empty lines are ignored
 
     readM :: forall a. Read a => String -> ReadM a
@@ -143,7 +198,7 @@ scReadExternal sc input =
 
     getTerm :: Int -> ReadM Term
     getTerm i =
-      do ts <- fst <$> State.get
+      do (ts,_,_) <- State.get
          case Map.lookup i ts of
            Nothing -> fail $ "scReadExternal: invalid term index: " ++ show i
            Just t -> pure t
@@ -151,17 +206,20 @@ scReadExternal sc input =
     readIdx :: String -> ReadM Term
     readIdx tok = getTerm =<< readM tok
 
-    readEC :: String -> String -> String -> ReadM (ExtCns Term)
-    readEC i x t =
+    readEC :: String -> String -> ReadM (ExtCns Term)
+    readEC i t =
       do vi <- readM i
          t' <- readIdx t
-         (ts, vs) <- State.get
+         (ts, nms, vs) <- State.get
+         nmi <- case Map.lookup vi nms of
+                  Just nmi -> pure nmi
+                  Nothing -> lift $ fail $ "scReadExternal: ExtCns missing name info: " ++ show vi
          case Map.lookup vi vs of
-           Just vi' -> pure $ EC vi' x t'
+           Just vi' -> pure $ EC vi' nmi t'
            Nothing ->
              do vi' <- lift $ scFreshGlobalVar sc
-                State.put (ts, Map.insert vi vi' vs)
-                pure $ EC vi' x t'
+                State.put (ts, nms, Map.insert vi vi' vs)
+                pure $ EC vi' nmi t'
 
     parse :: [String] -> ReadM (TermF Term)
     parse tokens =
@@ -170,7 +228,7 @@ scReadExternal sc input =
         ["Lam", x, t, e]    -> Lambda x <$> readIdx t <*> readIdx e
         ["Pi", s, t, e]     -> Pi s <$> readIdx t <*> readIdx e
         ["Var", i]          -> pure $ LocalVar (read i)
-        ["Constant",i,x,t,e]-> Constant <$> readEC i x t <*> readIdx e
+        ["Constant",i,t,e]  -> Constant <$> readEC i t <*> readIdx e
         ["Global", x]       -> pure $ FTermF (GlobalDef (parseIdent x))
         ["Unit"]            -> pure $ FTermF UnitValue
         ["UnitT"]           -> pure $ FTermF UnitType
@@ -202,5 +260,5 @@ scReadExternal sc input =
         ["Nat", n]          -> FTermF <$> (NatLit <$> readM n)
         ("Array" : e : es)  -> FTermF <$> (ArrayValue <$> readIdx e <*> (V.fromList <$> traverse readIdx es))
         ("String" : ts)     -> FTermF <$> (StringLit <$> (readM (unwords ts)))
-        ["ExtCns", i, n, t] -> FTermF <$> (ExtCns <$> readEC i n t)
+        ["ExtCns", i, t] -> FTermF <$> (ExtCns <$> readEC i t)
         _ -> fail $ "Parse error: " ++ unwords tokens

--- a/saw-core/src/Verifier/SAW/ExternalFormat.hs
+++ b/saw-core/src/Verifier/SAW/ExternalFormat.hs
@@ -21,6 +21,7 @@ import Data.Traversable
 #endif
 import Data.Map (Map)
 import qualified Data.Map as Map
+import qualified Data.Text as Text
 import Data.List (elemIndex)
 import qualified Data.Vector as V
 import Text.Read (readMaybe)
@@ -79,7 +80,7 @@ scWriteExternal t0 =
         Lambda s t e   -> unwords ["Lam", s, show t, show e]
         Pi s t e       -> unwords ["Pi", s, show t, show e]
         LocalVar i     -> unwords ["Var", show i]
-        Constant ec e  -> unwords ["Constant", show (ecVarIndex ec), ecName ec, show (ecType ec), show e]
+        Constant ec e  -> unwords ["Constant", show (ecVarIndex ec), toShortName (ecName ec), show (ecType ec), show e]
         FTermF ftf     ->
           case ftf of
             GlobalDef ident     -> unwords ["Global", show ident]
@@ -108,7 +109,7 @@ scWriteExternal t0 =
                                             map show (V.toList v))
             StringLit s         -> unwords ["String", show s]
             ExtCns ext          -> unwords ("ExtCns" : writeExtCns ext)
-    writeExtCns ec = [show (ecVarIndex ec), ecName ec, show (ecType ec)]
+    writeExtCns ec = [show (ecVarIndex ec), show (ecName ec), show (ecType ec)]
 
 -- | During parsing, we maintain two maps used for renumbering: The
 -- first is for the 'Int' values that appear in the external core

--- a/saw-core/src/Verifier/SAW/SCTypeCheck.hs
+++ b/saw-core/src/Verifier/SAW/SCTypeCheck.hs
@@ -155,7 +155,7 @@ data TCError
   | NoSuchCtor Ident
   | NotFullyAppliedRec Ident
   | BadParamsOrArgsLength Bool Ident [Term] [Term]
-  | BadConstType String Term Term
+  | BadConstType NameInfo Term Term
   | MalformedRecursor Term String
   | DeclError String String
   | ErrorPos Pos TCError

--- a/saw-core/src/Verifier/SAW/SharedTerm.hs
+++ b/saw-core/src/Verifier/SAW/SharedTerm.hs
@@ -377,7 +377,8 @@ moduleIdentToURI ident = fromMaybe (panic "moduleIdentToURI" ["Failed to constru
 data DuplicateNameException = DuplicateNameException URI
 instance Exception DuplicateNameException
 instance Show DuplicateNameException where
-  show (DuplicateNameException uri) = "Attempted to register the following name twice: " ++ show uri
+  show (DuplicateNameException uri) =
+      "Attempted to register the following name twice: " ++ Text.unpack (render uri)
 
 scRegisterName :: SharedContext -> VarIndex -> NameInfo -> IO ()
 scRegisterName sc i nmi = atomicModifyIORef' (scNamingEnv sc) (\env -> (f env, ()))
@@ -410,7 +411,7 @@ scResolveUnambiguous sc nm =
      [x] -> pure x
      xs  ->
        do nms <- mapM (scFindBestName sc . snd) xs
-          fail $ unlines (("Ambiguous name " ++ show nm ++ "might refer to any of the following:") : map show nms)
+          fail $ unlines (("Ambiguous name " ++ show nm ++ " might refer to any of the following:") : map show nms)
 
 scFindBestName :: SharedContext -> NameInfo -> IO Text
 scFindBestName _sc (ModuleIdentifier nm) = pure (identText nm)

--- a/saw-core/src/Verifier/SAW/SharedTerm.hs
+++ b/saw-core/src/Verifier/SAW/SharedTerm.hs
@@ -27,6 +27,8 @@ module Verifier.SAW.SharedTerm
   , Ident, mkIdent
   , VarIndex
   , ExtCns(..)
+  , NameInfo(..)
+  , ppName
     -- * Shared terms
   , Term(..)
   , TermIndex
@@ -37,6 +39,11 @@ module Verifier.SAW.SharedTerm
   , scImport
   , alphaEquiv
   , alistAllFields
+  , scRegisterName
+  , scResolveName
+  , scResolveUnambiguous
+  , scFindBestName
+  , DuplicateNameException(..)
     -- * Re-exported pretty-printing functions
   , PPOpts(..)
   , defaultPPOpts
@@ -56,6 +63,7 @@ module Verifier.SAW.SharedTerm
   , scDefTerm
   , scFreshGlobalVar
   , scFreshGlobal
+  , scFreshEC
   , scExtCns
   , scGlobalDef
     -- ** Recursors and datatypes
@@ -87,6 +95,7 @@ module Verifier.SAW.SharedTerm
     -- *** Variables and constants
   , scLocalVar
   , scConstant
+  , scConstant'
   , scLookupDef
     -- *** Functions and function application
   , scApply
@@ -246,19 +255,23 @@ import Data.Maybe
 import qualified Data.Foldable as Fold
 import Data.Foldable (foldl', foldlM, foldrM, maximum)
 import Data.HashMap.Strict (HashMap)
+import Data.List.NonEmpty ( NonEmpty(..) )
 import qualified Data.HashMap.Strict as HMap
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
 import qualified Data.IntSet as IntSet
-import Data.IORef (IORef,newIORef,readIORef,modifyIORef')
+import Data.IORef (IORef,newIORef,readIORef,modifyIORef',atomicModifyIORef')
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Ref ( C )
 import Data.Set (Set)
+import Data.Text (Text)
 import qualified Data.Set as Set
+import qualified Data.Text as Text
 import qualified Data.Vector as V
 import Numeric.Natural (Natural)
 import Prelude hiding (mapM, maximum)
+import Text.URI
 
 import Verifier.SAW.Cache
 import Verifier.SAW.Change
@@ -266,9 +279,10 @@ import Verifier.SAW.Prelude.Constants
 import Verifier.SAW.Recognizer
 import Verifier.SAW.Term.Functor
 import Verifier.SAW.Term.CtxTerm
---import Verifier.SAW.Term.Pretty
+import Verifier.SAW.Term.Pretty
 import Verifier.SAW.TypedAST
 import Verifier.SAW.Unique
+import Verifier.SAW.Utils
 
 #if !MIN_VERSION_base(4,8,0)
 countTrailingZeros :: (FiniteBits b) => b -> Int
@@ -314,9 +328,16 @@ insertTFM tf x tfm =
 ----------------------------------------------------------------------
 -- SharedContext: a high-level interface for building Terms.
 
+data SAWNamingEnv = SAWNamingEnv
+  { resolvedNames :: !(Map VarIndex NameInfo)
+  , absoluteNames :: !(Map URI VarIndex)
+  , aliasNames    :: !(Map Text (Set VarIndex))
+  }
+
 data SharedContext = SharedContext
   { scModuleMap      :: IORef ModuleMap
   , scTermF          :: TermF Term -> IO Term
+  , scNamingEnv      :: IORef SAWNamingEnv
   , scFreshGlobalVar :: IO VarIndex
   }
 
@@ -328,11 +349,105 @@ scFlatTermF sc ftf = scTermF sc (FTermF ftf)
 scExtCns :: SharedContext -> ExtCns Term -> IO Term
 scExtCns sc ec = scFlatTermF sc (ExtCns ec)
 
+scFreshNameURI :: Text -> VarIndex -> URI
+scFreshNameURI nm i = fromMaybe (panic "scFreshNameURI" ["Failed to constructed name URI", show nm, show i]) $
+  do sch <- mkScheme "fresh"
+     nm' <- mkPathPiece (if Text.null nm then "_" else nm)
+     i'  <- mkPathPiece (Text.pack (show i))
+     pure URI
+       { uriScheme = Just sch
+       , uriAuthority = Left True -- absolute path
+       , uriPath   = Just (False, (nm' :| [i']))
+       , uriQuery  = []
+       , uriFragment = Nothing
+       }
+
+moduleIdentToURI :: Ident -> URI
+moduleIdentToURI ident = fromMaybe (panic "moduleIdentToURI" ["Failed to constructed ident URI", show ident]) $
+  do sch  <- mkScheme "sawcore"
+     path <- mapM mkPathPiece (identPieces ident)
+     pure URI
+       { uriScheme = Just sch
+       , uriAuthority = Left True -- absolute path
+       , uriPath   = Just (False, path)
+       , uriQuery  = []
+       , uriFragment = Nothing
+       }
+
+data DuplicateNameException = DuplicateNameException URI
+instance Exception DuplicateNameException
+instance Show DuplicateNameException where
+  show (DuplicateNameException uri) = "Attempted to register the following name twice: " ++ show uri
+
+scRegisterName :: SharedContext -> VarIndex -> NameInfo -> IO ()
+scRegisterName sc i nmi = atomicModifyIORef' (scNamingEnv sc) (\env -> (f env, ()))
+  where
+    uri = case nmi of
+            ImportedName x _ -> x
+            ModuleIdentifier x -> moduleIdentToURI x
+
+    aliases = case nmi of
+                ImportedName x xs -> render x : xs
+                ModuleIdentifier x  -> [identBaseName x, identText x, render uri]
+
+    insertAlias :: Text -> Map Text (Set VarIndex) -> Map Text (Set VarIndex)
+    insertAlias x m = Map.alter (Just . maybe (Set.singleton i) (Set.insert i)) x m
+
+    f env =
+      case Map.lookup uri (absoluteNames env) of
+        Just _ -> throw (DuplicateNameException uri)
+        Nothing ->
+            SAWNamingEnv
+            { resolvedNames = Map.insert i nmi (resolvedNames env)
+            , absoluteNames = Map.insert uri i (absoluteNames env)
+            , aliasNames    = foldr insertAlias (aliasNames env) aliases
+            }
+
+scResolveUnambiguous :: SharedContext -> Text -> IO (VarIndex, NameInfo)
+scResolveUnambiguous sc nm =
+  scResolveName sc nm >>= \case
+     []  -> fail ("Could not resolve name: " ++ show nm)
+     [x] -> pure x
+     xs  ->
+       do nms <- mapM (scFindBestName sc . snd) xs
+          fail $ unlines (("Ambiguous name " ++ show nm ++ "might refer to any of the following:") : map show nms)
+
+scFindBestName :: SharedContext -> NameInfo -> IO Text
+scFindBestName _sc (ModuleIdentifier nm) = pure (identText nm)
+scFindBestName sc (ImportedName uri as) = go as
+  where
+  go [] = pure (render uri)
+  go (x:xs) =
+    do vs <- scResolveName sc x
+       case vs of
+         [_] -> return x
+         _   -> go xs
+
+scResolveName :: SharedContext -> Text -> IO [(VarIndex, NameInfo)]
+scResolveName sc nm =
+  do env <- readIORef (scNamingEnv sc)
+     case Map.lookup nm (aliasNames env) of
+       Nothing -> pure []
+       Just vs -> pure [ (v, fndName v (resolvedNames env)) | v <- Set.toList vs ]
+ where
+ fndName v m =
+   case Map.lookup v m of
+     Just nmi -> nmi
+     Nothing -> panic "scResolveName" ["Unbound VarIndex when resolving name", show nm, show v]
+
+-- | Create a global variable with the given identifier (which may be "_") and type.
+scFreshEC :: SharedContext -> String -> Term -> IO (ExtCns Term)
+scFreshEC sc x tp = do
+  i   <- scFreshGlobalVar sc
+  let x' = Text.pack x
+  let uri = scFreshNameURI x' i
+  let nmi = ImportedName uri [x',Text.pack (x <> "#" <>  show i)]
+  scRegisterName sc i nmi
+  pure (EC i nmi tp)
+
 -- | Create a global variable with the given identifier (which may be "_") and type.
 scFreshGlobal :: SharedContext -> String -> Term -> IO Term
-scFreshGlobal sc sym tp = do
-  i <- scFreshGlobalVar sc
-  scExtCns sc (EC i sym tp)
+scFreshGlobal sc x tp = scExtCns sc =<< scFreshEC sc x tp
 
 -- | Returns shared term associated with ident.
 -- Does not check module namespace.
@@ -669,6 +784,7 @@ scWhnf sc t0 =
         p_ret cs_fs _ : xs)   (asCtorOrNat ->
                                Just (c, _, args))               = (scReduceRecursor sc d ps
                                                                    p_ret cs_fs c args) >>= go xs
+
     go xs                     (asGlobalDef -> Just c)           = scRequireDef sc c >>= tryDef c xs
     go xs                     (asRecursorApp ->
                                Just (d, params, p_ret, cs_fs, ixs,
@@ -1297,10 +1413,34 @@ scConstant sc name rhs ty =
      let ecs = getAllExts rhs
      rhs' <- scAbstractExts sc ecs rhs
      ty' <- scFunAll sc (map ecType ecs) ty
-     i <- scFreshGlobalVar sc
-     t <- scTermF sc (Constant (EC i name ty') rhs')
+     ec <- scFreshEC sc name ty'
+     t <- scTermF sc (Constant ec rhs')
      args <- mapM (scFlatTermF sc . ExtCns) ecs
      scApplyAll sc t args
+
+
+-- | Create an abstract constant with the specified name, body, and
+-- type. The term for the body must not have any loose de Bruijn
+-- indices. If the body contains any ExtCns variables, they will be
+-- abstracted over and reapplied to the resulting constant.
+scConstant' :: SharedContext
+           -> NameInfo -- ^ The name
+           -> Term   -- ^ The body
+           -> Term   -- ^ The type
+           -> IO Term
+scConstant' sc nmi rhs ty =
+  do unless (looseVars rhs == emptyBitSet) $
+       fail "scConstant: term contains loose variables"
+     let ecs = getAllExts rhs
+     rhs' <- scAbstractExts sc ecs rhs
+     ty' <- scFunAll sc (map ecType ecs) ty
+     i <- scFreshGlobalVar sc
+     scRegisterName sc i nmi
+     let ec = EC i nmi ty'
+     t <- scTermF sc (Constant ec rhs')
+     args <- mapM (scFlatTermF sc . ExtCns) ecs
+     scApplyAll sc t args
+
 
 -- | Create a function application term from a global identifier and a list of
 -- arguments (as 'Term's).
@@ -2010,10 +2150,12 @@ mkSharedContext = do
   cr <- newMVar emptyAppCache
   let freshGlobalVar = modifyMVar vr (\i -> return (i+1, i))
   mod_map_ref <- newIORef HMap.empty
+  envRef <- newIORef (SAWNamingEnv mempty mempty mempty)
   return SharedContext {
              scModuleMap = mod_map_ref
            , scTermF = getTerm cr
            , scFreshGlobalVar = freshGlobalVar
+           , scNamingEnv = envRef
            }
 
 useChangeCache :: C m => Cache m k (Change v) -> k -> ChangeT m v -> ChangeT m v
@@ -2049,7 +2191,7 @@ getAllExtSet t = snd $ getExtCns (IntSet.empty, Set.empty) t
           getExtCns acc (Unshared tf') =
             foldl' getExtCns acc tf'
 
-getConstantSet :: Term -> Map String (Term, Term)
+getConstantSet :: Term -> Map VarIndex (NameInfo, Term, Term)
 getConstantSet t = snd $ go (IntSet.empty, Map.empty) t
   where
     go acc@(idxs, names) (STApp{ stAppIndex = i, stAppTermF = tf})
@@ -2059,7 +2201,7 @@ getConstantSet t = snd $ go (IntSet.empty, Map.empty) t
 
     termf acc@(idxs, names) tf =
       case tf of
-        Constant (EC _ n ty) body -> (idxs, Map.insert n (ty, body) names)
+        Constant (EC vidx n ty) body -> (idxs, Map.insert vidx (n, ty, body) names)
         _ -> foldl' go acc tf
 
 -- | Instantiate some of the external constants
@@ -2125,7 +2267,7 @@ scExtsToLocals sc exts x = instantiateVars sc fn 0 x
 scAbstractExts :: SharedContext -> [ExtCns Term] -> Term -> IO Term
 scAbstractExts _ [] x = return x
 scAbstractExts sc exts x =
-   do let lams = [ (ecName ec, ecType ec) | ec <- exts ]
+   do let lams = [ (Text.unpack (toShortName (ecName ec)), ecType ec) | ec <- exts ]
       scLambdaList sc lams =<< scExtsToLocals sc exts x
 
 -- | Generalize over the given list of external constants by wrapping
@@ -2134,19 +2276,19 @@ scAbstractExts sc exts x =
 scGeneralizeExts :: SharedContext -> [ExtCns Term] -> Term -> IO Term
 scGeneralizeExts _ [] x = return x
 scGeneralizeExts sc exts x =
-  do let pis = [ (ecName ec, ecType ec) | ec <- exts ]
+  do let pis = [ (Text.unpack (toShortName (ecName ec)), ecType ec) | ec <- exts ]
      scPiList sc pis =<< scExtsToLocals sc exts x
 
-scUnfoldConstants :: SharedContext -> [String] -> Term -> IO Term
+scUnfoldConstants :: SharedContext -> [VarIndex] -> Term -> IO Term
 scUnfoldConstants sc names t0 = scUnfoldConstantSet sc True (Set.fromList names) t0
 
 -- | TODO: test whether this version is slower or faster.
-scUnfoldConstants' :: SharedContext -> [String] -> Term -> IO Term
+scUnfoldConstants' :: SharedContext -> [VarIndex] -> Term -> IO Term
 scUnfoldConstants' sc names t0 = scUnfoldConstantSet' sc True (Set.fromList names) t0
 
 scUnfoldConstantSet :: SharedContext
                     -> Bool  -- ^ True: unfold constants in set. False: unfold constants NOT in set
-                    -> Set String -- ^ Set of constant names
+                    -> Set VarIndex -- ^ Set of constant names
                     -> Term
                     -> IO Term
 scUnfoldConstantSet sc b names t0 = do
@@ -2154,15 +2296,15 @@ scUnfoldConstantSet sc b names t0 = do
   let go :: Term -> IO Term
       go t@(Unshared tf) =
         case tf of
-          Constant (EC _ name _) rhs
-            | Set.member name names == b -> go rhs
-            | otherwise                  -> return t
+          Constant (EC idx _ _) rhs
+            | Set.member idx names == b -> go rhs
+            | otherwise                 -> return t
           _ -> Unshared <$> traverse go tf
       go t@(STApp{ stAppIndex = idx, stAppTermF = tf }) = useCache cache idx $
         case tf of
-          Constant (EC _ name _) rhs
-            | Set.member name names == b -> go rhs
-            | otherwise         -> return t
+          Constant (EC ecidx _ _) rhs
+            | Set.member ecidx names == b -> go rhs
+            | otherwise                   -> return t
           _ -> scTermF sc =<< traverse go tf
   go t0
 
@@ -2170,7 +2312,7 @@ scUnfoldConstantSet sc b names t0 = do
 -- | TODO: test whether this version is slower or faster.
 scUnfoldConstantSet' :: SharedContext
                     -> Bool  -- ^ True: unfold constants in set. False: unfold constants NOT in set
-                    -> Set String -- ^ Set of constant names
+                    -> Set VarIndex -- ^ Set of constant names
                     -> Term
                     -> IO Term
 scUnfoldConstantSet' sc b names t0 = do
@@ -2178,15 +2320,15 @@ scUnfoldConstantSet' sc b names t0 = do
   let go :: Term -> ChangeT IO Term
       go t@(Unshared tf) =
         case tf of
-          Constant (EC _ name _) rhs
-            | Set.member name names == b -> taint (go rhs)
-            | otherwise                  -> pure t
+          Constant (EC idx _ _) rhs
+            | Set.member idx names == b -> taint (go rhs)
+            | otherwise                 -> pure t
           _ -> whenModified t (return . Unshared) (traverse go tf)
       go t@(STApp{ stAppIndex = idx, stAppTermF = tf }) =
         case tf of
-          Constant (EC _ name _) rhs
-            | Set.member name names == b -> taint (go rhs)
-            | otherwise                  -> pure t
+          Constant (EC ecidx _ _) rhs
+            | Set.member ecidx names == b -> taint (go rhs)
+            | otherwise                   -> pure t
           _ -> useChangeCache tcache idx $
                  whenModified t (scTermF sc) (traverse go tf)
   commitChangeT (go t0)
@@ -2226,8 +2368,7 @@ scOpenTerm :: SharedContext
          -> Term
          -> IO (ExtCns Term, Term)
 scOpenTerm sc nm tp idx body = do
-    v <- scFreshGlobalVar sc
-    let ec = EC v nm tp
+    ec <- scFreshEC sc nm tp
     ec_term <- scFlatTermF sc (ExtCns ec)
     body' <- instantiateVar sc idx ec_term body
     return (ec, body')
@@ -2243,4 +2384,4 @@ scCloseTerm :: (SharedContext -> String -> Term -> Term -> IO Term)
 scCloseTerm close sc ec body = do
     lv <- scLocalVar sc 0
     body' <- scInstantiateExt sc (Map.insert (ecVarIndex ec) lv Map.empty) =<< incVars sc 0 1 body
-    close sc (ecName ec) (ecType ec) body'
+    close sc (Text.unpack (toShortName (ecName ec))) (ecType ec) body'

--- a/saw-core/src/Verifier/SAW/SharedTerm.hs
+++ b/saw-core/src/Verifier/SAW/SharedTerm.hs
@@ -41,6 +41,7 @@ module Verifier.SAW.SharedTerm
   , alistAllFields
   , scRegisterName
   , scResolveName
+  , scResolveNameByURI
   , scResolveUnambiguous
   , scFindBestName
   , DuplicateNameException(..)
@@ -423,6 +424,11 @@ scFindBestName sc (ImportedName uri as) = go as
        case vs of
          [_] -> return x
          _   -> go xs
+
+scResolveNameByURI :: SharedContext -> URI -> IO (Maybe VarIndex)
+scResolveNameByURI sc uri =
+  do env <- readIORef (scNamingEnv sc)
+     pure $! Map.lookup uri (absoluteNames env)
 
 scResolveName :: SharedContext -> Text -> IO [(VarIndex, NameInfo)]
 scResolveName sc nm =

--- a/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
@@ -55,7 +55,7 @@ evalSharedTerm m addlPrims t =
            extcns (const Nothing)
     Sim.evalSharedTerm cfg t
   where
-    extcns ec = return $ Prim.userError $ "Unimplemented: external constant " ++ ecName ec
+    extcns ec = return $ Prim.userError $ "Unimplemented: external constant " ++ show (ecName ec)
 
 ------------------------------------------------------------
 -- Values

--- a/saw-core/src/Verifier/SAW/Simulator/RME.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/RME.hs
@@ -65,7 +65,7 @@ evalSharedTerm m addlPrims t =
            extcns (const Nothing)
     Sim.evalSharedTerm cfg t
   where
-    extcns ec = return $ Prim.userError $ "Unimplemented: external constant " ++ ecName ec
+    extcns ec = return $ Prim.userError $ "Unimplemented: external constant " ++ show (ecName ec)
 
 ------------------------------------------------------------
 -- Values
@@ -387,7 +387,7 @@ bitBlastBasic :: ModuleMap
               -> RValue
 bitBlastBasic m addlPrims t = runIdentity $ do
   cfg <- Sim.evalGlobal m (Map.union constMap addlPrims)
-         (\ec -> error ("RME: unsupported ExtCns: " ++ ecName ec))
+         (\ec -> error ("RME: unsupported ExtCns: " ++ show (ecName ec)))
          (const Nothing)
   Sim.evalSharedTerm cfg t
 

--- a/saw-core/src/Verifier/SAW/Term/Pretty.hs
+++ b/saw-core/src/Verifier/SAW/Term/Pretty.hs
@@ -29,6 +29,7 @@ module Verifier.SAW.Term.Pretty
   , scTermCount
   , OccurrenceMap
   , shouldMemoizeTerm
+  , ppName
   ) where
 
 import Data.Maybe (isJust)
@@ -421,8 +422,11 @@ ppFlatTermF prec tf =
     ArrayValue _ args   ->
       ppArrayValue <$> mapM (ppTerm' PrecNone) (V.toList args)
     StringLit s -> return $ text (show s)
-    ExtCns cns -> maybeColorM dullred $ text $ ecName cns
+    ExtCns cns -> maybeColorM dullred $ ppName (ecName cns)
 
+ppName :: NameInfo -> Doc
+ppName (ModuleIdentifier i) = ppIdent i
+ppName (ImportedName absName _) = text (show absName)
 
 -- | Pretty-print a non-shared term
 ppTermF :: Prec -> TermF Term -> PPM Doc
@@ -437,7 +441,7 @@ ppTermF prec (Pi x tp body) =
   (ppPi <$> ppTerm' PrecApp tp <*>
    ppTermInBinder PrecLambda x body)
 ppTermF _ (LocalVar x) = (text <$> varLookupM x) >>= maybeColorM dullgreen
-ppTermF _ (Constant ec _) = maybeColorM dullblue $ text $ ecName ec
+ppTermF _ (Constant ec _) = maybeColorM dullblue $ ppName (ecName ec)
 
 
 -- | Internal function to recursively pretty-print a term

--- a/saw-core/src/Verifier/SAW/TypedAST.hs
+++ b/saw-core/src/Verifier/SAW/TypedAST.hs
@@ -68,6 +68,7 @@ module Verifier.SAW.TypedAST
    -- * Primitive types.
  , Sort, mkSort, propSort, sortOf, maxSort
  , Ident(..), identName, mkIdent
+ , NameInfo(..), toShortName, toAbsoluteName
  , parseIdent
  , isIdent
  , DeBruijnIndex


### PR DESCRIPTION
Some early work on adding structured names to SAWCore.  For now, this is really only addressing naming concerns for `ExtCns` and `Constant` terms, but there are already quite a lot of design issues to untangle.