### PR TITLE
Switch from `GlobalDef` to `Constant` for definitions in .sawcore files.

### DIFF
--- a/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
@@ -1329,7 +1329,7 @@ proveEq sc env t1 t2
            a2' <- importType sc env a2
            num <- scDataTypeApp sc "Cryptol.Num" []
            nEq <- if n1 == n2
-                  then scGlobalApply sc "Prelude.Refl" [num, n1']
+                  then scCtorApp sc "Prelude.Refl" [num, n1']
                   else scGlobalApply sc "Prelude.unsafeAssert" [num, n1', n2']
            aEq <- proveEq sc env a1 a2
            if a1 == a2

--- a/saw-core/src/Verifier/SAW/ExternalFormat.hs
+++ b/saw-core/src/Verifier/SAW/ExternalFormat.hs
@@ -61,7 +61,7 @@ renderNames nms = show
   | (idx,nmi) <- Map.toList nms
   ]
  where
-   f (ModuleIdentifier i)  = Left i
+   f (ModuleIdentifier i)  = Left (show i)
    f (ImportedName uri as) = Right (render uri, as)
 
 readNames :: String -> Maybe (Map VarIndex NameInfo)

--- a/saw-core/src/Verifier/SAW/Recognizer.hs
+++ b/saw-core/src/Verifier/SAW/Recognizer.hs
@@ -120,7 +120,11 @@ asFTermF (unwrapTermF -> FTermF ftf) = return ftf
 asFTermF _ = Nothing
 
 asGlobalDef :: Recognizer Term Ident
-asGlobalDef t = do GlobalDef i <- asFTermF t; return i
+asGlobalDef t =
+  case unwrapTermF t of
+    FTermF (GlobalDef ident) -> pure ident
+    Constant (EC _ (ModuleIdentifier ident) _) _ -> pure ident
+    _ -> Nothing
 
 isGlobalDef :: Ident -> Recognizer Term ()
 isGlobalDef i t = do

--- a/saw-core/src/Verifier/SAW/SharedTerm.hs
+++ b/saw-core/src/Verifier/SAW/SharedTerm.hs
@@ -67,6 +67,7 @@ module Verifier.SAW.SharedTerm
   , scFreshEC
   , scExtCns
   , scGlobalDef
+  , scRegisterGlobal
     -- ** Recursors and datatypes
   , scRecursorElimTypes
   , scRecursorRetTypeType
@@ -332,6 +333,7 @@ data SharedContext = SharedContext
   { scModuleMap      :: IORef ModuleMap
   , scTermF          :: TermF Term -> IO Term
   , scNamingEnv      :: IORef SAWNamingEnv
+  , scGlobalEnv      :: MVar (HashMap Ident Term)
   , scFreshGlobalVar :: IO VarIndex
   }
 
@@ -400,7 +402,21 @@ scFreshGlobal sc x tp = scExtCns sc =<< scFreshEC sc x tp
 -- | Returns shared term associated with ident.
 -- Does not check module namespace.
 scGlobalDef :: SharedContext -> Ident -> IO Term
-scGlobalDef sc ident = scFlatTermF sc (GlobalDef ident)
+scGlobalDef sc ident =
+  do m <- readMVar (scGlobalEnv sc)
+     case HMap.lookup ident m of
+       Nothing -> fail ("Could not find global: " ++ show ident)
+       Just t -> pure t
+
+scRegisterGlobal :: SharedContext -> Ident -> Term -> IO ()
+scRegisterGlobal sc ident t =
+  do m <- takeMVar (scGlobalEnv sc)
+     case HMap.lookup ident m of
+       Just _ ->
+         do putMVar (scGlobalEnv sc) m
+            fail ("Global identifier already registered: " ++ show ident)
+       Nothing ->
+         do putMVar (scGlobalEnv sc) $! HMap.insert ident t m
 
 -- | Create a function application term.
 scApply :: SharedContext
@@ -2096,6 +2112,7 @@ mkSharedContext :: IO SharedContext
 mkSharedContext = do
   vr <- newMVar 0 -- Reference for getting variables.
   cr <- newMVar emptyAppCache
+  gr <- newMVar HMap.empty
   let freshGlobalVar = modifyMVar vr (\i -> return (i+1, i))
   mod_map_ref <- newIORef HMap.empty
   envRef <- newIORef emptySAWNamingEnv
@@ -2104,6 +2121,7 @@ mkSharedContext = do
            , scTermF = getTerm cr
            , scFreshGlobalVar = freshGlobalVar
            , scNamingEnv = envRef
+           , scGlobalEnv = gr
            }
 
 useChangeCache :: C m => Cache m k (Change v) -> k -> ChangeT m v -> ChangeT m v

--- a/saw-core/src/Verifier/SAW/Simulator.hs
+++ b/saw-core/src/Verifier/SAW/Simulator.hs
@@ -241,16 +241,25 @@ evalGlobal' ::
   forall l. (VMonadLazy l, MonadFix (EvalM l), Show (Extra l)) =>
   ModuleMap -> Map Ident (Value l) ->
   (TermF Term -> ExtCns (TValue l) -> MValue l) ->
-  (TermF Term -> ExtCns (TValue l) -> Maybe (EvalM l (Value l))) ->
+  (TermF Term -> ExtCns (TValue l) -> Maybe (MValue l)) ->
   EvalM l (SimulatorConfig l)
 evalGlobal' modmap prims extcns uninterpreted = do
    checkPrimitives modmap prims
    mfix $ \cfg -> do
      thunks <- mapM delay (globals cfg)
-     return (SimulatorConfig (global thunks) extcns uninterpreted modmap)
+     return (SimulatorConfig (global thunks) extcns uninterpreted' modmap)
   where
     ms :: [Module]
     ms = HashMap.elems modmap
+
+    uninterpreted' :: TermF Term -> ExtCns (TValue l) -> Maybe (MValue l)
+    uninterpreted' tf ec =
+      case uninterpreted tf ec of
+        Just v -> Just v
+        Nothing ->
+          case ecName ec of
+            ModuleIdentifier ident -> pure <$> Map.lookup ident prims
+            _ -> Nothing
 
     global :: HashMap Ident (Thunk l) -> Ident -> MValue l
     global thunks ident =


### PR DESCRIPTION
This implements most of #43.

The saw-core parser/typechecker now uses `scConstant` to represent defined constants. The `GlobalDef` constructor is still used to represent primitives and axioms declared in .sawcore files.

The change is done in a backward-compatible way: The SharedContext now contains an environment mapping from `Ident`s to `Term`s, so `scGlobalDef` can be used in the same way as before (although the checking for validity of names is more strict now).

The recognizer `asGlobalDef` is also made backward compatible: It now recognizes either `GlobalDef` constants or `Constant` terms that have a name made from an `Ident`.

Finally, the simulator has been updated to accommodate backends that implement "primitives" that are actually constants with overridden definitions: In the uninterpreted-function handler, the prims map is also consulted to see if the `Constant` under consideration was a converted `GlobalDef` that has another implementation.