### PR TITLE
Remove saw-core `bitvector` type synonym; use `Vec n Bool` instead.

### DIFF
--- a/cryptol-saw-core/saw/Cryptol.sawcore
+++ b/cryptol-saw-core/saw/Cryptol.sawcore
@@ -14,10 +14,10 @@ const a b x y = x;
 compose : (a b c : sort 0) -> (b -> c) -> (a -> b) -> (a -> c);
 compose _ _ _ f g x = f (g x);
 
-bvExp : (n : Nat) -> bitvector n -> bitvector n -> bitvector n;
-bvExp n x y = foldr Bool (bitvector n) n
-  (\ (b : Bool) -> \ (a : bitvector n) ->
-    ite (bitvector n) b (bvMul n x (bvMul n a a)) (bvMul n a a))
+bvExp : (n : Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool;
+bvExp n x y = foldr Bool (Vec n Bool) n
+  (\ (b : Bool) -> \ (a : Vec n Bool) ->
+    ite (Vec n Bool) b (bvMul n x (bvMul n a a)) (bvMul n a a))
   (bvNat n 1)
   (reverse n Bool y);
 
@@ -438,10 +438,10 @@ integerCmp x y k = or (intLt x y) (and (intEq x y) k);
 rationalCmp : Rational -> Rational -> Bool -> Bool;
 rationalCmp x y k = or (ltRational x y) (and (eqRational x y) k);
 
-bvCmp : (n : Nat) -> bitvector n -> bitvector n -> Bool -> Bool;
+bvCmp : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool -> Bool;
 bvCmp n x y k = or (bvult n x y) (and (bvEq n x y) k);
 
-bvSCmp : (n : Nat) -> bitvector n -> bitvector n -> Bool -> Bool;
+bvSCmp : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool -> Bool;
 bvSCmp n x y k = or (bvslt n x y) (and (bvEq n x y) k);
 
 vecCmp : (n : Nat) -> (a : sort 0) -> (a -> a -> Bool -> Bool)
@@ -1163,10 +1163,10 @@ ecSShiftR =
     (\ (n:Nat) ->
          (\ (ix : sort 0) -> \ (pix : PIntegral ix) ->
             natCase
-              (\ (w : Nat) -> bitvector w -> ix -> bitvector w)
-              (\ (xs : bitvector 0) -> \ (_ : ix) -> xs)
-              (\ (w : Nat) -> \ (xs : bitvector (Succ w)) ->
-                   pix.posNegCases (bitvector (Succ w))
+              (\ (w : Nat) -> Vec w Bool -> ix -> Vec w Bool)
+              (\ (xs : Vec 0 Bool) -> \ (_ : ix) -> xs)
+              (\ (w : Nat) -> \ (xs : Vec (Succ w) Bool) ->
+                   pix.posNegCases (Vec (Succ w) Bool)
 		     (bvSShr w xs)
 		     (bvShl (Succ w) xs))
               n));
@@ -1368,24 +1368,24 @@ ecInfFromThen a pa x y =
 
 
 -- Run-time error
-ecError : (a : sort 0) -> (len : Num) -> seq len (bitvector 8) -> a;
+ecError : (a : sort 0) -> (len : Num) -> seq len (Vec 8 Bool) -> a;
 ecError a len msg = error a "encountered call to the Cryptol 'error' function"; -- FIXME: don't throw away message
 {-
-primitive cryError : (a : sort 0) -> (n : Nat) -> Vec n (bitvector 8) -> a;
+primitive cryError : (a : sort 0) -> (n : Nat) -> Vec n (Vec 8 Bool) -> a;
 
-ecError : (a : sort 0) -> (len : Num) -> seq len (bitvector 8) -> a;
+ecError : (a : sort 0) -> (len : Num) -> seq len (Vec 8 Bool) -> a;
 ecError a =
   finNumRec
-    (\ (len:Num) -> seq len (bitvector 8) -> a)
+    (\ (len:Num) -> seq len (Vec 8 Bool) -> a)
     (\ (len:Nat) -> cryError a len);
 -}
 
 -- Random values
-ecRandom : (a : sort 0) -> bitvector 32 -> a;
+ecRandom : (a : sort 0) -> Vec 32 Bool -> a;
 ecRandom a _ = error a "Cryptol.random";
 
 -- Trace function; simply return the final argument
-ecTrace : (n : Num) -> (a b : sort 0) -> seq n (bitvector 8) -> a -> b -> b;
+ecTrace : (n : Num) -> (a b : sort 0) -> seq n (Vec 8 Bool) -> a -> b -> b;
 ecTrace _ _ _ _ _ x = x;
 
 
@@ -1481,16 +1481,16 @@ ecFpToBits e p _ = error (seq (tcAdd e p) Bool) "Unimplemented: fpToBits";
 ecFpEq : (e : Num) -> (p : Num) -> TCFloat e p -> TCFloat e p -> Bool;
 ecFpEq e p _ _ = error Bool "Unimplemented: =.=";
 
-ecFpAdd : (e : Num) -> (p : Num) -> bitvector 3 -> TCFloat e p -> TCFloat e p -> TCFloat e p;
+ecFpAdd : (e : Num) -> (p : Num) -> Vec 3 Bool -> TCFloat e p -> TCFloat e p -> TCFloat e p;
 ecFpAdd e p _ _ _ = error (TCFloat e p) "Unimplemented: fpAdd";
 
-ecFpSub : (e : Num) -> (p : Num) -> bitvector 3 -> TCFloat e p -> TCFloat e p -> TCFloat e p;
+ecFpSub : (e : Num) -> (p : Num) -> Vec 3 Bool -> TCFloat e p -> TCFloat e p -> TCFloat e p;
 ecFpSub e p _ _ _ = error (TCFloat e p) "Unimplemented: fpSub";
 
-ecFpMul : (e : Num) -> (p : Num) -> bitvector 3 -> TCFloat e p -> TCFloat e p -> TCFloat e p;
+ecFpMul : (e : Num) -> (p : Num) -> Vec 3 Bool -> TCFloat e p -> TCFloat e p -> TCFloat e p;
 ecFpMul e p _ _ _ = error (TCFloat e p) "Unimplemented: fpMul";
 
-ecFpDiv : (e : Num) -> (p : Num) -> bitvector 3 -> TCFloat e p -> TCFloat e p -> TCFloat e p;
+ecFpDiv : (e : Num) -> (p : Num) -> Vec 3 Bool -> TCFloat e p -> TCFloat e p -> TCFloat e p;
 ecFpDiv e p _ _ _ = error (TCFloat e p) "Unimplemented: fpDiv";
 
 ecFpIsFinite : (e : Num) -> (p : Num) -> TCFloat e p -> Bool;
@@ -1499,7 +1499,7 @@ ecFpIsFinite e p _ = error Bool "Unimplemented: fpIsFinite";
 ecFpToRational : (e : Num) -> (p : Num) -> TCFloat e p -> Rational;
 ecFpToRational e p _ = error Rational "Unimplemented: fpToRational";
 
-ecFpFromRational : (e : Num) -> (p : Num) -> bitvector 3 -> Rational -> TCFloat e p;
+ecFpFromRational : (e : Num) -> (p : Num) -> Vec 3 Bool -> Rational -> TCFloat e p;
 ecFpFromRational e p _ _ = error (TCFloat e p) "Unimplemented: fpFromRational";
 
 
@@ -1555,8 +1555,8 @@ ecSExt =
     (\ (m n : Num) -> seq n Bool -> seq (tcAdd m n) Bool)
     (\ (m n : Nat) ->
        natCase
-         (\ (n' : Nat) -> bitvector n' -> bitvector (addNat m n'))
-         (\ (_ : bitvector 0) -> bvNat (addNat m 0) 0)
+         (\ (n' : Nat) -> Vec n' Bool -> Vec (addNat m n') Bool)
+         (\ (_ : Vec 0 Bool) -> bvNat (addNat m 0) 0)
          (bvSExt m)
          n);
 
@@ -1593,7 +1593,7 @@ ecArrayUpdate = arrayUpdate;
 --------------------------------------------------------------------------------
 -- Rewrite rules
 
-axiom replicate_False : (n : Nat) -> Eq (bitvector n) (replicate n Bool False) (bvNat n 0);
+axiom replicate_False : (n : Nat) -> Eq (Vec n Bool) (replicate n Bool False) (bvNat n 0);
 
 axiom subNat_0 : (n : Nat) -> Eq Nat (subNat n 0) n;
 
@@ -1601,7 +1601,7 @@ axiom subNat_0 : (n : Nat) -> Eq Nat (subNat n 0) n;
 axiom demote_add_distr
   : (w : Nat)
   -> (x y : Num)
-  -> Eq (bitvector w)
+  -> Eq (Vec w Bool)
         (ecNumber (tcAdd x y) (TCNum w))
         (bvAdd w (ecNumber x (TCNum w)) (ecNumber y (TCNum w)));
 -}

--- a/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
@@ -1412,7 +1412,7 @@ scCryptolType sc t =
 -- | Deprecated.
 scCryptolEq :: SharedContext -> Term -> Term -> IO Term
 scCryptolEq sc x y =
-  do rules <- concat <$> traverse defRewrites (defs1 ++ defs2)
+  do rules <- concat <$> traverse defRewrites defs
      let ss = addConvs natConversions (addRules rules emptySimpset)
      tx <- scTypeOf sc x >>= rewriteSharedTerm sc ss >>= scCryptolType sc
      ty <- scTypeOf sc y >>= rewriteSharedTerm sc ss >>= scCryptolType sc
@@ -1432,8 +1432,7 @@ scCryptolEq sc x y =
      scGlobalApply sc "Cryptol.ecEq" [k, eqPrf, x, y]
 
   where
-    defs1 = map (mkIdent (mkModuleName ["Prelude"])) ["bitvector"]
-    defs2 = map (mkIdent (mkModuleName ["Cryptol"])) ["seq", "ty"]
+    defs = map (mkIdent (mkModuleName ["Cryptol"])) ["seq", "ty"]
     defRewrites ident =
       do maybe_def <- scFindDef sc ident
          case maybe_def of

--- a/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
+++ b/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
@@ -138,7 +138,7 @@ wordFun f = strictFun (\x -> toWord x >>= f)
 
 ------------------------------------------------------------
 
--- | op :: (n :: Nat) -> bitvector n -> Nat -> bitvector n
+-- | op : (n : Nat) -> Vec n Bool -> Nat -> Vec n Bool
 bvShiftOp :: (LitVector l -> LitVector l -> IO (LitVector l))
           -> (LitVector l -> Natural -> LitVector l)
           -> BValue l
@@ -324,21 +324,21 @@ bitblastLogBase2 g x = do
 -----------------------------------------
 -- Integer/bitvector conversions
 
--- primitive bvToInt :: (n::Nat) -> bitvector n -> Integer;
+-- primitive bvToInt : (n : Nat) -> Vec n Bool -> Integer;
 bvToIntOp :: AIG.IsAIG l g => g s -> BValue (l s)
 bvToIntOp g = constFun $ wordFun $ \v ->
    case AIG.asUnsigned g v of
       Just i -> return $ VInt i
       Nothing -> fail "Cannot convert symbolic bitvector to integer"
 
--- primitive sbvToInt :: (n::Nat) -> bitvector n -> Integer;
+-- primitive sbvToInt : (n : Nat) -> Vec n Bool -> Integer;
 sbvToIntOp :: AIG.IsAIG l g => g s -> BValue (l s)
 sbvToIntOp g = constFun $ wordFun $ \v ->
    case AIG.asSigned g v of
       Just i -> return $ VInt i
       Nothing -> fail "Cannot convert symbolic bitvector to integer"
 
--- primitive intToBv :: (n::Nat) -> Integer -> bitvector n;
+-- primitive intToBv : (n : Nat) -> Integer -> Vec n Bool;
 intToBvOp :: AIG.IsAIG l g => g s -> BValue (l s)
 intToBvOp g =
   Prims.natFun' "intToBv n" $ \n -> return $

--- a/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
+++ b/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
@@ -332,7 +332,7 @@ svSlice i j x = svExtract (w - i - 1) (w - i - j) x
 ----------------------------------------
 -- Shift operations
 
--- | op :: (n :: Nat) -> bitvector n -> Nat -> bitvector n
+-- | op : (n : Nat) -> Vec n Bool -> Nat -> Vec n Bool
 bvShiftOp :: (SWord -> SWord -> SWord) -> (SWord -> Int -> SWord) -> SValue
 bvShiftOp bvOp natOp =
   constFun $
@@ -344,15 +344,15 @@ bvShiftOp bvOp natOp =
       VToNat v -> fmap (vWord . bvOp x) (toWord v)
       _        -> error $ unwords ["Verifier.SAW.Simulator.SBV.bvShiftOp", show y]
 
--- bvShl :: (w :: Nat) -> bitvector w -> Nat -> bitvector w;
+-- bvShl : (w : Nat) -> Vec w Bool -> Nat -> Vec w Bool;
 bvShLOp :: SValue
 bvShLOp = bvShiftOp svShiftLeft svShl
 
--- bvShR :: (w :: Nat) -> bitvector w -> Nat -> bitvector w;
+-- bvShR : (w : Nat) -> Vec w Bool -> Nat -> Vec w Bool;
 bvShROp :: SValue
 bvShROp = bvShiftOp svShiftRight svShr
 
--- bvSShR :: (w :: Nat) -> bitvector w -> Nat -> bitvector w;
+-- bvSShR : (w : Nat) -> Vec w Bool -> Nat -> Vec w Bool;
 bvSShROp :: SValue
 bvSShROp = bvShiftOp bvOp natOp
   where
@@ -382,21 +382,21 @@ natToIntOp =
   Prims.natFun' "natToInt" $ \n -> return $
     VInt (literalSInteger (toInteger n))
 
--- primitive bvToInt :: (n::Nat) -> bitvector n -> Integer;
+-- primitive bvToInt : (n : Nat) -> Vec n Bool -> Integer;
 bvToIntOp :: SValue
 bvToIntOp = constFun $ wordFun $ \v ->
    case svAsInteger v of
       Just i -> return $ VInt (literalSInteger i)
       Nothing -> return $ VInt (svFromIntegral KUnbounded v)
 
--- primitive sbvToInt :: (n::Nat) -> bitvector n -> Integer;
+-- primitive sbvToInt : (n : Nat) -> Vec n Bool -> Integer;
 sbvToIntOp :: SValue
 sbvToIntOp = constFun $ wordFun $ \v ->
    case svAsInteger (svSign v) of
       Just i -> return $ VInt (literalSInteger i)
       Nothing -> return $ VInt (svFromIntegral KUnbounded (svSign v))
 
--- primitive intToBv :: (n::Nat) -> Integer -> bitvector n;
+-- primitive intToBv : (n : Nat) -> Integer -> Vec n Bool;
 intToBvOp :: SValue
 intToBvOp =
   Prims.natFun' "intToBv n" $ \n -> return $

--- a/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
+++ b/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
@@ -339,18 +339,18 @@ natToIntOp =
     VInt <$> W.intLit (given :: sym) (toInteger n)
 
 -- interpret bitvector as unsigned integer
--- primitive bvToInt :: (n::Nat) -> bitvector n -> Integer;
+-- primitive bvToInt : (n : Nat) -> Vec n Bool -> Integer;
 bvToIntOp :: forall sym. (Sym sym) => SValue sym
 bvToIntOp = constFun $ wordFun $ \(v :: SWord sym) -> do
   VInt <$> SW.bvToInteger (given :: sym) v
 
 -- interpret bitvector as signed integer
--- primitive sbvToInt :: (n::Nat) -> bitvector n -> Integer;
+-- primitive sbvToInt : (n : Nat) -> Vec n Bool -> Integer;
 sbvToIntOp :: forall sym. (Sym sym) => SValue sym
 sbvToIntOp = constFun $ wordFun $ \v -> do
    VInt <$> SW.sbvToInteger (given :: sym) v
 
--- primitive intToBv :: (n::Nat) -> Integer -> bitvector n;
+-- primitive intToBv : (n : Nat) -> Integer -> Vec n Bool;
 intToBvOp :: forall sym. (Sym sym) => SValue sym
 intToBvOp =
   Prims.natFun' "intToBv n" $ \n -> return $
@@ -393,7 +393,7 @@ liftRotate sym f w i =
   f w =<< SW.bvLit sym (SW.bvWidth w) (i `mod` SW.bvWidth w)
 
 
--- | op :: (n :: Nat) -> bitvector n -> Nat -> bitvector n
+-- | op : (n : Nat) -> Vec n Bool -> Nat -> Vec n Bool
 bvShiftOp :: (Sym sym) =>
              (SWord sym -> SWord sym -> IO (SWord sym)) ->
              (SWord sym -> Integer   -> IO (SWord sym)) -> SValue sym
@@ -408,17 +408,17 @@ bvShiftOp bvOp natOp =
       VToNat v -> VWord <$> (bvOp x =<< toWord v)
       _        -> error $ unwords ["Verifier.SAW.Simulator.What4.bvShiftOp", show y]
 
--- bvShl :: (w :: Nat) -> bitvector w -> Nat -> bitvector w;
+-- bvShl : (w : Nat) -> Vec w Bool -> Nat -> Vec w Bool;
 bvShLOp :: forall sym. (Sym sym) => SValue sym
 bvShLOp = bvShiftOp (SW.bvShl given)
                     (liftShift given (SW.bvShl given))
 
--- bvShR :: (w :: Nat) -> bitvector w -> Nat -> bitvector w;
+-- bvShR : (w : Nat) -> Vec w Bool -> Nat -> Vec w Bool;
 bvShROp :: forall sym. (Sym sym) => SValue sym
 bvShROp = bvShiftOp (SW.bvLshr given)
                     (liftShift given (SW.bvLshr given))
 
--- bvSShR :: (w :: Nat) -> bitvector w -> Nat -> bitvector w;
+-- bvSShR : (w : Nat) -> Vec w Bool -> Nat -> Vec w Bool;
 bvSShROp :: forall sym. (Sym sym) => SValue sym
 bvSShROp = bvShiftOp (SW.bvAshr given)
                      (liftShift given (SW.bvAshr given))

--- a/saw-core/prelude/Prelude.sawcore
+++ b/saw-core/prelude/Prelude.sawcore
@@ -1038,80 +1038,78 @@ splitLittleEndian m n a v = reverse m (Vec n a) (split m n a v);
 --------------------------------------------------------------------------------
 -- Bitvectors
 
--- | Bitvector operations expect the most-significant bit first.
-bitvector : (n : Nat) -> sort 0;
-bitvector n = Vec n Bool;
+-- Bitvector operations expect the most-significant bit first.
 
 -- | Returns most-significant bit in a signed bitvector.
-msb : (n : Nat) -> bitvector (Succ n) -> Bool;
+msb : (n : Nat) -> Vec (Succ n) Bool -> Bool;
 msb n v = at (Succ n) Bool v 0;
 
 -- | Returns least-significant bit in a bitvector.
-lsb : (n : Nat) -> bitvector (Succ n) -> Bool;
+lsb : (n : Nat) -> Vec (Succ n) Bool -> Bool;
 lsb n v = at (Succ n) Bool v n;
 
 -- | (bvNat n x) yields (x mod 2^n) as an n-bit vector.
-primitive bvNat : (n : Nat) -> Nat -> bitvector n;
+primitive bvNat : (n : Nat) -> Nat -> Vec n Bool;
 
 -- | Satisfies @bvNat n (bvToNat n x) = x@.
-primitive bvToNat : (n : Nat) -> bitvector n -> Nat;
+primitive bvToNat : (n : Nat) -> Vec n Bool -> Nat;
 
-bvAt : (n : Nat) -> (a : sort 0) -> (w : Nat) -> Vec n a -> bitvector w
+bvAt : (n : Nat) -> (a : sort 0) -> (w : Nat) -> Vec n a -> Vec w Bool
      -> a;
 bvAt n a w xs i = at n a xs (bvToNat w i);
 
-bvUpd : (n : Nat) -> (a : sort 0) -> (w : Nat) -> Vec n a -> bitvector w
+bvUpd : (n : Nat) -> (a : sort 0) -> (w : Nat) -> Vec n a -> Vec w Bool
       -> a -> Vec n a;
 bvUpd n a w xs i y = upd n a xs (bvToNat w i) y;
 
-bvRotateL : (n : Nat) -> (a : sort 0) -> (w : Nat) -> Vec n a -> bitvector w -> Vec n a;
+bvRotateL : (n : Nat) -> (a : sort 0) -> (w : Nat) -> Vec n a -> Vec w Bool -> Vec n a;
 bvRotateL n a w xs i = rotateL n a xs (bvToNat w i);
 
-bvRotateR : (n : Nat) -> (a : sort 0) -> (w : Nat) -> Vec n a -> bitvector w -> Vec n a;
+bvRotateR : (n : Nat) -> (a : sort 0) -> (w : Nat) -> Vec n a -> Vec w Bool -> Vec n a;
 bvRotateR n a w xs i = rotateR n a xs (bvToNat w i);
 
-bvShiftL : (n : Nat) -> (a : sort 0) -> (w : Nat) -> a -> Vec n a -> bitvector w -> Vec n a;
+bvShiftL : (n : Nat) -> (a : sort 0) -> (w : Nat) -> a -> Vec n a -> Vec w Bool -> Vec n a;
 bvShiftL n a w z xs i = shiftL n a z xs (bvToNat w i);
 
-bvShiftR : (n : Nat) -> (a : sort 0) -> (w : Nat) -> a -> Vec n a -> bitvector w -> Vec n a;
+bvShiftR : (n : Nat) -> (a : sort 0) -> (w : Nat) -> a -> Vec n a -> Vec w Bool -> Vec n a;
 bvShiftR n a w z xs i = shiftR n a z xs (bvToNat w i);
 
-primitive bvAdd : (n : Nat) -> bitvector n -> bitvector n -> bitvector n;
+primitive bvAdd : (n : Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool;
 
 -- | Unsigned and signed comparison functions.
-primitive bvugt : (n : Nat) -> bitvector n -> bitvector n -> Bool;
-primitive bvuge : (n : Nat) -> bitvector n -> bitvector n -> Bool;
-primitive bvult : (n : Nat) -> bitvector n -> bitvector n -> Bool;
-primitive bvule : (n : Nat) -> bitvector n -> bitvector n -> Bool;
+primitive bvugt : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool;
+primitive bvuge : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool;
+primitive bvult : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool;
+primitive bvule : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool;
 
-primitive bvsgt : (n : Nat) -> bitvector n -> bitvector n -> Bool;
-primitive bvsge : (n : Nat) -> bitvector n -> bitvector n -> Bool;
-primitive bvslt : (n : Nat) -> bitvector n -> bitvector n -> Bool;
-primitive bvsle : (n : Nat) -> bitvector n -> bitvector n -> Bool;
+primitive bvsgt : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool;
+primitive bvsge : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool;
+primitive bvslt : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool;
+primitive bvsle : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool;
 
-primitive bvPopcount : (n : Nat) -> bitvector n -> bitvector n;
-primitive bvCountLeadingZeros : (n : Nat) -> bitvector n -> bitvector n;
-primitive bvCountTrailingZeros : (n : Nat) -> bitvector n -> bitvector n;
+primitive bvPopcount : (n : Nat) -> Vec n Bool -> Vec n Bool;
+primitive bvCountLeadingZeros : (n : Nat) -> Vec n Bool -> Vec n Bool;
+primitive bvCountTrailingZeros : (n : Nat) -> Vec n Bool -> Vec n Bool;
 
 -- Universal quantification over bitvectors
-primitive bvForall : (n : Nat) -> (bitvector n -> Bool) -> Bool;
+primitive bvForall : (n : Nat) -> (Vec n Bool -> Bool) -> Bool;
 
-bvCarry : (n : Nat) -> bitvector n -> bitvector n -> Bool;
+bvCarry : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool;
 bvCarry n x y = bvult n (bvAdd n x y) x;
 
-bvSCarry : (n : Nat) -> bitvector (Succ n) -> bitvector (Succ n) -> Bool;
+bvSCarry : (n : Nat) -> Vec (Succ n) Bool -> Vec (Succ n) Bool -> Bool;
 bvSCarry n x y = and (boolEq (msb n x) (msb n y)) (xor (msb n x) (msb n (bvAdd (Succ n) x y)));
 
-bvAddWithCarry : (n : Nat) -> bitvector n -> bitvector n -> Bool * bitvector n;
+bvAddWithCarry : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool * Vec n Bool;
 bvAddWithCarry n x y = (bvCarry n x y, bvAdd n x y);
 
-axiom bvAddZeroL : (n : Nat) -> (x : bitvector n) -> Eq (bitvector n) (bvAdd n (bvNat n 0) x) x;
-axiom bvAddZeroR : (n : Nat) -> (x : bitvector n) -> Eq (bitvector n) (bvAdd n x (bvNat n 0)) x;
+axiom bvAddZeroL : (n : Nat) -> (x : Vec n Bool) -> Eq (Vec n Bool) (bvAdd n (bvNat n 0) x) x;
+axiom bvAddZeroR : (n : Nat) -> (x : Vec n Bool) -> Eq (Vec n Bool) (bvAdd n x (bvNat n 0)) x;
 
-primitive bvNeg : (n : Nat) -> bitvector n -> bitvector n;
-primitive bvSub : (n : Nat) -> bitvector n -> bitvector n -> bitvector n;
-primitive bvMul : (n : Nat) -> bitvector n -> bitvector n -> bitvector n;
-primitive bvLg2 : (n : Nat) -> bitvector n -> bitvector n;
+primitive bvNeg : (n : Nat) -> Vec n Bool -> Vec n Bool;
+primitive bvSub : (n : Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool;
+primitive bvMul : (n : Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool;
+primitive bvLg2 : (n : Nat) -> Vec n Bool -> Vec n Bool;
 
 -- Unsigned division and remainder.
 --
@@ -1120,8 +1118,8 @@ primitive bvLg2 : (n : Nat) -> bitvector n -> bitvector n;
 --
 -- These two functions satisfy the property that:
 --   bvAdd x (bvMul x (bvUDiv x u v) v) (bvURem x u v) == u
-primitive bvUDiv : (n : Nat) -> bitvector n -> bitvector n -> bitvector n;
-primitive bvURem : (n : Nat) -> bitvector n -> bitvector n -> bitvector n;
+primitive bvUDiv : (n : Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool;
+primitive bvURem : (n : Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool;
 
 
 -- Signed division.
@@ -1136,59 +1134,58 @@ primitive bvURem : (n : Nat) -> bitvector n -> bitvector n -> bitvector n;
 -- bvSDiv and bvSRem satisfy the property that:
 --
 --   bvAdd x (bvMul x (bvSDiv x u v) v) (bvSRem x u v) == u
-primitive bvSDiv : (x : Nat) -> bitvector (Succ x) -> bitvector (Succ x) -> bitvector (Succ x);
-primitive bvSRem : (x : Nat) -> bitvector (Succ x) -> bitvector (Succ x)
-       -> bitvector (Succ x);
+primitive bvSDiv : (n : Nat) -> Vec (Succ n) Bool -> Vec (Succ n) Bool -> Vec (Succ n) Bool;
+primitive bvSRem : (n : Nat) -> Vec (Succ n) Bool -> Vec (Succ n) Bool -> Vec (Succ n) Bool;
 --TODO:
 
 -- | Shift left by the given number of bits.
 -- New bits are False.
-primitive bvShl : (w : Nat) -> bitvector w -> Nat -> bitvector w;
+primitive bvShl : (w : Nat) -> Vec w Bool -> Nat -> Vec w Bool;
 
 -- Logical right shift.  New bits are False.
-primitive bvShr : (w : Nat) -> bitvector w -> Nat -> bitvector w;
+primitive bvShr : (w : Nat) -> Vec w Bool -> Nat -> Vec w Bool;
 
 -- | Signed right shift.  New bits are equal to most-significant bit.
-primitive bvSShr : (w : Nat) -> bitvector (Succ w) -> Nat -> bitvector (Succ w);
+primitive bvSShr : (w : Nat) -> Vec (Succ w) Bool -> Nat -> Vec (Succ w) Bool;
 
 axiom bvShiftL_bvShl :
-  (n : Nat) -> (w : Nat) -> (x : Vec n Bool) -> (i : bitvector w) ->
+  (n : Nat) -> (w : Nat) -> (x : Vec n Bool) -> (i : Vec w Bool) ->
   Eq (Vec n Bool) (bvShiftL n Bool w False x i) (bvShl n x (bvToNat w i));
 
 axiom bvShiftR_bvShr :
-  (n : Nat) -> (w : Nat) -> (x : Vec n Bool) -> (i : bitvector w) ->
+  (n : Nat) -> (w : Nat) -> (x : Vec n Bool) -> (i : Vec w Bool) ->
   Eq (Vec n Bool) (bvShiftR n Bool w False x i) (bvShr n x (bvToNat w i));
 
 -- | Zipwith specialized to bitvectors.
 bvZipWith : (Bool -> Bool -> Bool)
           -> (n : Nat)
-          -> bitvector n -> bitvector n -> bitvector n;
+          -> Vec n Bool -> Vec n Bool -> Vec n Bool;
 bvZipWith = zipWith Bool Bool Bool;
 
 -- | Bitwise complement.
-bvNot : (n : Nat) -> bitvector n -> bitvector n;
+bvNot : (n : Nat) -> Vec n Bool -> Vec n Bool;
 bvNot = map Bool Bool not;
 
 -- | Pairwise conjunction
-bvAnd : (n : Nat) -> bitvector n -> bitvector n -> bitvector n;
+bvAnd : (n : Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool;
 bvAnd = bvZipWith and;
 
 -- | Pairwise disjunction
-bvOr : (n : Nat) -> bitvector n -> bitvector n -> bitvector n;
+bvOr : (n : Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool;
 bvOr  = bvZipWith or;
 
 -- | Pairwise exclusive or
-bvXor : (n : Nat) -> bitvector n -> bitvector n -> bitvector n;
+bvXor : (n : Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool;
 bvXor = bvZipWith xor;
 
 -- | Return true if two bitvectors are equal.
-bvEq : (n : Nat) -> bitvector n -> bitvector n -> Bool;
+bvEq : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool;
 bvEq n x y = vecEq n Bool boolEq x y;
 
-axiom bvEq_refl : (n : Nat) -> (x : bitvector n) -> Eq Bool (bvEq n x x) True;
+axiom bvEq_refl : (n : Nat) -> (x : Vec n Bool) -> Eq Bool (bvEq n x x) True;
 
 -- | Axiom: bvEq implements *the* equality operation on bitvectors.
-axiom eq_bitvector : (n : Nat) -> Eq (bitvector n -> bitvector n -> Bool) (eq (bitvector n)) (bvEq n);
+axiom eq_bitvector : (n : Nat) -> Eq (Vec n Bool -> Vec n Bool -> Bool) (eq (Vec n Bool)) (bvEq n);
 
 axiom eq_VecBool : (n : Nat) -> Eq (Vec n Bool -> Vec n Bool -> Bool) (eq (Vec n Bool)) (bvEq n);
 
@@ -1197,50 +1194,50 @@ axiom eq_VecVec : (n : Nat) -> (m : Nat) -> (a : sort 0)
                 (eq (Vec n (Vec m a)))
                 (vecEq n (Vec m a) (eq (Vec m a)));
 
-axiom equalNat_bv : (n : Nat) -> (x : bitvector n) -> (i : Nat) ->
+axiom equalNat_bv : (n : Nat) -> (x : Vec n Bool) -> (i : Nat) ->
                Eq Bool (equalNat i (bvToNat n x)) (bvEq n (bvNat n i) x);
 
 -- | Returns the bitvector 1 if the boolean is true,
 --   and returns 0 otherwise
-bvBool : (n : Nat) -> Bool -> bitvector n;
-bvBool n b = ite (bitvector n) b (bvNat n 1) (bvNat n 0);
+bvBool : (n : Nat) -> Bool -> Vec n Bool;
+bvBool n b = ite (Vec n Bool) b (bvNat n 1) (bvNat n 0);
 
 -- | Return true if two bitvectors are not equal.
-bvNe : (n : Nat) -> bitvector n -> bitvector n -> Bool;
+bvNe : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool;
 bvNe n x y = not (bvEq n x y);
 
 -- | Return true if the bitvector is nonzero
-bvNonzero : (n : Nat) -> bitvector n -> Bool;
+bvNonzero : (n : Nat) -> Vec n Bool -> Bool;
 bvNonzero n x = bvNe n x (bvNat n 0);
 
 -- | Truncates a vector a smaller size.
 -- msb implementation:
-bvTrunc : (x y : Nat) -> bitvector (addNat x y) -> bitvector y;
+bvTrunc : (m n : Nat) -> Vec (addNat m n) Bool -> Vec n Bool;
 bvTrunc = drop Bool;
 -- lsb implementation:
--- bvTrunc : (x y : Nat) -> bitvector (addNat y x) -> bitvector y;
--- bvTrunc x y = take Bool y x;
+-- bvTrunc : (m n : Nat) -> Vec (addNat n m) Bool -> Vec n Bool;
+-- bvTrunc m n = take Bool n m;
 
 -- | Perform a unsigned extension of the bitvector.
 -- @bvUExt m n x@ adds m bits of zeros to the most-significant bits of
 -- the n-bit vector x.
 -- msb implementation:
-bvUExt : (m n : Nat) -> bitvector n -> bitvector (addNat m n);
+bvUExt : (m n : Nat) -> Vec n Bool -> Vec (addNat m n) Bool;
 bvUExt m n x = append m n Bool (bvNat m 0) x;
 -- lsb implementation:
--- bvUExt : (m n : Nat) -> bitvector n -> bitvector (addNat n m);
+-- bvUExt : (m n : Nat) -> Vec n Bool -> Vec (addNat n m) Bool;
 -- bvUExt m n a = append n m Bool x (bvNat m 0);
 
 -- | 'replicateBool' is an version of 'replicate' optimized for type Bool.
-replicateBool : (n : Nat) -> Bool -> bitvector n;
-replicateBool n b = ite (bitvector n) b (bvNot n (bvNat n 0)) (bvNat n 0);
+replicateBool : (n : Nat) -> Bool -> Vec n Bool;
+replicateBool n b = ite (Vec n Bool) b (bvNot n (bvNat n 0)) (bvNat n 0);
 
 -- | Perform a signed extension of the bitvector.
 -- msb implementation:
-bvSExt : (m n : Nat) -> bitvector (Succ n) -> bitvector (addNat m (Succ n));
+bvSExt : (m n : Nat) -> Vec (Succ n) Bool -> Vec (addNat m (Succ n)) Bool;
 bvSExt m n x = append m (Succ n) Bool (replicateBool m (msb n x)) x;
 -- lsb implementation:
--- bvSExt : (m n : Nat) -> bitvector (Succ n) -> bitvector (addNat (Succ n) m);
+-- bvSExt : (m n : Nat) -> Vec (Succ n) Bool -> Vec (addNat (Succ n) m) Bool;
 -- bvSExt m n x = append (Succ n) m Bool x (replicateBool m (msb n x));
 
 --------------------------------------------------------------------------------
@@ -1261,7 +1258,7 @@ streamUpd a strm i y =
                  MkStream a (\ (j : Nat) -> ite a (equalNat i j) y (s j))) strm;
 
 bvStreamUpd : (a : sort 0) -> (w : Nat) ->
-     Stream a -> bitvector w -> a -> Stream a;
+     Stream a -> Vec w Bool -> a -> Stream a;
 bvStreamUpd a w xs i y = streamUpd a xs (bvToNat w i) y;
 
 streamGet : (a : sort 0) -> Stream a -> Nat -> a;
@@ -1335,13 +1332,13 @@ primitive natToInt : Nat -> Integer;
 
 -- for x >= 0, intToBv n x = x `mod` 2^n
 -- for x <  0, intToBv n x = bvNeg n (-x `mod` 2^n)
-primitive intToBv : (n:Nat) -> Integer -> bitvector n;
+primitive intToBv : (n:Nat) -> Integer -> Vec n Bool;
 
 -- return the unsigned value of the bitvector as an integer
-primitive bvToInt : (n:Nat) -> bitvector n -> Integer;
+primitive bvToInt : (n:Nat) -> Vec n Bool -> Integer;
 
 -- return the 2's complement signed value of the bitvector as an integer
-primitive sbvToInt : (n:Nat) -> bitvector n -> Integer;
+primitive sbvToInt : (n:Nat) -> Vec n Bool -> Integer;
 
 
 --------------------------------------------------------------------------------
@@ -1367,7 +1364,7 @@ updNatFun : (a:sort 0)
 updNatFun a f i v x = ite a (equalNat i x) v (f x);
 
 updBvFun : (n:Nat) -> (a:sort 0)
-	 -> (bitvector n -> a) -> bitvector n -> a -> (bitvector n -> a);
+	 -> (Vec n Bool -> a) -> Vec n Bool -> a -> (Vec n Bool -> a);
 updBvFun n a f i v x = ite a (bvEq n i x) v (f x);
 
 --------------------------------------------------------------------------------
@@ -1378,15 +1375,15 @@ primitive Float : sort 0;
 
 -- mkFloat m e = m * 2^^e
 primitive mkFloat : Integer -> Integer -> Float;
--- primitive bvToFloat : bitvector 32 -> Float;
--- primitive floatToBV : Float -> bitvector 32;
+-- primitive bvToFloat : Vec 32 Bool -> Float;
+-- primitive floatToBV : Float -> Vec 32 Bool;
 
 primitive Double : sort 0;
 
 -- mkDouble m e = m * 2^^e
 primitive mkDouble : Integer -> Integer -> Float;
--- primitive bvToDouble : bitvector 64 -> Double;
--- primitive doubleToBV : Double -> bitvector 64;
+-- primitive bvToDouble : Vec 64 Bool -> Double;
+-- primitive doubleToBV : Double -> Vec 64 Bool;
 
 
 --------------------------------------------------------------------------------
@@ -1451,63 +1448,63 @@ fixM a b f x =
 
 
 -- Test computations
-test_fun0 : bitvector 64 -> CompM (bitvector 64);
-test_fun0 _ = returnM (bitvector 64) (bvNat 64 0);
+test_fun0 : Vec 64 Bool -> CompM (Vec 64 Bool);
+test_fun0 _ = returnM (Vec 64 Bool) (bvNat 64 0);
 
-test_fun1 : bitvector 64 -> CompM (bitvector 64);
-test_fun1 _ = returnM (bitvector 64) (bvNat 64 1);
+test_fun1 : Vec 64 Bool -> CompM (Vec 64 Bool);
+test_fun1 _ = returnM (Vec 64 Bool) (bvNat 64 1);
 
-test_fun2 : bitvector 64 -> CompM (bitvector 64);
-test_fun2 x = returnM (bitvector 64) x;
+test_fun2 : Vec 64 Bool -> CompM (Vec 64 Bool);
+test_fun2 x = returnM (Vec 64 Bool) x;
 
 -- If x == 0 then x else 0; should be equal to 0
-test_fun3 : bitvector 64 -> CompM (bitvector 64);
+test_fun3 : Vec 64 Bool -> CompM (Vec 64 Bool);
 test_fun3 x =
-  ite (CompM (bitvector 64)) (bvEq 64 x (bvNat 64 0))
-      (returnM (bitvector 64) x)
-      (returnM (bitvector 64) (bvNat 64 0));
+  ite (CompM (Vec 64 Bool)) (bvEq 64 x (bvNat 64 0))
+      (returnM (Vec 64 Bool) x)
+      (returnM (Vec 64 Bool) (bvNat 64 0));
 
 -- let rec f x = 0 in f x
-test_fun4 : bitvector 64 -> CompM (bitvector 64);
+test_fun4 : Vec 64 Bool -> CompM (Vec 64 Bool);
 test_fun4 x =
   letRecM1
-    (bitvector 64) (bitvector 64) (bitvector 64)
-    (\ (f: bitvector 64 -> CompM (bitvector 64)) (y:bitvector 64) ->
-      returnM (bitvector 64) (bvNat 64 0))
-    (\ (f: bitvector 64 -> CompM (bitvector 64)) ->
+    (Vec 64 Bool) (Vec 64 Bool) (Vec 64 Bool)
+    (\ (f: Vec 64 Bool -> CompM (Vec 64 Bool)) (y:Vec 64 Bool) ->
+      returnM (Vec 64 Bool) (bvNat 64 0))
+    (\ (f: Vec 64 Bool -> CompM (Vec 64 Bool)) ->
       f x);
 
 {- Alternate version of test_fun4 that uses letRecM directly
-test_fun4 : bitvector 64 -> CompM (bitvector 64);
+test_fun4 : Vec 64 Bool -> CompM (Vec 64 Bool);
 test_fun4 x =
   letRecM
-    (TypesCons (bitvector 64) (bitvector 64) TypesNil) (bitvector 64)
-    (\ (funs:#((bitvector 64 -> CompM (bitvector 64)), #())) ->
-      ((\ (y:bitvector 64) -> returnM (bitvector 64) (bvNat 64 0)), ()))
-    (\ (funs:#((bitvector 64 -> CompM (bitvector 64)), #())) ->
+    (TypesCons (Vec 64 Bool) (Vec 64 Bool) TypesNil) (Vec 64 Bool)
+    (\ (funs:#((Vec 64 Bool -> CompM (Vec 64 Bool)), #())) ->
+      ((\ (y:Vec 64 Bool) -> returnM (Vec 64 Bool) (bvNat 64 0)), ()))
+    (\ (funs:#((Vec 64 Bool -> CompM (Vec 64 Bool)), #())) ->
       funs.1 x);
 -}
 
 -- let rec f = f in f x
-test_fun5 : bitvector 64 -> CompM (bitvector 64);
+test_fun5 : Vec 64 Bool -> CompM (Vec 64 Bool);
 test_fun5 x =
   letRecM1
-    (bitvector 64) (bitvector 64) (bitvector 64)
-    (\ (f: bitvector 64 -> CompM (bitvector 64)) -> f)
-    (\ (f: bitvector 64 -> CompM (bitvector 64)) -> f x);
+    (Vec 64 Bool) (Vec 64 Bool) (Vec 64 Bool)
+    (\ (f: Vec 64 Bool -> CompM (Vec 64 Bool)) -> f)
+    (\ (f: Vec 64 Bool -> CompM (Vec 64 Bool)) -> f x);
 
 -- let rec f = g and g = f in f x
-test_fun6 : bitvector 64 -> CompM (bitvector 64);
+test_fun6 : Vec 64 Bool -> CompM (Vec 64 Bool);
 test_fun6 x =
   letRecM
-    (TypesCons (bitvector 64) (bitvector 64)
-      (TypesCons (bitvector 64) (bitvector 64) TypesNil))
-    (bitvector 64)
-    (\ (funs:#((bitvector 64 -> CompM (bitvector 64)),
-                 #((bitvector 64 -> CompM (bitvector 64)), #()))) ->
+    (TypesCons (Vec 64 Bool) (Vec 64 Bool)
+      (TypesCons (Vec 64 Bool) (Vec 64 Bool) TypesNil))
+    (Vec 64 Bool)
+    (\ (funs:#((Vec 64 Bool -> CompM (Vec 64 Bool)),
+                 #((Vec 64 Bool -> CompM (Vec 64 Bool)), #()))) ->
       (funs.2, (funs.1, ())))
-    (\ (funs:#((bitvector 64 -> CompM (bitvector 64)),
-                 #((bitvector 64 -> CompM (bitvector 64)), #()))) ->
+    (\ (funs:#((Vec 64 Bool -> CompM (Vec 64 Bool)),
+                 #((Vec 64 Bool -> CompM (Vec 64 Bool)), #()))) ->
       funs.1 x);
 
 --------------------------------------------------------------------------------
@@ -1524,26 +1521,26 @@ primitive arrayUpdate : (a b : sort 0) -> (Array a b) -> a -> b -> (Array a b);
 -- General axioms
 
 axiom bveq_sameL : (n : Nat)
-           -> (x z : bitvector n)
+           -> (x z : Vec n Bool)
            -> Eq Bool
                  (bvEq n x (bvAdd n x z))
                  (bvEq n (bvNat n 0) z);
 
 axiom bveq_sameR : (n : Nat)
-           -> (x y : bitvector n)
+           -> (x y : Vec n Bool)
            -> Eq Bool
                  (bvEq n (bvAdd n x y) x)
                  (bvEq n y (bvNat n 0));
 
 axiom bveq_same2 : (n : Nat)
-           -> (x y z : bitvector n)
+           -> (x y z : Vec n Bool)
            -> Eq Bool
                  (bvEq n (bvAdd n x y) (bvAdd n x z))
                  (bvEq n y z);
 
 axiom bvNat_bvToNat : (n : Nat)
-              -> (x : bitvector n)
-              -> Eq (bitvector n)
+              -> (x : Vec n Bool)
+              -> Eq (Vec n Bool)
                     (bvNat n (bvToNat n x))
                     x;
 

--- a/saw-core/src/Verifier/SAW/Prim.hs
+++ b/saw-core/src/Verifier/SAW/Prim.hs
@@ -105,11 +105,11 @@ upd _ _ (Vec t v) i e = Vec t (v V.// [(i, e)])
 ----------------------------------------
 -- Bitvector operations
 
--- bvNat :: (x :: Nat) -> Nat -> bitvector x;
+-- bvNat : (n : Nat) -> Nat -> Vec n Bool;
 bvNat :: Int -> Integer -> BitVector
 bvNat w x = bv w x
 
--- bvAdd :: (x :: Nat) -> bitvector x -> bitvector x -> bitvector x;
+-- bvAdd : (n : Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool;
 bvAdd, bvSub, bvMul :: Natural -> BitVector -> BitVector -> BitVector
 bvAdd _ (BV w x) (BV _ y) = bv w (x + y)
 bvSub _ (BV w x) (BV _ y) = bv w (x - y)
@@ -180,11 +180,11 @@ append_bv _ _ _ (BV m x) (BV n y) = BV (m + n) (shiftL x n .|. y)
 -- little-endian version:
 -- append_bv _ _ _ (BV m x) (BV n y) = BV (m + n) (x .|. shiftL y m)
 
--- bvToNat :: (n :: Nat) -> bitvector n -> Nat;
+-- bvToNat : (n : Nat) -> Vec n Bool -> Nat;
 bvToNat :: Int -> BitVector -> Integer
 bvToNat _ (BV _ x) = x
 
--- bvAddWithCarry :: (x :: Nat) -> bitvector x -> bitvector x -> #(Bool, bitvector x);
+-- bvAddWithCarry : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool * Vec n Bool;
 bvAddWithCarry :: Int -> BitVector -> BitVector -> (Bool, BitVector)
 bvAddWithCarry _ (BV w x) (BV _ y) = (testBit z w, bv w z)
     where z = x + y
@@ -218,15 +218,15 @@ bvShr _ (BV w x) i = bv w (x `shiftR` i)
 bvSShr :: Int -> BitVector -> Int -> BitVector
 bvSShr _ x i = bv (width x) (signed x `shiftR` i)
 
--- bvTrunc :: (x y :: Nat) -> bitvector (addNat y x) -> bitvector y;
+-- bvTrunc : (m n : Nat) -> Vec (addNat m n) Bool -> Vec n Bool;
 bvTrunc :: Int -> Int -> BitVector -> BitVector
 bvTrunc _ n (BV _ x) = bv n x
 
--- bvUExt :: (x y :: Nat) -> bitvector y -> bitvector (addNat y x);
+-- bvUExt : (m n : Nat) -> Vec n Bool -> Vec (addNat m n) Bool;
 bvUExt :: Int -> Int -> BitVector -> BitVector
 bvUExt m n x = BV (m + n) (unsigned x)
 
--- bvSExt :: (x y :: Nat) -> bitvector (Succ y) -> bitvector (addNat (Succ y) x);
+-- bvSExt : (m n : Nat) -> Vec (Succ n) Bool -> Vec (addNat m (Succ n)) Bool;
 bvSExt :: Int -> Int -> BitVector -> BitVector
 bvSExt m n x = bv (m + n + 1) (signed x)
 

--- a/saw-core/src/Verifier/SAW/Recognizer.hs
+++ b/saw-core/src/Verifier/SAW/Recognizer.hs
@@ -356,9 +356,7 @@ asVecType :: Recognizer Term (Natural :*: Term)
 asVecType = isVecType return
 
 asBitvectorType :: Recognizer Term Natural
-asBitvectorType =
-  (isGlobalDef "Prelude.bitvector" @> asNat)
-  `orElse` ((isGlobalDef "Prelude.Vec" @> asNat) <@ asBoolType)
+asBitvectorType = (isGlobalDef "Prelude.Vec" @> asNat) <@ asBoolType
 
 asMux :: Recognizer Term (Term :*: Term :*: Term :*: Term)
 asMux = isGlobalDef "Prelude.ite" @> return <@> return <@> return <@> return

--- a/saw-core/src/Verifier/SAW/SharedTerm.hs
+++ b/saw-core/src/Verifier/SAW/SharedTerm.hs
@@ -1418,7 +1418,7 @@ scBoolEq sc x y = scGlobalApply sc "Prelude.boolEq" [x,y]
 
 -- | Create a universally quantified bitvector term.
 --
--- > bvForall : (n : Nat) -> (bitvector n -> Bool) -> Bool;
+-- > bvForall : (n : Nat) -> (Vec n Bool -> Bool) -> Bool;
 scBvForall :: SharedContext -> Term -> Term -> IO Term
 scBvForall sc w f = scGlobalApply sc "Prelude.bvForall" [w, f]
 
@@ -1465,7 +1465,7 @@ scGet sc n e v i = scGlobalApply sc (mkIdent preludeName "get") [n, e, v, i]
 -- | Create a term accessing a particular element of a vector with @bvAt@,
 -- which uses a bitvector for indexing.
 --
--- > bvAt : (n : Nat) -> (a : sort 0) -> (i : Nat) -> Vec n a -> bitvector i -> a;
+-- > bvAt : (n : Nat) -> (a : sort 0) -> (w : Nat) -> Vec n a -> Vec w Bool -> a;
 scBvAt :: SharedContext -> Term -> Term ->
          Term -> Term -> Term -> IO Term
 scBvAt sc n a i xs idx = scGlobalApply sc (mkIdent preludeName "bvAt") [n, a, i, xs, idx]
@@ -1494,14 +1494,14 @@ scSingle sc e x = scGlobalApply sc (mkIdent preludeName "single") [e, x]
 -- | Create a term computing the least significant bit of a bitvector, given a
 -- length and bitvector.
 --
--- > lsb : (n : Nat) -> bitvector (Succ n) -> Bool;
+-- > lsb : (n : Nat) -> Vec (Succ n) Bool -> Bool;
 scLsb :: SharedContext -> Term -> Term -> IO Term
 scLsb sc n x = scGlobalApply sc (mkIdent preludeName "lsb") [n, x]
 
 -- | Create a term computing the most significant bit of a bitvector, given a
 -- length and bitvector.
 --
--- > msb : (n : Nat) -> bitvector (Succ n) -> Bool;
+-- > msb : (n : Nat) -> Vec (Succ n) Bool -> Bool;
 scMsb :: SharedContext -> Term -> Term -> IO Term
 scMsb sc n x = scGlobalApply sc (mkIdent preludeName "lsb") [n, x]
 
@@ -1677,7 +1677,7 @@ scNatToInt sc x = scGlobalApply sc "Prelude.natToInt" [x]
 -- | Create a term computing a bitvector of length n from an @Integer@, if
 -- possible.
 --
--- > intToBv : (n::Nat) -> Integer -> bitvector n;
+-- > intToBv : (n::Nat) -> Integer -> Vec n Bool;
 scIntToBv
    :: SharedContext -> Term -> Term -> IO Term
 scIntToBv sc n x = scGlobalApply sc "Prelude.intToBv" [n,x]
@@ -1685,7 +1685,7 @@ scIntToBv sc n x = scGlobalApply sc "Prelude.intToBv" [n,x]
 -- | Create a term computing an @Integer@ from a bitvector of length n.
 -- This produces the unsigned value of the bitvector.
 --
--- > bvToInt : (n : Nat) -> bitvector n -> Integer;
+-- > bvToInt : (n : Nat) -> Vec n Bool -> Integer;
 scBvToInt
    :: SharedContext -> Term -> Term -> IO Term
 scBvToInt sc n x = scGlobalApply sc "Prelude.bvToInt" [n,x]
@@ -1693,7 +1693,7 @@ scBvToInt sc n x = scGlobalApply sc "Prelude.bvToInt" [n,x]
 -- | Create a term computing an @Integer@ from a bitvector of length n.
 -- This produces the 2's complement signed value of the bitvector.
 --
--- > sbvToInt : (n : Nat) -> bitvector n -> Integer;
+-- > sbvToInt : (n : Nat) -> Vec n Bool -> Integer;
 scSbvToInt
    :: SharedContext -> Term -> Term -> IO Term
 scSbvToInt sc n x = scGlobalApply sc "Prelude.sbvToInt" [n,x]
@@ -1705,20 +1705,20 @@ scSbvToInt sc n x = scGlobalApply sc "Prelude.sbvToInt" [n,x]
 --
 -- > bitvector : (n : Nat) -> sort 1
 scBitvector :: SharedContext -> Natural -> IO Term
-scBitvector sc size = do
-  c <- scGlobalDef sc "Prelude.bitvector"
-  s <- scNat sc size
-  scApply sc c s
+scBitvector sc size =
+  do s <- scNat sc size
+     t <- scBoolType sc
+     scVecType sc s t
 
 -- | Create a term computing a bitvector of length x from a @Nat@, if possible.
 --
--- > bvNat : (x : Nat) -> Nat -> bitvector x;
+-- > bvNat : (n : Nat) -> Nat -> Vec n Bool;
 scBvNat :: SharedContext -> Term -> Term -> IO Term
 scBvNat sc x y = scGlobalApply sc "Prelude.bvNat" [x, y]
 
 -- | Create a term computing a @Nat@ from a bitvector of length n.
 --
--- > bvToNat : (n : Nat) -> bitvector n -> Nat;
+-- > bvToNat : (n : Nat) -> Vec n Bool -> Nat;
 scBvToNat :: SharedContext -> Natural -> Term -> IO Term
 scBvToNat sc n x = do
     n' <- scNat sc n
@@ -1742,200 +1742,200 @@ scFinVal sc a b = scCtorApp sc "Prelude.FinVal" [a, b]
 -- the other given term evaluates to @False@ and representing 1 if the other
 -- given term evaluates to @True@.
 --
--- > bvBool : (n : Nat) -> Bool -> bitvector n;
+-- > bvBool : (n : Nat) -> Bool -> Vec n Bool;
 scBvBool :: SharedContext -> Term -> Term -> IO Term
 scBvBool sc n x = scGlobalApply sc "Prelude.bvBool" [n, x]
 
 -- | Create a term returning true if and only if the given bitvector represents
 -- a nonzero value.
 --
--- > bvNonzero : (n : Nat) -> bitvector n -> Bool;
+-- > bvNonzero : (n : Nat) -> Vec n Bool -> Bool;
 scBvNonzero :: SharedContext -> Term -> Term -> IO Term
 scBvNonzero sc n x = scGlobalApply sc "Prelude.bvNonzero" [n, x]
 
 -- | Create a term computing the 2's complement negation of the given
 -- bitvector.
--- > bvNeg : (x : Nat) -> bitvector x -> bitvector x;
+-- > bvNeg : (n : Nat) -> Vec n Bool -> Vec n Bool;
 scBvNeg :: SharedContext -> Term -> Term -> IO Term
 scBvNeg sc n x = scGlobalApply sc "Prelude.bvNeg" [n, x]
 
 -- | Create a term applying the bitvector addition primitive.
 --
--- > bvAdd : (x : Nat) -> bitvector x -> bitvector x -> bitvector x;
+-- > bvAdd : (n : Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool;
 scBvAdd :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvAdd sc n x y = scGlobalApply sc "Prelude.bvAdd" [n, x, y]
 
 -- | Create a term applying the bitvector subtraction primitive.
 --
--- > bvSub : (x : Nat) -> bitvector x -> bitvector x -> bitvector x;
+-- > bvSub : (n : Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool;
 scBvSub :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvSub sc n x y = scGlobalApply sc "Prelude.bvSub" [n, x, y]
 
 -- | Create a term applying the bitvector multiplication primitive.
 --
--- > bvMul : (x : Nat) -> bitvector x -> bitvector x -> bitvector x;
+-- > bvMul : (n : Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool;
 scBvMul :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvMul sc n x y = scGlobalApply sc "Prelude.bvMul" [n, x, y]
 
 -- | Create a term applying the bitvector (unsigned) modulus primitive.
 --
--- > bvURem : (x : Nat) -> bitvector x -> bitvector x -> bitvector x;
+-- > bvURem : (n : Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool;
 scBvURem :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvURem sc n x y = scGlobalApply sc "Prelude.bvURem" [n, x, y]
 
 -- | Create a term applying the bitvector (unsigned) division primitive.
 --
--- > bvUDiv : (x : Nat) -> bitvector x -> bitvector x -> bitvector x;
+-- > bvUDiv : (n : Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool;
 scBvUDiv :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvUDiv sc n x y = scGlobalApply sc "Prelude.bvUDiv" [n, x, y]
 
 -- | Create a term applying the bitvector (signed) modulus primitive.
 --
--- > bvSRem : (x : Nat) -> bitvector x -> bitvector x -> bitvector x;
+-- > bvSRem : (n : Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool;
 scBvSRem :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvSRem sc n x y = scGlobalApply sc "Prelude.bvSRem" [n, x, y]
 
 -- | Create a term applying the bitvector (signed) division primitive.
 --
--- > bvSDiv : (x : Nat) -> bitvector x -> bitvector x -> bitvector x;
+-- > bvSDiv : (n : Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool;
 scBvSDiv :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvSDiv sc n x y = scGlobalApply sc "Prelude.bvSDiv" [n, x, y]
 
 -- | Create a term applying the population count bitvector primitive.
 --
--- > bvPopcount : (x : Nat) -> bitvector n -> bitvector n;
+-- > bvPopcount : (n : Nat) -> Vec n Bool -> Vec n Bool;
 scBvPopcount :: SharedContext -> Term -> Term -> IO Term
 scBvPopcount sc n x = scGlobalApply sc "Prelude.bvPopcount" [n, x]
 
 -- | Create a term applying the leading zero counting bitvector primitive.
 --
--- > bvCountLeadingZeros : (x : Nat) -> bitvector n -> bitvector n;
+-- > bvCountLeadingZeros : (n : Nat) -> Vec n Bool -> Vec n Bool;
 scBvCountLeadingZeros :: SharedContext -> Term -> Term -> IO Term
 scBvCountLeadingZeros sc n x = scGlobalApply sc "Prelude.bvCountLeadingZeros" [n, x]
 
 -- | Create a term applying the trailing zero counting bitvector primitive.
 --
--- > bvCountTrailingZeros : (x : Nat) -> bitvector n -> bitvector n;
+-- > bvCountTrailingZeros : (n : Nat) -> Vec n Bool -> Vec n Bool;
 scBvCountTrailingZeros :: SharedContext -> Term -> Term -> IO Term
 scBvCountTrailingZeros sc n x = scGlobalApply sc "Prelude.bvCountTrailingZeros" [n, x]
 
 -- | Create a term applying the bit-wise and primitive.
 --
--- > bvAnd : (n : Nat) -> bitvector n -> bitvector n -> bitvector n;
+-- > bvAnd : (n : Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool;
 scBvAnd :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvAnd sc n x y = scGlobalApply sc "Prelude.bvAnd" [n, x, y]
 
 -- | Create a term applying the bit-wise xor primitive.
 --
--- > bvXor : (n : Nat) -> bitvector n -> bitvector n -> bitvector n;
+-- > bvXor : (n : Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool;
 scBvXor :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvXor sc n x y = scGlobalApply sc "Prelude.bvXor" [n, x, y]
 
 -- | Create a term applying the bit-wise or primitive.
 --
--- > bvOr : (n : Nat) -> bitvector n -> bitvector n -> bitvector n;
+-- > bvOr : (n : Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool;
 scBvOr :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvOr  sc n x y = scGlobalApply sc "Prelude.bvOr"  [n, x, y]
 
 -- | Create a term applying the bit-wise negation primitive.
 --
--- > bvNot : (n : Nat) -> bitvector n -> bitvector n;
+-- > bvNot : (n : Nat) -> Vec n Bool -> Vec n Bool;
 scBvNot :: SharedContext -> Term -> Term -> IO Term
 scBvNot sc n x = scGlobalApply sc "Prelude.bvNot" [n, x]
 
 -- | Create a term computing whether the two given bitvectors (of equal length)
 -- are equal.
 --
--- > bvEq : (n : Nat) -> bitvector n -> bitvector n -> Bool;
+-- > bvEq : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool;
 scBvEq :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvEq  sc n x y = scGlobalApply sc "Prelude.bvEq"  [n, x, y]
 
 -- | Create a term applying the bitvector (unsigned) greater-than-or-equal
 -- primitive.
 --
--- > bvuge : (n : Nat) -> bitvector n -> bitvector n -> Bool;
+-- > bvuge : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool;
 scBvUGe :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvUGe sc n x y = scGlobalApply sc "Prelude.bvuge" [n, x, y]
 
 -- | Create a term applying the bitvector (unsigned) less-than-or-equal
 -- primitive.
 --
--- > bvule : (n : Nat) -> bitvector n -> bitvector n -> Bool;
+-- > bvule : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool;
 scBvULe :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvULe sc n x y = scGlobalApply sc "Prelude.bvule" [n, x, y]
 
 -- | Create a term applying the bitvector (unsigned) greater-than primitive.
 --
--- > bvugt : (n : Nat) -> bitvector n -> bitvector n -> Bool;
+-- > bvugt : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool;
 scBvUGt :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvUGt sc n x y = scGlobalApply sc "Prelude.bvugt" [n, x, y]
 
 -- | Create a term applying the bitvector (unsigned) less-than primitive.
 --
--- > bvult : (n : Nat) -> bitvector n -> bitvector n -> Bool;
+-- > bvult : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool;
 scBvULt :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvULt sc n x y = scGlobalApply sc "Prelude.bvult" [n, x, y]
 
 -- | Create a term applying the bitvector (signed) greater-than-or-equal
 -- primitive.
 --
--- > bvsge : (n : Nat) -> bitvector n -> bitvector n -> Bool;
+-- > bvsge : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool;
 scBvSGe :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvSGe sc n x y = scGlobalApply sc "Prelude.bvsge" [n, x, y]
 
 -- | Create a term applying the bitvector (signed) less-than-or-equal
 -- primitive.
 --
--- > bvsle : (n : Nat) -> bitvector n -> bitvector n -> Bool;
+-- > bvsle : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool;
 scBvSLe :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvSLe sc n x y = scGlobalApply sc "Prelude.bvsle" [n, x, y]
 
 -- | Create a term applying the bitvector (signed) greater-than primitive.
 --
--- > bvsgt : (n : Nat) -> bitvector n -> bitvector n -> Bool;
+-- > bvsgt : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool;
 scBvSGt :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvSGt sc n x y = scGlobalApply sc "Prelude.bvsgt" [n, x, y]
 
 -- | Create a term applying the bitvector (signed) less-than primitive.
 --
--- > bvslt : (n : Nat) -> bitvector n -> bitvector n -> Bool;
+-- > bvslt : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool;
 scBvSLt :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvSLt sc n x y = scGlobalApply sc "Prelude.bvslt" [n, x, y]
 
 -- | Create a term applying the left-shift primitive.
 --
--- > bvShl : (n : Nat) -> bitvector n -> Nat -> bitvector n;
+-- > bvShl : (n : Nat) -> Vec n Bool -> Nat -> Vec n Bool;
 scBvShl :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvShl sc n x y = scGlobalApply sc "Prelude.bvShl" [n, x, y]
 
 -- | Create a term applying the logical right-shift primitive.
 --
--- > bvShr : (n : Nat) -> bitvector n -> Nat -> bitvector n;
+-- > bvShr : (n : Nat) -> Vec n Bool -> Nat -> Vec n Bool;
 scBvShr :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvShr sc n x y = scGlobalApply sc "Prelude.bvShr" [n, x, y]
 
 -- | Create a term applying the arithmetic/signed right-shift primitive.
 --
--- > bvSShr : (w : Nat) -> bitvector (Succ w) -> Nat -> bitvector (Succ w);
+-- > bvSShr : (w : Nat) -> Vec (Succ w) Bool -> Nat -> Vec (Succ w) Bool;
 scBvSShr :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvSShr sc n x y = scGlobalApply sc "Prelude.bvSShr" [n, x, y]
 
 -- | Create a term applying the unsigned bitvector extension primitive.
 --
--- > bvUExt : (x y : Nat) -> bitvector y -> bitvector (addNat x y);
+-- > bvUExt : (m n : Nat) -> Vec n Bool -> Vec (addNat m n) Bool;
 scBvUExt :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvUExt sc n m x = scGlobalApply sc "Prelude.bvUExt" [n,m,x]
 
 -- | Create a term applying the signed bitvector extension primitive.
 --
--- > bvSExt : (x y : Nat) -> bitvector (Succ y) -> bitvector (addNat x (Succ y));
+-- > bvSExt : (m n : Nat) -> Vec (Succ n) Bool -> Vec (addNat m (Succ n)) Bool;
 scBvSExt :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvSExt sc n m x = scGlobalApply sc "Prelude.bvSExt" [n,m,x]
 
 -- | Create a term applying the bitvector truncation primitive. Note that this
 -- truncates starting from the most significant bit.
 --
--- > bvTrunc : (x y : Nat) -> bitvector (addNat x y) -> bitvector y;
+-- > bvTrunc : (m n : Nat) -> Vec (addNat m n) Bool -> Vec n Bool;
 scBvTrunc :: SharedContext -> Term -> Term -> Term -> IO Term
 scBvTrunc sc n m x = scGlobalApply sc "Prelude.bvTrunc" [n,m,x]
 
@@ -1952,7 +1952,7 @@ scUpdNatFun sc a f i v = scGlobalApply sc "Prelude.updNatFun" [a, f, i, v]
 -- | Create a term applying the @updBvFun@ primitive, which has the same
 -- behavior as @updNatFun@ but acts on bitvectors.
 --
--- > updBvFun : (n::Nat) -> (a : sort 0) -> (bitvector n -> a) -> bitvector n -> a -> (bitvector n -> a);
+-- > updBvFun : (n : Nat) -> (a : sort 0) -> (Vec n Bool -> a) -> Vec n Bool -> a -> (Vec n Bool -> a);
 scUpdBvFun :: SharedContext -> Term -> Term
            -> Term -> Term -> Term -> IO Term
 scUpdBvFun sc n a f i v = scGlobalApply sc "Prelude.updBvFun" [n, a, f, i, v]

--- a/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
@@ -123,7 +123,7 @@ flattenBValue _ = error $ unwords ["Verifier.SAW.Simulator.Concrete.flattenBValu
 wordFun :: (BitVector -> CValue) -> CValue
 wordFun f = pureFun (\x -> f (toWord x))
 
--- | op :: (n :: Nat) -> bitvector n -> Nat -> bitvector n
+-- | op : (n : Nat) -> Vec n Bool -> Nat -> Vec n Bool
 bvShiftOp :: (BitVector -> Int -> BitVector) -> CValue
 bvShiftOp natOp =
   constFun $
@@ -271,19 +271,19 @@ constMap =
 
 ------------------------------------------------------------
 
--- primitive bvToNat :: (n::Nat) -> bitvector n -> Nat;
+-- primitive bvToNat : (n : Nat) -> Vec n Bool -> Nat;
 bvToNatOp :: CValue
 bvToNatOp = constFun $ wordFun $ VNat . fromInteger . unsigned
 
--- primitive bvToInt :: (n::Nat) -> bitvector n -> Integer;
+-- primitive bvToInt : (n : Nat) -> Vec n Bool -> Integer;
 bvToIntOp :: CValue
 bvToIntOp = constFun $ wordFun $ VInt . unsigned
 
--- primitive sbvToInt :: (n::Nat) -> bitvector n -> Integer;
+-- primitive sbvToInt : (n : Nat) -> Vec n Bool -> Integer;
 sbvToIntOp :: CValue
 sbvToIntOp = constFun $ wordFun $ VInt . signed
 
--- primitive intToBv :: (n::Nat) -> Integer -> bitvector n;
+-- primitive intToBv : (n : Nat) -> Integer -> Vec n Bool;
 intToBvOp :: CValue
 intToBvOp =
   Prims.natFun' "intToBv n" $ \n -> return $

--- a/saw-core/src/Verifier/SAW/Simulator/Prims.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Prims.hs
@@ -354,7 +354,7 @@ boolBinOp op =
   strictFun $ \x -> return $
   strictFun $ \y -> VBool <$> op (toBool x) (toBool y)
 
--- op :: (n :: Nat) -> bitvector n -> bitvector n;
+-- op : (n : Nat) -> Vec n Bool -> Vec n Bool;
 wordUnOp ::
   (VMonad l, Show (Extra l)) =>
   Pack l -> (VWord l -> MWord l) -> Value l
@@ -364,7 +364,7 @@ wordUnOp pack op =
   do xw <- toWord pack x
      VWord <$> op xw
 
--- op :: (n :: Nat) -> bitvector n -> bitvector n -> bitvector n;
+-- op : (n : Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool;
 wordBinOp ::
   (VMonad l, Show (Extra l)) =>
   Pack l -> (VWord l -> VWord l -> MWord l) -> Value l
@@ -376,7 +376,7 @@ wordBinOp pack op =
      yw <- toWord pack y
      VWord <$> op xw yw
 
--- op :: (n :: Nat) -> bitvector n -> bitvector n -> Bool;
+-- op : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool;
 wordBinRel ::
   (VMonad l, Show (Extra l)) =>
   Pack l -> (VWord l -> VWord l -> MBool l) -> Value l
@@ -407,14 +407,14 @@ selectV mux maxValue valueFn v = impl len 0
 ------------------------------------------------------------
 -- Values for common primitives
 
--- bvNat :: (n :: Nat) -> Nat -> bitvector n;
+-- bvNat : (n : Nat) -> Nat -> Vec n Bool;
 bvNatOp :: (VMonad l, Show (Extra l)) => BasePrims l -> Value l
 bvNatOp bp =
   natFun'' "bvNatOp1" $ \w -> return $
   natFun'' "bvNatOp2"  $ \x ->
   VWord <$> bpBvLit bp (fromIntegral w) (toInteger x) -- FIXME check for overflow on w
 
--- bvToNat :: (n :: Nat) -> bitvector n -> Nat;
+-- bvToNat : (n : Nat) -> Vec n Bool -> Nat;
 bvToNatOp :: VMonad l => Value l
 bvToNatOp = constFun $ pureFun VToNat
 
@@ -1187,7 +1187,7 @@ intToNatOp =
 natToIntOp :: (VMonad l, VInt l ~ Integer) => Value l
 natToIntOp = natFun' "natToInt" $ \x -> return $ VInt (toInteger x)
 
--- primitive bvLg2 :: (n :: Nat) -> bitvector n -> bitvector n;
+-- primitive bvLg2 : (n : Nat) -> Vec n Bool -> Vec n Bool;
 bvLg2Op :: VMonad l => (Value l -> MWord l) -> (VWord l -> MWord l) -> Value l
 bvLg2Op asWord wordLg2 =
   natFun' "bvLg2 1" $ \_n -> return $

--- a/saw-core/src/Verifier/SAW/Simulator/RME.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/RME.hs
@@ -118,7 +118,7 @@ genShift cond f x0 v = go x0 (V.toList v)
     go x [] = x
     go x (y : ys) = go (cond y (f x (2 ^ length ys)) x) ys
 
--- | op :: (w :: Nat) -> bitvector w -> Nat -> bitvector w;
+-- | op : (w : Nat) -> Vec w Bool -> Nat -> Vec w Bool;
 bvShiftOp :: (Vector RME -> Integer -> Vector RME) -> RValue
 bvShiftOp op =
   constFun $
@@ -256,15 +256,15 @@ constMap =
   , ("Prelude.expByNat", Prims.expByNatOp prims)
   ]
 
--- primitive bvToInt :: (n::Nat) -> bitvector n -> Integer;
+-- primitive bvToInt : (n : Nat) -> Vec n Bool -> Integer;
 bvToIntOp :: RValue
 bvToIntOp = unsupportedRMEPrimitive "bvToIntOp"
 
--- primitive sbvToInt :: (n::Nat) -> bitvector n -> Integer;
+-- primitive sbvToInt : (n : Nat) -> Vec n Bool -> Integer;
 sbvToIntOp :: RValue
 sbvToIntOp = unsupportedRMEPrimitive "sbvToIntOp"
 
--- primitive intToBv :: (n::Nat) -> Integer -> bitvector n;
+-- primitive intToBv : (n : Nat) -> Integer -> Vec n Bool;
 intToBvOp :: RValue
 intToBvOp =
   Prims.natFun' "intToBv n" $ \n -> return $

--- a/saw-core/tests/src/Tests/Rewriter.hs
+++ b/saw-core/tests/src/Tests/Rewriter.hs
@@ -38,7 +38,8 @@ prelude_bveq_sameL_test =
     let sc = rewritingSharedContext sc0 ss
     natType <- scMkTerm sc (mkDataType "Prelude.Nat" [] [])
     n <- scFreshGlobal sc "n" natType
-    bvType <- scMkTerm sc (mkGlobalDef "Prelude.bitvector" `mkApp` return n)
+    boolType <- scMkTerm sc (mkDataType "Prelude.Bool" [] [])
+    bvType <- scMkTerm sc (mkDataType "Prelude.Vec" [] [n, boolType])
     x <- scFreshGlobal sc "x" bvType
     z <- scFreshGlobal sc "z" bvType
     let lhs =


### PR DESCRIPTION
See https://github.com/GaloisInc/saw-script/issues/863#issuecomment-709484290