### PR TITLE
Fix implementation of `fromIntMod` in concrete evaluation backend.

### DIFF
--- a/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
@@ -254,7 +254,7 @@ constMap =
   , ("Prelude.sbvToInt", sbvToIntOp)
   -- Integers mod n
   , ("Prelude.toIntMod"  , toIntModOp)
-  , ("Prelude.fromIntMod", constFun (VFun force))
+  , ("Prelude.fromIntMod", fromIntModOp)
   , ("Prelude.intModEq"  , intModEqOp)
   , ("Prelude.intModAdd" , intModBinOp (+))
   , ("Prelude.intModSub" , intModBinOp (-))
@@ -319,6 +319,12 @@ toIntModOp =
   Prims.natFun $ \n -> return $
   Prims.intFun "toIntModOp" $ \x -> return $
   VIntMod n (x `mod` toInteger n)
+
+fromIntModOp :: CValue
+fromIntModOp =
+  constFun $
+  Prims.intModFun "fromIntModOp" $ \x -> pure $
+  VInt x
 
 intModEqOp :: CValue
 intModEqOp =


### PR DESCRIPTION
It had been broken since #93 introduced a separate value constructor
for the `IntMod` type.

(GaloisInc/saw-script#936)