### PR TITLE
Text fieldname

### DIFF
--- a/cryptol-saw-core/src/Verifier/SAW/TypedTerm.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/TypedTerm.hs
@@ -14,7 +14,7 @@ import qualified Data.Map as Map
 import Cryptol.ModuleSystem.Name (nameIdent)
 import qualified Cryptol.TypeCheck.AST as C
 import Cryptol.Utils.PP (pretty)
-import qualified Cryptol.Utils.Ident as C (packIdent)
+import qualified Cryptol.Utils.Ident as C (mkIdent)
 import qualified Cryptol.Utils.RecordMap as C (recordFromFields)
 
 import Verifier.SAW.Cryptol (scCryptolType)
@@ -106,7 +106,7 @@ cryptolTypeOfFirstOrderType fot =
     FOTRec m ->
       C.tRec $
       C.recordFromFields $
-      [ (C.packIdent l, cryptolTypeOfFirstOrderType t)
+      [ (C.mkIdent l, cryptolTypeOfFirstOrderType t)
       | (l, t) <- Map.assocs m ]
 
 typedTermOfFirstOrderValue :: SharedContext -> FirstOrderValue -> IO TypedTerm

--- a/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
+++ b/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
@@ -699,7 +699,7 @@ nextId = ST.get >>= (\s-> modify (+1) >> return ("x" ++ show s))
 --unzipMap :: Map k (a, b) -> (Map k a, Map k b)
 --unzipMap m = (fmap fst m, fmap snd m)
 
-myfun ::(Map String (Labeler, Symbolic SValue)) -> (Map String Labeler, Map String (Symbolic SValue))
+myfun ::(Map FieldName (Labeler, Symbolic SValue)) -> (Map FieldName Labeler, Map FieldName (Symbolic SValue))
 myfun = fmap fst A.&&& fmap snd
 
 newVarsForType :: TValue SBV -> String -> StateT Int IO (Maybe Labeler, Symbolic SValue)
@@ -728,8 +728,8 @@ newVars (FOTTuple ts) = do
   (labels, vals) <- V.unzip <$> traverse newVars (V.fromList ts)
   return (TupleLabel labels, vTuple <$> traverse (fmap ready) (V.toList vals))
 newVars (FOTRec tm) = do
-  (labels, vals) <- myfun <$> (traverse newVars tm :: StateT Int IO (Map String (Labeler, Symbolic SValue)))
-  return (RecLabel labels, vRecord <$> traverse (fmap ready) (vals :: (Map String (Symbolic SValue))))
+  (labels, vals) <- myfun <$> (traverse newVars tm :: StateT Int IO (Map FieldName (Labeler, Symbolic SValue)))
+  return (RecLabel labels, vRecord <$> traverse (fmap ready) (vals :: (Map FieldName (Symbolic SValue))))
 
 ------------------------------------------------------------
 -- Code Generation

--- a/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
+++ b/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
@@ -618,7 +618,7 @@ parseUninterpreted cws nm ty =
       -> (VRecordValue <$>
           mapM (\(f,tp) ->
                  (f,) <$> ready <$>
-                 parseUninterpreted cws (nm ++ "." ++ f) tp) elem_tps)
+                 parseUninterpreted cws (nm ++ "." ++ Text.unpack f) tp) elem_tps)
 
     _ -> fail $ "could not create uninterpreted type for " ++ show ty
 

--- a/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
+++ b/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
@@ -994,7 +994,7 @@ newVarsForType ref v nm =
          return (Nothing, sv)
   where sym = given :: sym
 
-myfun ::(Map String (Labeler sym, SValue sym)) -> (Map String (Labeler sym), Map String (SValue sym))
+myfun ::(Map FieldName (Labeler sym, SValue sym)) -> (Map FieldName (Labeler sym), Map FieldName (SValue sym))
 myfun = fmap fst A.&&& fmap snd
 
 data Labeler sym
@@ -1021,7 +1021,7 @@ newVarFOT (FOTVec n tp)
 
 newVarFOT (FOTRec tm)
   = do (labels, vals) <- myfun <$> traverse newVarFOT tm
-       args <- traverse (return . ready) (vals :: (Map String (SValue sym)))
+       args <- traverse (return . ready) (vals :: (Map FieldName (SValue sym)))
        return (RecLabel labels, vRecord args)
 
 newVarFOT (FOTIntMod n)
@@ -1258,7 +1258,7 @@ data ArgTerm
   | ArgTermVector Term [ArgTerm] -- ^ element type, elements
   | ArgTermUnit
   | ArgTermPair ArgTerm ArgTerm
-  | ArgTermRecord [(String, ArgTerm)]
+  | ArgTermRecord [(FieldName, ArgTerm)]
   | ArgTermConst Term
   | ArgTermApply ArgTerm ArgTerm
   | ArgTermAt Natural Term ArgTerm Natural

--- a/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
+++ b/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
@@ -779,7 +779,7 @@ parseUninterpreted sym ref app ty =
       -> (VRecordValue <$>
           mapM (\(f,tp) ->
                  (f,) <$> ready <$>
-                 parseUninterpreted sym ref (suffixUnintApp ("_" ++ f) app) tp) elem_tps)
+                 parseUninterpreted sym ref (suffixUnintApp ("_" ++ Text.unpack f) app) tp) elem_tps)
 
     _ -> fail $ "could not create uninterpreted symbol of type " ++ show ty
 

--- a/saw-core/src/Verifier/SAW/ExternalFormat.hs
+++ b/saw-core/src/Verifier/SAW/ExternalFormat.hs
@@ -149,7 +149,7 @@ scWriteExternal t0 =
                        map show ixs ++ [show e])
             RecordType elem_tps -> pure $ unwords ["RecordType", show elem_tps]
             RecordValue elems   -> pure $ unwords ["Record", show elems]
-            RecordProj e prj    -> pure $ unwords ["RecordProj", show e, prj]
+            RecordProj e prj    -> pure $ unwords ["RecordProj", show e, Text.unpack prj]
             Sort s              -> pure $
               if s == propSort then unwords ["Prop"] else
                 unwords ["Sort", drop 5 (show s)] -- Ugly hack to drop "sort "
@@ -254,7 +254,7 @@ scReadExternal sc input =
           FTermF <$> (RecordType <$> (traverse (traverse getTerm) =<< readM elem_tps))
         ["Record", elems] ->
           FTermF <$> (RecordValue <$> (traverse (traverse getTerm) =<< readM elems))
-        ["RecordProj", e, prj] -> FTermF <$> (RecordProj <$> readIdx e <*> pure prj)
+        ["RecordProj", e, prj] -> FTermF <$> (RecordProj <$> readIdx e <*> pure (Text.pack prj))
         ["Prop"]            -> pure $ FTermF (Sort propSort)
         ["Sort", s]         -> FTermF <$> (Sort <$> (mkSort <$> readM s))
         ["Nat", n]          -> FTermF <$> (NatLit <$> readM n)

--- a/saw-core/src/Verifier/SAW/FiniteValue.hs
+++ b/saw-core/src/Verifier/SAW/FiniteValue.hs
@@ -18,6 +18,7 @@ import qualified Control.Monad.State as S
 import Data.List (intersperse)
 import Data.Map (Map)
 import qualified Data.Map as Map
+import qualified Data.Text as Text
 import Numeric.Natural (Natural)
 
 import Prettyprinter hiding (Doc)
@@ -100,7 +101,7 @@ instance Show FirstOrderValue where
       FOVRec vm   -> showString "{" . commaSep (map showField (Map.assocs vm)) . showString "}"
     where
       commaSep ss = foldr (.) id (intersperse (showString ",") ss)
-      showField (field, v) = showString field . showString " = " . shows v
+      showField (field, v) = showString (Text.unpack field) . showString " = " . shows v
 
 ppFiniteValue :: PPOpts -> FiniteValue -> SawDoc
 ppFiniteValue opts fv = ppFirstOrderValue opts (toFirstOrderValue fv)

--- a/saw-core/src/Verifier/SAW/Grammar.y
+++ b/saw-core/src/Verifier/SAW/Grammar.y
@@ -191,10 +191,10 @@ Ident : ident { fmap tokIdent $1 }
 IdentRec :: { PosPair String }
 IdentRec : identrec { fmap tokRecursor $1 }
 
-FieldValue :: { (PosPair String, Term) }
+FieldValue :: { (PosPair FieldName, Term) }
 FieldValue : Ident '=' Term { ($1, $3) }
 
-FieldType :: { (PosPair String, Term) }
+FieldType :: { (PosPair FieldName, Term) }
 FieldType : Ident ':' LTerm { ($1, $3) }
 
 opt(q) :: { Maybe q }

--- a/saw-core/src/Verifier/SAW/SharedTerm.hs
+++ b/saw-core/src/Verifier/SAW/SharedTerm.hs
@@ -740,7 +740,7 @@ scReduceRecursor sc d params p_ret cs_fs c args =
 -- | An elimination for 'scWhnf'
 data WHNFElim
   = ElimApp Term
-  | ElimProj String
+  | ElimProj FieldName
   | ElimPair Bool
   | ElimRecursor Ident [Term] Term [(Ident,Term)] [Term]
 
@@ -1268,9 +1268,9 @@ scRecordSelect :: SharedContext -> Term -> FieldName -> IO Term
 scRecordSelect sc t fname = scFlatTermF sc (RecordProj t fname)
 
 -- | Create a term representing the type of a record from a list associating
--- field names (as 'String's) and types (as 'Term's). Note that the order of
+-- field names (as 'FieldName's) and types (as 'Term's). Note that the order of
 -- the given list is irrelevant, as record fields are not ordered.
-scRecordType :: SharedContext -> [(String,Term)] -> IO Term
+scRecordType :: SharedContext -> [(FieldName, Term)] -> IO Term
 scRecordType sc elem_tps = scFlatTermF sc (RecordType elem_tps)
 
 -- | Create a unit-valued term.

--- a/saw-core/src/Verifier/SAW/Simulator/Value.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Value.hs
@@ -61,7 +61,7 @@ data Value l
   | VString !String
   | VFloat !Float
   | VDouble !Double
-  | VRecordValue ![(String, Thunk l)]
+  | VRecordValue ![(FieldName, Thunk l)]
   | VExtra (Extra l)
   | TValue (TValue l)
 
@@ -76,7 +76,7 @@ data TValue l
   | VUnitType
   | VPairType !(TValue l) !(TValue l)
   | VDataType !Ident ![Value l]
-  | VRecordType ![(String, TValue l)]
+  | VRecordType ![(FieldName, TValue l)]
   | VSort !Sort
 
 type Thunk l = Lazy (EvalM l) (Value l)
@@ -221,7 +221,7 @@ valPairRight v = panic "Verifier.SAW.Simulator.Value.valPairRight" ["Not a pair 
 vRecord :: Map FieldName (Thunk l) -> Value l
 vRecord m = VRecordValue (Map.assocs m)
 
-valRecordProj :: (VMonad l, Show (Extra l)) => Value l -> String -> MValue l
+valRecordProj :: (VMonad l, Show (Extra l)) => Value l -> FieldName -> MValue l
 valRecordProj (VRecordValue fld_map) fld
   | Just t <- lookup fld fld_map = force t
 valRecordProj v@(VRecordValue _) fld =

--- a/saw-core/src/Verifier/SAW/Simulator/Value.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Value.hs
@@ -27,6 +27,7 @@ import Control.Monad (foldM, liftM, mapM)
 import Data.Kind (Type)
 import Data.Map (Map)
 import qualified Data.Map as Map
+import qualified Data.Text as Text
 import Data.Vector (Vector)
 import qualified Data.Vector as V
 import Numeric.Natural
@@ -164,7 +165,7 @@ instance Show (Extra l) => Show (Value l) where
       VString s      -> shows s
       VRecordValue [] -> showString "{}"
       VRecordValue ((fld,_):_) ->
-        showString "{" . showString fld . showString " = _, ...}"
+        showString "{" . showString (Text.unpack fld) . showString " = _, ...}"
       VExtra x       -> showsPrec p x
       TValue x       -> showsPrec p x
     where
@@ -186,7 +187,7 @@ instance Show (Extra l) => Show (TValue l) where
         | otherwise  -> shows s . showList vs
       VRecordType [] -> showString "{}"
       VRecordType ((fld,_):_) ->
-        showString "{" . showString fld . showString " :: _, ...}"
+        showString "{" . showString (Text.unpack fld) . showString " :: _, ...}"
       VVecType n a   -> showString "Vec " . shows n
                         . showString " " . showParen True (showsPrec p a)
       VSort s        -> shows s
@@ -226,7 +227,7 @@ valRecordProj (VRecordValue fld_map) fld
   | Just t <- lookup fld fld_map = force t
 valRecordProj v@(VRecordValue _) fld =
   panic "Verifier.SAW.Simulator.Value.valRecordProj"
-  ["Record field not found:", fld, "in value:", show v]
+  ["Record field not found:", show fld, "in value:", show v]
 valRecordProj v _ =
   panic "Verifier.SAW.Simulator.Value.valRecordProj"
   ["Not a record value:", show v]

--- a/saw-core/src/Verifier/SAW/Term/Functor.hs
+++ b/saw-core/src/Verifier/SAW/Term/Functor.hs
@@ -88,7 +88,7 @@ import qualified Verifier.SAW.TermNet as Net
 import Verifier.SAW.Utils (internalError)
 
 type DeBruijnIndex = Int
-type FieldName = String
+type FieldName = Text
 
 instance (Hashable k, Hashable a) => Hashable (Map k a) where
     hashWithSalt x m = hashWithSalt x (Map.assocs m)

--- a/saw-core/src/Verifier/SAW/Term/Functor.hs
+++ b/saw-core/src/Verifier/SAW/Term/Functor.hs
@@ -312,13 +312,13 @@ data FlatTermF e
     -- | Non-dependent record types, i.e., N-ary tuple types with named
     -- fields. These are considered equal up to reordering of fields. Actual
     -- tuple types are represented with field names @"1"@, @"2"@, etc.
-  | RecordType ![(String, e)]
+  | RecordType ![(FieldName, e)]
     -- | Non-dependent records, i.e., N-ary tuples with named fields. These are
     -- considered equal up to reordering of fields. Actual tuples are
     -- represented with field names @"1"@, @"2"@, etc.
-  | RecordValue ![(String, e)]
+  | RecordValue ![(FieldName, e)]
     -- | Non-dependent record projection
-  | RecordProj e !String
+  | RecordProj e !FieldName
 
     -- | Sorts, aka universes, are the types of types; i.e., an object is a
     -- "type" iff it has type @Sort s@ for some s

--- a/saw-core/src/Verifier/SAW/Term/Pretty.hs
+++ b/saw-core/src/Verifier/SAW/Term/Pretty.hs
@@ -351,7 +351,7 @@ ppPairType prec x y = ppParensPrec prec PrecProd (x <+> pretty '*' <+> y)
 --
 -- * @{ fld1 op val1, ..., fldn op valn }@ otherwise, where @op@ is @::@ for
 --   types and @=@ for values.
-ppRecord :: Bool -> [(String, SawDoc)] -> SawDoc
+ppRecord :: Bool -> [(FieldName, SawDoc)] -> SawDoc
 ppRecord type_p alist =
   (if type_p then (pretty '#' <>) else id) $
   encloseSep lbrace rbrace comma $ map ppField alist
@@ -360,7 +360,7 @@ ppRecord type_p alist =
     op_str = if type_p then ":" else "="
 
 -- | Pretty-print a projection / selector "x.f"
-ppProj :: String -> SawDoc -> SawDoc
+ppProj :: FieldName -> SawDoc -> SawDoc
 ppProj sel doc = doc <> pretty '.' <> pretty sel
 
 -- | Pretty-print an array value @[v1, ..., vn]@

--- a/saw-core/src/Verifier/SAW/UntypedAST.hs
+++ b/saw-core/src/Verifier/SAW/UntypedAST.hs
@@ -65,9 +65,9 @@ data Term
   | UnitValue Pos
   | UnitType Pos
     -- | New-style records
-  | RecordValue Pos [(PosPair String, Term)]
-  | RecordType Pos [(PosPair String, Term)]
-  | RecordProj Term String
+  | RecordValue Pos [(PosPair FieldName, Term)]
+  | RecordType Pos [(PosPair FieldName, Term)]
+  | RecordProj Term FieldName
     -- | Simple pairs
   | PairValue Pos Term Term
   | PairType Pos Term Term


### PR DESCRIPTION
Use `Text` instead of `String` for the `FieldName` type in saw-core ASTs and related functions.