### PR TITLE
Fix incorrect implementation of `intModUnOp` in sbv backend.

### DIFF
--- a/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
+++ b/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
@@ -467,7 +467,7 @@ intModBinOp f =
 intModUnOp :: (SInteger -> SInteger) -> SValue
 intModUnOp f =
   Prims.natFun $ \n -> return $
-  Prims.intFun "intModUnOp" $ \x -> return $
+  Prims.intModFun "intModUnOp" $ \x -> return $
   VIntMod n (normalizeIntMod n (f x))
 
 normalizeIntMod :: Natural -> SInteger -> SInteger


### PR DESCRIPTION
This was an unintentional omission from PR #93, which correctly
updated `intModUnOp` in the what4 backend, but not in sbv.

Fixes #114.