### PR TITLE
Refactor saw-core `Value` type to make a separate datatype for type values

### DIFF
--- a/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
@@ -1366,7 +1366,7 @@ asCryptolTypeValue v =
       t1 <- asCryptolTypeValue v1
       t2 <- asCryptolTypeValue v2
       return $ C.tArray t1 t2
-    SC.VVecType (SC.VNat n) v2 -> do
+    SC.VVecType n v2 -> do
       t2 <- asCryptolTypeValue v2
       return (C.tSeq (C.tNum n) t2)
     SC.VDataType "Prelude.Stream" [v1] -> do

--- a/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
@@ -1360,31 +1360,31 @@ pIsNeq ty = case C.tNoUser ty of
 asCryptolTypeValue :: SC.CValue -> Maybe C.Type
 asCryptolTypeValue v =
   case v of
-    SC.VBoolType -> return C.tBit
-    SC.VIntType -> return C.tInteger
-    SC.VArrayType v1 v2 -> do
+    SC.TValue SC.VBoolType -> return C.tBit
+    SC.TValue SC.VIntType -> return C.tInteger
+    SC.TValue (SC.VArrayType v1 v2) -> do
       t1 <- asCryptolTypeValue v1
       t2 <- asCryptolTypeValue v2
       return $ C.tArray t1 t2
-    SC.VVecType (SC.VNat n) v2 -> do
+    SC.TValue (SC.VVecType (SC.VNat n) v2) -> do
       t2 <- asCryptolTypeValue v2
       return (C.tSeq (C.tNum n) t2)
-    SC.VDataType "Prelude.Stream" [v1] -> do
+    SC.TValue (SC.VDataType "Prelude.Stream" [v1]) -> do
       t1 <- asCryptolTypeValue v1
       return (C.tSeq C.tInf t1)
-    SC.VUnitType -> return (C.tTuple [])
-    SC.VPairType v1 v2 -> do
+    SC.TValue SC.VUnitType -> return (C.tTuple [])
+    SC.TValue (SC.VPairType v1 v2) -> do
       t1 <- asCryptolTypeValue v1
       t2 <- asCryptolTypeValue v2
       case C.tIsTuple t2 of
         Just ts -> return (C.tTuple (t1 : ts))
         Nothing -> return (C.tTuple [t1, t2])
-    SC.VPiType v1 f -> do
+    SC.TValue (SC.VPiType v1 f) -> do
       case v1 of
         -- if we see that the parameter is a Cryptol.Num, it's a
         -- pretty good guess that it originally was a
         -- polymorphic number type.
-        SC.VDataType "Cryptol.Num" [] ->
+        SC.TValue (SC.VDataType "Cryptol.Num" []) ->
           let msg= unwords ["asCryptolTypeValue: can't infer a polymorphic Cryptol"
                            ,"type. Please, make sure all numeric types are"
                            ,"specialized before constructing a typed term."

--- a/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
+++ b/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
@@ -444,7 +444,7 @@ bitBlastBasic be m addlPrims ecMap t = do
   Sim.evalSharedTerm cfg t
 
 bitBlastExtCns ::
-  Map VarIndex (BValue (l s)) -> ExtCns (BValue (l s)) ->
+  Map VarIndex (BValue (l s)) -> ExtCns (TValue (BitBlast (l s))) ->
   IO (BValue (l s))
 bitBlastExtCns ecMap (EC idx name _v) =
   case Map.lookup idx ecMap of

--- a/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
+++ b/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
@@ -269,7 +269,7 @@ beConstMap be =
   , ("Prelude.bvToInt" , bvToIntOp be)
   , ("Prelude.sbvToInt", sbvToIntOp be)
   -- Integers mod n
-  , ("Prelude.IntMod"    , constFun VIntType)
+  , ("Prelude.IntMod"    , constFun (TValue VIntType))
   , ("Prelude.toIntMod"  , toIntModOp)
   , ("Prelude.fromIntMod", constFun (VFun force))
   , ("Prelude.intModEq"  , intModEqOp be)

--- a/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
+++ b/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
@@ -581,10 +581,10 @@ parseUninterpreted cws nm ty =
     VIntType
       -> return $ vInteger $ mkUninterpreted KUnbounded cws nm
 
-    (VVecType (VNat n) VBoolType)
+    (VVecType n VBoolType)
       -> return $ vWord $ mkUninterpreted (KBounded False (fromIntegral n)) cws nm
 
-    (VVecType (VNat n) ety)
+    (VVecType n ety)
       -> do xs <- sequence $
                   [ parseUninterpreted cws (nm ++ "@" ++ show i) ety
                   | i <- [0 .. n-1] ]
@@ -627,7 +627,7 @@ vAsFirstOrderType v =
       -> return FOTBit
     VIntType
       -> return FOTInt
-    VVecType (VNat n) v2
+    VVecType n v2
       -> FOTVec n <$> vAsFirstOrderType v2
     VUnitType
       -> return (FOTTuple [])

--- a/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
+++ b/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
@@ -196,7 +196,7 @@ constMap =
   , ("Prelude.bvToInt" , bvToIntOp)
   , ("Prelude.sbvToInt", sbvToIntOp)
   -- Integers mod n
-  , ("Prelude.IntMod"    , constFun VIntType)
+  , ("Prelude.IntMod"    , constFun (TValue VIntType))
   , ("Prelude.toIntMod"  , constFun (VFun force))
   , ("Prelude.fromIntMod", fromIntModOp)
   , ("Prelude.intModEq"  , intModEqOp)
@@ -568,37 +568,37 @@ sbvSolveBasic m addlPrims unints t = do
 parseUninterpreted :: [SVal] -> String -> SValue -> IO SValue
 parseUninterpreted cws nm ty =
   case ty of
-    (VPiType _ f)
+    TValue (VPiType _ f)
       -> return $
          strictFun $ \x -> do
            (cws', suffix) <- flattenSValue x
            t2 <- f (ready x)
            parseUninterpreted (cws ++ cws') (nm ++ suffix) t2
 
-    VBoolType
+    TValue VBoolType
       -> return $ vBool $ mkUninterpreted KBool cws nm
 
-    VIntType
+    TValue VIntType
       -> return $ vInteger $ mkUninterpreted KUnbounded cws nm
 
-    (VVecType (VNat n) VBoolType)
+    TValue (VVecType (VNat n) (TValue VBoolType))
       -> return $ vWord $ mkUninterpreted (KBounded False (fromIntegral n)) cws nm
 
-    (VVecType (VNat n) ety)
+    TValue (VVecType (VNat n) ety)
       -> do xs <- sequence $
                   [ parseUninterpreted cws (nm ++ "@" ++ show i) ety
                   | i <- [0 .. n-1] ]
             return (VVector (V.fromList (map ready xs)))
 
-    VUnitType
+    TValue VUnitType
       -> return VUnit
 
-    (VPairType ty1 ty2)
+    TValue (VPairType ty1 ty2)
       -> do x1 <- parseUninterpreted cws (nm ++ ".L") ty1
             x2 <- parseUninterpreted cws (nm ++ ".R") ty2
             return (VPair (ready x1) (ready x2))
 
-    (VRecordType elem_tps)
+    TValue (VRecordType elem_tps)
       -> (VRecordValue <$>
           mapM (\(f,tp) ->
                  (f,) <$> ready <$>
@@ -613,8 +613,8 @@ mkUninterpreted k args nm = svUninterpreted k nm' Nothing args
 asPredType :: SValue -> IO [SValue]
 asPredType v =
   case v of
-    VBoolType -> return []
-    VPiType v1 f ->
+    TValue VBoolType -> return []
+    TValue (VPiType v1 f) ->
       do v2 <- f (error "asPredType: unsupported dependent SAW-Core type")
          vs <- asPredType v2
          return (v1 : vs)
@@ -623,22 +623,22 @@ asPredType v =
 vAsFirstOrderType :: SValue -> Maybe FirstOrderType
 vAsFirstOrderType v =
   case v of
-    VBoolType
+    TValue VBoolType
       -> return FOTBit
-    VIntType
+    TValue VIntType
       -> return FOTInt
-    VVecType (VNat n) v2
+    TValue (VVecType (VNat n) v2)
       -> FOTVec n <$> vAsFirstOrderType v2
-    VUnitType
+    TValue VUnitType
       -> return (FOTTuple [])
-    VPairType v1 v2
+    TValue (VPairType v1 v2)
       -> do t1 <- vAsFirstOrderType v1
             t2 <- vAsFirstOrderType v2
             case t2 of
               FOTTuple ts -> return (FOTTuple (t1 : ts))
               _ -> return (FOTTuple [t1, t2])
 
-    VRecordType tps
+    TValue (VRecordType tps)
       -> (FOTRec <$> Map.fromList <$>
           mapM (\(f,tp) -> (f,) <$> vAsFirstOrderType tp) tps)
     _ -> Nothing

--- a/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
+++ b/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
@@ -734,14 +734,14 @@ parseUninterpreted sym ref app ty =
       -> VInt  <$> mkUninterpreted sym ref app BaseIntegerRepr
 
     -- 0 width bitvector is a constant
-    VVecType (VNat 0) VBoolType
+    VVecType 0 VBoolType
       -> return $ VWord ZBV
 
-    VVecType (VNat n) VBoolType
+    VVecType n VBoolType
       | Just (Some (PosNat w)) <- somePosNat n
       -> (VWord . DBV) <$> mkUninterpreted sym ref app (BaseBVRepr w)
 
-    VVecType (VNat n) ety
+    VVecType n ety
       ->  do xs <- sequence $
                   [ parseUninterpreted sym ref (suffixUnintApp ("_a" ++ show i) app) ety
                   | i <- [0 .. n-1] ]
@@ -895,7 +895,7 @@ vAsFirstOrderType v =
       -> return FOTBit
     VIntType
       -> return FOTInt
-    VVecType (VNat n) v2
+    VVecType n v2
       -> FOTVec n <$> vAsFirstOrderType v2
     VArrayType iv ev
       -> FOTArray <$> vAsFirstOrderType iv <*> vAsFirstOrderType ev
@@ -1102,14 +1102,14 @@ parseUninterpretedSAW sym sc ref trm app ty =
       -> VInt  <$> mkUninterpretedSAW sym ref trm app BaseIntegerRepr
 
     -- 0 width bitvector is a constant
-    VVecType (VNat 0) VBoolType
+    VVecType 0 VBoolType
       -> return $ VWord ZBV
 
-    VVecType (VNat n) VBoolType
+    VVecType n VBoolType
       | Just (Some (PosNat w)) <- somePosNat n
       -> (VWord . DBV) <$> mkUninterpretedSAW sym ref trm app (BaseBVRepr w)
 
-    VVecType (VNat n) ety | n >= 0
+    VVecType n ety | n >= 0
       ->  do ety' <- termOfTValue sc ety
              let mkElem i =
                    do let trm' = ArgTermAt n ety' trm i
@@ -1273,7 +1273,7 @@ termOfTValue sc val =
     VBoolType -> scBoolType sc
     VIntType -> scIntegerType sc
     VUnitType -> scUnitType sc
-    VVecType (VNat n) a ->
+    VVecType n a ->
       do n' <- scNat sc n
          a' <- termOfTValue sc a
          scVecType sc n' a'

--- a/saw-core/src/Verifier/SAW/Simulator.hs
+++ b/saw-core/src/Verifier/SAW/Simulator.hs
@@ -166,7 +166,7 @@ evalTermF cfg lam recEval tf env =
         RecordValue elems   ->
           VRecordValue <$> mapM (\(fld,t) -> (fld,) <$> recEvalDelay t) elems
         RecordProj t fld    -> recEval t >>= flip valRecordProj fld
-        Sort {}             -> return $ TValue VType
+        Sort s              -> return $ TValue (VSort s)
         NatLit n            -> return $ VNat n
         ArrayValue _ tv     -> liftM VVector $ mapM recEvalDelay tv
         StringLit s         -> return $ VString s

--- a/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
@@ -16,7 +16,7 @@ Portability : non-portable (language extensions)
 
 module Verifier.SAW.Simulator.Concrete
        ( evalSharedTerm
-       , CValue, Value(..), TValue(..)
+       , CValue, Concrete, Value(..), TValue(..), toTValue
        , CExtra(..)
        , toBool
        , toWord

--- a/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
@@ -16,7 +16,7 @@ Portability : non-portable (language extensions)
 
 module Verifier.SAW.Simulator.Concrete
        ( evalSharedTerm
-       , CValue, Value(..)
+       , CValue, Value(..), TValue(..)
        , CExtra(..)
        , toBool
        , toWord
@@ -253,7 +253,7 @@ constMap =
   , ("Prelude.bvToInt" , bvToIntOp)
   , ("Prelude.sbvToInt", sbvToIntOp)
   -- Integers mod n
-  , ("Prelude.IntMod"    , constFun VIntType)
+  , ("Prelude.IntMod"    , constFun (TValue VIntType))
   , ("Prelude.toIntMod"  , toIntModOp)
   , ("Prelude.fromIntMod", constFun (VFun force))
   , ("Prelude.intModEq"  , intModEqOp)

--- a/saw-core/src/Verifier/SAW/Simulator/Prims.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Prims.hs
@@ -125,7 +125,7 @@ data BasePrims l =
   , bpIntMin :: VInt l -> VInt l -> MInt l
   , bpIntMax :: VInt l -> VInt l -> MInt l
     -- Array operations
-  , bpArrayConstant :: Value l -> Value l -> MArray l
+  , bpArrayConstant :: TValue l -> Value l -> MArray l
   , bpArrayLookup :: VArray l -> Value l -> MValue l
   , bpArrayUpdate :: VArray l -> Value l -> Value l -> MArray l
   , bpArrayEq :: VArray l -> VArray l -> MBool l
@@ -577,7 +577,7 @@ natCaseOp =
 
 -- Vec :: (n :: Nat) -> (a :: sort 0) -> sort 0;
 vecTypeOp :: VMonad l => Value l
-vecTypeOp = pureFun $ \n -> pureFun $ \a -> TValue (VVecType n a)
+vecTypeOp = pureFun $ \n -> pureFun $ \a -> TValue (VVecType n (toTValue a))
 
 -- gen :: (n :: Nat) -> (a :: sort 0) -> (Nat -> a) -> Vec n a;
 genOp :: (VMonadLazy l, Show (Extra l)) => Value l
@@ -1296,7 +1296,7 @@ fixOp =
 
 -- Array :: sort 0 -> sort 0 -> sort 0
 arrayTypeOp :: VMonad l => Value l
-arrayTypeOp = pureFun $ \a -> pureFun $ \b -> TValue (VArrayType a b)
+arrayTypeOp = pureFun $ \a -> pureFun $ \b -> TValue (VArrayType (toTValue a) (toTValue b))
 
 -- arrayConstant :: (a b :: sort 0) -> b -> (Array a b);
 arrayConstantOp :: VMonad l => BasePrims l -> Value l
@@ -1304,7 +1304,7 @@ arrayConstantOp bp =
   pureFun $ \a ->
   constFun $
   strictFun $ \e ->
-    VArray <$> (bpArrayConstant bp) a e
+    VArray <$> (bpArrayConstant bp) (toTValue a) e
 
 -- arrayLookup :: (a b :: sort 0) -> (Array a b) -> a -> b;
 arrayLookupOp :: (VMonad l, Show (Extra l)) => BasePrims l -> Value l

--- a/saw-core/src/Verifier/SAW/Simulator/Prims.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Prims.hs
@@ -577,7 +577,9 @@ natCaseOp =
 
 -- Vec :: (n :: Nat) -> (a :: sort 0) -> sort 0;
 vecTypeOp :: VMonad l => Value l
-vecTypeOp = pureFun $ \n -> pureFun $ \a -> TValue (VVecType n (toTValue a))
+vecTypeOp =
+  natFun' "VecType" $ \n -> return $
+  pureFun $ \a -> TValue (VVecType n (toTValue a))
 
 -- gen :: (n :: Nat) -> (a :: sort 0) -> (Nat -> a) -> Vec n a;
 genOp :: (VMonadLazy l, Show (Extra l)) => Value l

--- a/saw-core/src/Verifier/SAW/Simulator/Prims.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Prims.hs
@@ -1264,7 +1264,7 @@ muxValue bp b = value
       ++ show x ++ " " ++ show y
 
     tvalue :: TValue l -> TValue l -> EvalM l (TValue l)
-    tvalue VType             VType             = return VType
+    tvalue (VSort x)         (VSort y)         | x == y = return $ VSort y
     tvalue x                 y                 =
       panic $ "Verifier.SAW.Simulator.Prims.iteOp: malformed arguments: "
       ++ show x ++ " " ++ show y

--- a/saw-core/src/Verifier/SAW/Simulator/RME.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/RME.hs
@@ -240,7 +240,7 @@ constMap =
   , ("Prelude.bvToInt" , bvToIntOp)
   , ("Prelude.sbvToInt", sbvToIntOp)
   -- Integers mod n
-  , ("Prelude.IntMod"    , constFun VIntType)
+  , ("Prelude.IntMod"    , constFun (TValue VIntType))
   , ("Prelude.toIntMod"  , toIntModOp)
   , ("Prelude.fromIntMod", constFun (VFun force))
   , ("Prelude.intModEq"  , intModEqOp)

--- a/saw-core/src/Verifier/SAW/Simulator/Value.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Value.hs
@@ -75,7 +75,7 @@ data TValue l
   | VPairType !(TValue l) !(TValue l)
   | VDataType !Ident ![Value l]
   | VRecordType ![(String, TValue l)]
-  | VType -- ^ Other unknown type
+  | VSort !Sort
 
 type Thunk l = Lazy (EvalM l) (Value l)
 
@@ -185,7 +185,7 @@ instance Show (Extra l) => Show (TValue l) where
         showString "{" . showString fld . showString " :: _, ...}"
       VVecType n a   -> showString "Vec " . shows n
                         . showString " " . showParen True (showsPrec p a)
-      VType          -> showString "_"
+      VSort s        -> shows s
 
 data Nil = Nil
 

--- a/saw-core/src/Verifier/SAW/Simulator/Value.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Value.hs
@@ -66,7 +66,7 @@ data Value l
 
 -- | The subset of values that represent types.
 data TValue l
-  = VVecType !(Value l) !(TValue l)
+  = VVecType !Natural !(TValue l)
   | VBoolType
   | VIntType
   | VArrayType !(TValue l) !(TValue l)
@@ -183,7 +183,7 @@ instance Show (Extra l) => Show (TValue l) where
       VRecordType [] -> showString "{}"
       VRecordType ((fld,_):_) ->
         showString "{" . showString fld . showString " :: _, ...}"
-      VVecType n a   -> showString "Vec " . showParen True (showsPrec p n)
+      VVecType n a   -> showString "Vec " . shows n
                         . showString " " . showParen True (showsPrec p a)
       VType          -> showString "_"
 
@@ -245,7 +245,7 @@ asFiniteTypeTValue :: TValue l -> Maybe FiniteType
 asFiniteTypeTValue v =
   case v of
     VBoolType -> return FTBit
-    VVecType (VNat n) v1 -> do
+    VVecType n v1 -> do
       t1 <- asFiniteTypeTValue v1
       return (FTVec n t1)
     VUnitType -> return (FTTuple [])

--- a/saw-core/src/Verifier/SAW/Simulator/Value.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Value.hs
@@ -51,27 +51,31 @@ data Value l
   | VPair (Thunk l) (Thunk l) -- TODO: should second component be strict?
   | VCtorApp !Ident !(Vector (Thunk l))
   | VVector !(Vector (Thunk l))
-  | VVecType (Value l) (Value l)
   | VBool (VBool l)
-  | VBoolType
   | VWord (VWord l)
   | VToNat (Value l)
   | VNat !Natural
   | VInt (VInt l)
-  | VIntType
   | VArray (VArray l)
-  | VArrayType (Value l) (Value l)
   | VString !String
   | VFloat !Float
   | VDouble !Double
+  | VRecordValue ![(String, Thunk l)]
+  | VExtra (Extra l)
+  | TValue (TValue l)
+
+-- | The subset of values that represent types.
+data TValue l
+  = VVecType (Value l) (Value l)
+  | VBoolType
+  | VIntType
+  | VArrayType (Value l) (Value l)
   | VPiType !(Value l) !(Thunk l -> MValue l)
   | VUnitType
   | VPairType (Value l) (Value l)
   | VDataType !Ident [Value l]
   | VRecordType ![(String, Value l)]
-  | VRecordValue ![(String, Thunk l)]
   | VType -- ^ Other unknown type
-  | VExtra (Extra l)
 
 type Thunk l = Lazy (EvalM l) (Value l)
 
@@ -143,17 +147,28 @@ instance Show (Extra l) => Show (Value l) where
         | otherwise  -> shows s . showList (toList xv)
       VVector xv     -> showList (toList xv)
       VBool _        -> showString "<<boolean>>"
-      VBoolType      -> showString "Bool"
       VWord _        -> showString "<<bitvector>>"
       VToNat x       -> showString "bvToNat " . showParen True (shows x)
       VNat n         -> shows n
       VInt _         -> showString "<<integer>>"
-      VIntType       -> showString "Integer"
       VArray{}       -> showString "<<array>>"
-      VArrayType{}   -> showString "Array"
       VFloat float   -> shows float
       VDouble double -> shows double
       VString s      -> shows s
+      VRecordValue [] -> showString "{}"
+      VRecordValue ((fld,_):_) ->
+        showString "{" . showString fld . showString " = _, ...}"
+      VExtra x       -> showsPrec p x
+      TValue x       -> showsPrec p x
+    where
+      toList = map (const Nil) . V.toList
+
+instance Show (Extra l) => Show (TValue l) where
+  showsPrec p v =
+    case v of
+      VBoolType      -> showString "Bool"
+      VIntType       -> showString "Integer"
+      VArrayType{}   -> showString "Array"
       VPiType t _    -> showParen True
                         (shows t . showString " -> ...")
       VUnitType      -> showString "#()"
@@ -164,15 +179,9 @@ instance Show (Extra l) => Show (Value l) where
       VRecordType [] -> showString "{}"
       VRecordType ((fld,_):_) ->
         showString "{" . showString fld . showString " :: _, ...}"
-      VRecordValue [] -> showString "{}"
-      VRecordValue ((fld,_):_) ->
-        showString "{" . showString fld . showString " = _, ...}"
       VVecType n a   -> showString "Vec " . showParen True (showsPrec p n)
                         . showString " " . showParen True (showsPrec p a)
       VType          -> showString "_"
-      VExtra x       -> showsPrec p x
-    where
-      toList = map (const Nil) . V.toList
 
 data Nil = Nil
 
@@ -189,9 +198,9 @@ vTuple [x, y] = VPair x y
 vTuple (x : xs) = VPair x (ready (vTuple xs))
 
 vTupleType :: VMonad l => [Value l] -> Value l
-vTupleType [] = VUnitType
+vTupleType [] = TValue VUnitType
 vTupleType [t] = t
-vTupleType (t : ts) = VPairType t (vTupleType ts)
+vTupleType (t : ts) = TValue (VPairType t (vTupleType ts))
 
 valPairLeft :: (VMonad l, Show (Extra l)) => Value l -> MValue l
 valPairLeft (VPair t1 _) = force t1
@@ -216,7 +225,7 @@ valRecordProj v _ =
 
 apply :: (VMonad l, Show (Extra l)) => Value l -> Thunk l -> MValue l
 apply (VFun f) x = f x
-apply (VPiType _ f) x = f x
+apply (TValue (VPiType _ f)) x = f x
 apply v _x = panic "Verifier.SAW.Simulator.Value.apply" ["Not a function value:", show v]
 
 applyAll :: (VMonad l, Show (Extra l)) => Value l -> [Thunk l] -> MValue l
@@ -225,18 +234,18 @@ applyAll = foldM apply
 asFiniteTypeValue :: Value l -> Maybe FiniteType
 asFiniteTypeValue v =
   case v of
-    VBoolType -> return FTBit
-    VVecType (VNat n) v1 -> do
+    TValue VBoolType -> return FTBit
+    TValue (VVecType (VNat n) v1) -> do
       t1 <- asFiniteTypeValue v1
       return (FTVec n t1)
-    VUnitType -> return (FTTuple [])
-    VPairType v1 v2 -> do
+    TValue VUnitType -> return (FTTuple [])
+    TValue (VPairType v1 v2) -> do
       t1 <- asFiniteTypeValue v1
       t2 <- asFiniteTypeValue v2
       case t2 of
         FTTuple ts -> return (FTTuple (t1 : ts))
         _ -> return (FTTuple [t1, t2])
-    VRecordType elem_tps ->
+    TValue (VRecordType elem_tps) ->
       FTRec <$> Map.fromList <$>
       mapM (\(fld,tp) -> (fld,) <$> asFiniteTypeValue tp) elem_tps
     _ -> Nothing

--- a/saw-core/src/Verifier/SAW/Testing/Random.hs
+++ b/saw-core/src/Verifier/SAW/Testing/Random.hs
@@ -21,7 +21,7 @@ import Verifier.SAW.Recognizer (asBoolType, asPi, asEq)
 import Verifier.SAW.SharedTerm
   (scApplyAll, scGetModuleMap, scWhnf, SharedContext, Term)
 import Verifier.SAW.Simulator.Concrete (evalSharedTerm, CValue)
-import Verifier.SAW.Simulator.Value (Value(..))
+import Verifier.SAW.Simulator.Value (Value(..), TValue(..))
 import Verifier.SAW.TypedAST (FieldName)
 import Verifier.SAW.Utils (panic)
 
@@ -78,7 +78,7 @@ scRunTest sc fun gens = do
     VBool True -> return $ Nothing
     VBool False -> do
       return $ Just xs
-    VDataType "Prelude.Eq" [VBoolType, VBool x, VBool y] -> do
+    TValue (VDataType "Prelude.Eq" [TValue VBoolType, VBool x, VBool y]) -> do
       return $ if x == y then Nothing else Just xs
     _ -> panic "Type error while running test"
          [ "Expected a boolean, but got:"


### PR DESCRIPTION
The saw-core `Value` constructors that represent type values (such as `VBoolType`, `VIntType`, `VVecType`, `VPairType`, `VPiType`, etc.) are now split into their own separate datatype `TValue`. This means that functions with `Value` arguments that are expected to be types can use the more precise `TValue` datatype.