### PR TITLE
Fix reference primitives.

### DIFF
--- a/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
@@ -617,7 +617,8 @@ importPrimitive sc env n sch
   | Just nm <- C.asPrim n, Just expr <- Map.lookup nm (envRefPrims env) =
       do t <- importSchema sc env sch
          e <- importExpr sc env expr
-         scConstant sc (nameToString n) e t
+         nmi <- importName n
+         scConstant' sc nmi e t
   | Just nm <- C.asPrim n = panic "Unknown Cryptol primitive name" [show nm]
   | otherwise = panic "Improper Cryptol primitive name" [show n]
 


### PR DESCRIPTION
Current error:
```
Ambiguous name "pmult" might refer to any of the following:
"pmult#29"
"Cryptol::Reference::pmult"
```