### PR TITLE
Switch Lambda and Pi constructors to use Text instead of String.

### DIFF
--- a/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
+++ b/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
@@ -463,7 +463,7 @@ asAIGType :: SharedContext -> Term -> IO [(String, Term)]
 asAIGType sc t = do
   t' <- scWhnf sc t
   case t' of
-    (R.asPi -> Just (n, t1, t2)) -> ((n, t1) :) <$> asAIGType sc t2
+    (R.asPi -> Just (n, t1, t2)) -> ((Text.unpack n, t1) :) <$> asAIGType sc t2
     (R.asBoolType -> Just ())    -> return []
     (R.asVecType -> Just _)      -> return []
     (R.asTupleType -> Just _)    -> return []

--- a/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
+++ b/saw-core-sbv/src/Verifier/SAW/Simulator/SBV.hs
@@ -669,7 +669,7 @@ sbvSolve :: SharedContext
 sbvSolve sc addlPrims unintSet t = do
   let eval = sbvSolveBasic sc addlPrims unintSet
   ty <- eval =<< scTypeOf sc t
-  let lamNames = map fst (fst (R.asLambdaList t))
+  let lamNames = map (Text.unpack . fst) (fst (R.asLambdaList t))
   let varNames = [ "var" ++ show (i :: Integer) | i <- [0 ..] ]
   let argNames = zipWith (++) varNames (map ("_" ++) lamNames ++ repeat "")
   argTs <- asPredType (toTValue ty)

--- a/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
+++ b/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
@@ -875,7 +875,7 @@ w4SolveAny sym sc ps unintSet t = give sym $ do
   ty <- eval =<< scTypeOf sc t
 
   -- get the names of the arguments to the function
-  let argNames = map fst (fst (R.asLambdaList t))
+  let argNames = map (Text.unpack . fst) (fst (R.asLambdaList t))
   let moreNames = [ "var" ++ show (i :: Integer) | i <- [0 ..] ]
 
   -- and their types
@@ -1082,7 +1082,7 @@ w4EvalAny sym sc ps unintSet t =
      ty <- eval =<< scTypeOf sc t
 
      -- get the names of the arguments to the function
-     let lamNames = map fst (fst (R.asLambdaList t))
+     let lamNames = map (Text.unpack . fst) (fst (R.asLambdaList t))
      let varNames = [ "var" ++ show (i :: Integer) | i <- [0 ..] ]
      let argNames = zipWith (++) varNames (map ("_" ++) lamNames ++ repeat "")
 

--- a/saw-core/src/Verifier/SAW/ExternalFormat.hs
+++ b/saw-core/src/Verifier/SAW/ExternalFormat.hs
@@ -124,8 +124,8 @@ scWriteExternal t0 =
     writeTermF tf =
       case tf of
         App e1 e2      -> pure $ unwords ["App", show e1, show e2]
-        Lambda s t e   -> pure $ unwords ["Lam", s, show t, show e]
-        Pi s t e       -> pure $ unwords ["Pi", s, show t, show e]
+        Lambda s t e   -> pure $ unwords ["Lam", Text.unpack s, show t, show e]
+        Pi s t e       -> pure $ unwords ["Pi", Text.unpack s, show t, show e]
         LocalVar i     -> pure $ unwords ["Var", show i]
         Constant ec e  ->
             do stashName ec
@@ -225,8 +225,8 @@ scReadExternal sc input =
     parse tokens =
       case tokens of
         ["App", e1, e2]     -> App <$> readIdx e1 <*> readIdx e2
-        ["Lam", x, t, e]    -> Lambda x <$> readIdx t <*> readIdx e
-        ["Pi", s, t, e]     -> Pi s <$> readIdx t <*> readIdx e
+        ["Lam", x, t, e]    -> Lambda (Text.pack x) <$> readIdx t <*> readIdx e
+        ["Pi", s, t, e]     -> Pi (Text.pack s) <$> readIdx t <*> readIdx e
         ["Var", i]          -> pure $ LocalVar (read i)
         ["Constant",i,t,e]  -> Constant <$> readEC i t <*> readIdx e
         ["Global", x]       -> pure $ FTermF (GlobalDef (parseIdent x))

--- a/saw-core/src/Verifier/SAW/Module.hs
+++ b/saw-core/src/Verifier/SAW/Module.hs
@@ -191,9 +191,9 @@ data DataType =
   DataType
   { dtName :: Ident
     -- ^ The name of this datatype
-  , dtParams :: [(String,Term)]
+  , dtParams :: [(LocalName, Term)]
     -- ^ The context of parameters of this datatype
-  , dtIndices :: [(String,Term)]
+  , dtIndices :: [(LocalName, Term)]
     -- ^ The context of indices of this datatype
   , dtSort :: Sort
     -- ^ The universe of this datatype

--- a/saw-core/src/Verifier/SAW/Recognizer.hs
+++ b/saw-core/src/Verifier/SAW/Recognizer.hs
@@ -75,6 +75,7 @@ import Control.Lens
 import Control.Monad
 import Data.Map (Map)
 import qualified Data.Map as Map
+import Data.Text (Text)
 import Numeric.Natural (Natural)
 
 import Verifier.SAW.Term.Functor
@@ -287,7 +288,7 @@ asUnsignedConcreteBv term = do
   (n :*: v) <- asBvNat term
   return $ mod v (2 ^ n)
 
-asStringLit :: Recognizer Term String
+asStringLit :: Recognizer Term Text
 asStringLit t = do StringLit i <- asFTermF t; return i
 
 asLambda :: Recognizer Term (LocalName, Term, Term)

--- a/saw-core/src/Verifier/SAW/Recognizer.hs
+++ b/saw-core/src/Verifier/SAW/Recognizer.hs
@@ -290,22 +290,22 @@ asUnsignedConcreteBv term = do
 asStringLit :: Recognizer Term String
 asStringLit t = do StringLit i <- asFTermF t; return i
 
-asLambda :: Recognizer Term (String, Term, Term)
+asLambda :: Recognizer Term (LocalName, Term, Term)
 asLambda (unwrapTermF -> Lambda s ty body) = return (s, ty, body)
 asLambda _ = Nothing
 
-asLambdaList :: Term -> ([(String, Term)], Term)
+asLambdaList :: Term -> ([(LocalName, Term)], Term)
 asLambdaList = go []
   where go r (asLambda -> Just (nm,tp,rhs)) = go ((nm,tp):r) rhs
         go r rhs = (reverse r, rhs)
 
-asPi :: Recognizer Term (String, Term, Term)
+asPi :: Recognizer Term (LocalName, Term, Term)
 asPi (unwrapTermF -> Pi nm tp body) = return (nm, tp, body)
 asPi _ = Nothing
 
 -- | Decomposes a term into a list of pi bindings, followed by a right
 -- term that is not a pi binding.
-asPiList :: Term -> ([(String, Term)], Term)
+asPiList :: Term -> ([(LocalName, Term)], Term)
 asPiList = go []
   where go r (asPi -> Just (nm,tp,rhs)) = go ((nm,tp):r) rhs
         go r rhs = (reverse r, rhs)

--- a/saw-core/src/Verifier/SAW/SharedTerm.hs
+++ b/saw-core/src/Verifier/SAW/SharedTerm.hs
@@ -1187,7 +1187,7 @@ scNat :: SharedContext -> Natural -> IO Term
 scNat sc n = scFlatTermF sc (NatLit n)
 
 -- | Create a literal term (of saw-core type @String@) from a 'String'.
-scString :: SharedContext -> String -> IO Term
+scString :: SharedContext -> Text -> IO Term
 scString sc s = scFlatTermF sc (StringLit s)
 
 -- | Create a term representing the primitive saw-core type @String@.

--- a/saw-core/src/Verifier/SAW/SharedTerm.hs
+++ b/saw-core/src/Verifier/SAW/SharedTerm.hs
@@ -1301,7 +1301,7 @@ scFunAll sc argTypes resultType = foldrM (scFun sc) resultType argTypes
 -- (as a 'Term'), and a body. Regarding deBruijn indices, in the body of the
 -- function, an index of 0 refers to the bound parameter.
 scLambda :: SharedContext
-         -> String -- ^ The parameter name
+         -> LocalName -- ^ The parameter name
          -> Term   -- ^ The parameter type
          -> Term   -- ^ The body
          -> IO Term
@@ -1313,7 +1313,7 @@ scLambda sc varname ty body = scTermF sc (Lambda varname ty body)
 -- parameter in the list, and n-1 (where n is the list length) refers to the
 -- first.
 scLambdaList :: SharedContext
-             -> [(String, Term)] -- ^ List of parameter / parameter type pairs
+             -> [(LocalName, Term)] -- ^ List of parameter / parameter type pairs
              -> Term -- ^ The body
              -> IO Term
 scLambdaList _ [] rhs = return rhs
@@ -1324,7 +1324,7 @@ scLambdaList sc ((nm,tp):r) rhs =
 -- type (as a 'Term'), and a body. This function follows the same deBruijn
 -- index convention as 'scLambda'.
 scPi :: SharedContext
-     -> String -- ^ The parameter name
+     -> LocalName -- ^ The parameter name
      -> Term   -- ^ The parameter type
      -> Term   -- ^ The body
      -> IO Term
@@ -1334,7 +1334,7 @@ scPi sc nm tp body = scTermF sc (Pi nm tp body)
 -- from a list associating parameter names to types (as 'Term's) and a body.
 -- This function follows the same deBruijn index convention as 'scLambdaList'.
 scPiList :: SharedContext
-         -> [(String, Term)] -- ^ List of parameter / parameter type pairs
+         -> [(LocalName, Term)] -- ^ List of parameter / parameter type pairs
          -> Term -- ^ The body
          -> IO Term
 scPiList _ [] rhs = return rhs
@@ -2215,7 +2215,7 @@ scExtsToLocals sc exts x = instantiateVars sc fn 0 x
 scAbstractExts :: SharedContext -> [ExtCns Term] -> Term -> IO Term
 scAbstractExts _ [] x = return x
 scAbstractExts sc exts x =
-   do let lams = [ (Text.unpack (toShortName (ecName ec)), ecType ec) | ec <- exts ]
+   do let lams = [ (toShortName (ecName ec), ecType ec) | ec <- exts ]
       scLambdaList sc lams =<< scExtsToLocals sc exts x
 
 -- | Generalize over the given list of external constants by wrapping
@@ -2224,7 +2224,7 @@ scAbstractExts sc exts x =
 scGeneralizeExts :: SharedContext -> [ExtCns Term] -> Term -> IO Term
 scGeneralizeExts _ [] x = return x
 scGeneralizeExts sc exts x =
-  do let pis = [ (Text.unpack (toShortName (ecName ec)), ecType ec) | ec <- exts ]
+  do let pis = [ (toShortName (ecName ec), ecType ec) | ec <- exts ]
      scPiList sc pis =<< scExtsToLocals sc exts x
 
 scUnfoldConstants :: SharedContext -> [VarIndex] -> Term -> IO Term
@@ -2324,7 +2324,7 @@ scOpenTerm sc nm tp idx body = do
 -- | `closeTerm closer sc ec body` replaces the external constant `ec` in `body` by
 --   a new deBruijn variable and binds it using the binding form given by 'close'.
 --   The name and type of the new bound variable are given by the name and type of `ec`.
-scCloseTerm :: (SharedContext -> String -> Term -> Term -> IO Term)
+scCloseTerm :: (SharedContext -> LocalName -> Term -> Term -> IO Term)
           -> SharedContext
           -> ExtCns Term
           -> Term
@@ -2332,4 +2332,4 @@ scCloseTerm :: (SharedContext -> String -> Term -> Term -> IO Term)
 scCloseTerm close sc ec body = do
     lv <- scLocalVar sc 0
     body' <- scInstantiateExt sc (Map.insert (ecVarIndex ec) lv Map.empty) =<< incVars sc 0 1 body
-    close sc (Text.unpack (toShortName (ecName ec))) (ecType ec) body'
+    close sc (toShortName (ecName ec)) (ecType ec) body'

--- a/saw-core/src/Verifier/SAW/Simulator/Prims.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Prims.hs
@@ -31,6 +31,7 @@ import Control.Monad.Fix (MonadFix(mfix))
 import Data.Bits
 import Data.Map (Map)
 import qualified Data.Map as Map
+import qualified Data.Text as Text
 import Data.Traversable
 import Data.Vector (Vector)
 import qualified Data.Vector as V
@@ -1209,7 +1210,7 @@ errorOp =
   constFun $
   strictFun $ \x ->
   case x of
-    VString s -> Prim.userError s
+    VString s -> Prim.userError (Text.unpack s)
     _ -> Prim.userError "unknown error"
 
 ------------------------------------------------------------

--- a/saw-core/src/Verifier/SAW/Simulator/Value.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Value.hs
@@ -27,6 +27,7 @@ import Control.Monad (foldM, liftM, mapM)
 import Data.Kind (Type)
 import Data.Map (Map)
 import qualified Data.Map as Map
+import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Vector (Vector)
 import qualified Data.Vector as V
@@ -59,7 +60,7 @@ data Value l
   | VInt (VInt l)
   | VIntMod !Natural (VInt l)
   | VArray (VArray l)
-  | VString !String
+  | VString !Text
   | VFloat !Float
   | VDouble !Double
   | VRecordValue ![(FieldName, Thunk l)]

--- a/saw-core/src/Verifier/SAW/Term/CtxTerm.hs
+++ b/saw-core/src/Verifier/SAW/Term/CtxTerm.hs
@@ -25,6 +25,7 @@ right when you finally get GHC to accept your code. :)
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
@@ -118,7 +119,7 @@ type CtxInv as = CtxInvApp EmptyCtx as
 -- and just write "represent" in quotes.
 data Bindings (tp :: Ctx Type -> Type -> Type) (ctx :: Ctx Type) (as :: [Type]) where
   NoBind :: Bindings tp ctx '[]
-  Bind :: String -> tp ctx (Typ a) -> Bindings tp (ctx ::> a) as ->
+  Bind :: LocalName -> tp ctx (Typ a) -> Bindings tp (ctx ::> a) as ->
           Bindings tp ctx (a ': as)
 
 -- | Compute the number of bindings in a bindings list
@@ -129,7 +130,7 @@ bindingsLength (Bind _ _ bs) = 1 + bindingsLength bs
 -- | An inverted list of bindings, seen from the "inside out"
 data InvBindings (tp :: Ctx Type -> Type -> Type) (ctx :: Ctx Type) (as :: Ctx Type) where
   InvNoBind :: InvBindings tp ctx EmptyCtx
-  InvBind :: InvBindings tp ctx as -> String -> tp (ctx <+> as) (Typ a) ->
+  InvBind :: InvBindings tp ctx as -> LocalName -> tp (ctx <+> as) (Typ a) ->
              InvBindings tp ctx (as ::> a)
 
 -- | Compute the number of bindings in an inverted bindings list
@@ -251,7 +252,7 @@ data ExistsTp tp ctx = forall a. ExistsTp (tp ctx a)
 -- the Haskell type system is not powerful enough to represent all the SAW types
 -- anyway, and any code that consumes this 'Bindings' list cannot know that
 -- anyway. See also the comments for 'CtxTerm'.
-ctxBindingsOfTerms :: [(String,Term)] -> ExistsTp (Bindings CtxTerm) ctx
+ctxBindingsOfTerms :: [(LocalName, Term)] -> ExistsTp (Bindings CtxTerm) ctx
 ctxBindingsOfTerms [] = ExistsTp NoBind
 ctxBindingsOfTerms ((x,tp):ctx) =
   case ctxBindingsOfTerms ctx of
@@ -423,7 +424,7 @@ ctxApplyMulti fm argsm =
          helper f' args
 
 -- | Form a lambda-abstraction as a 'CtxTerm'
-ctxLambda1 :: MonadTerm m => String -> CtxTerm ctx (Typ a) ->
+ctxLambda1 :: MonadTerm m => LocalName -> CtxTerm ctx (Typ a) ->
               (CtxTerm (ctx ::> a) a -> m (CtxTerm (ctx ::> a) b)) ->
               m (CtxTerm ctx (a -> b))
 ctxLambda1 x (CtxTerm tp) body_f =
@@ -444,7 +445,7 @@ ctxLambda (Bind x tp xs) body_f =
      body_f (CtxTermsCons var vars)
 
 -- | Form a pi-abstraction as a 'CtxTerm'
-ctxPi1 :: MonadTerm m => String -> CtxTerm ctx (Typ a) ->
+ctxPi1 :: MonadTerm m => LocalName -> CtxTerm ctx (Typ a) ->
           (CtxTerm (ctx ::> a) a ->
            m (CtxTerm (ctx ::> a) (Typ b))) ->
           m (CtxTerm ctx (Typ (a -> b)))
@@ -476,7 +477,7 @@ ctxPiProxy _ = ctxPi
 -- | Existential return type of 'ctxAsPi'
 data CtxPi ctx =
   forall b c.
-  CtxPi String (CtxTerm ctx (Typ b)) (CtxTerm (ctx ::> b) (Typ c))
+  CtxPi LocalName (CtxTerm ctx (Typ b)) (CtxTerm (ctx ::> b) (Typ c))
 
 -- | Test if a 'CtxTerm' is a pi-abstraction, returning its components if so.
 -- Note that we are not returning any equality constraints on the input type,
@@ -758,8 +759,9 @@ ctxPRetTp (_ :: Proxy (Typ a)) (d :: DataIdent d) params ixs s =
 
 -- | Like 'ctxPRetTp', but also take in a list of parameters and substitute them
 -- for the parameter variables returned by that function
-mkPRetTp :: MonadTerm m => Ident -> [(String,Term)] -> [(String,Term)] ->
-            [Term] -> Sort -> m Term
+mkPRetTp ::
+  MonadTerm m => Ident -> [(LocalName, Term)] -> [(LocalName, Term)] ->
+  [Term] -> Sort -> m Term
 mkPRetTp d untyped_p_ctx untyped_ix_ctx untyped_params s =
   case ctxBindingsOfTerms untyped_p_ctx of
     ExistsTp p_ctx ->
@@ -1082,7 +1084,7 @@ asCtorArg _ _ _ _ _ = Nothing
 -- | Existential return type of 'asPiCtorArg'
 data CtxPiCtorArg d ixs ctx =
   forall a b .
-  CtxPiCtorArg String (CtorArg d ixs ctx (Typ a))
+  CtxPiCtorArg LocalName (CtorArg d ixs ctx (Typ a))
   (CtxTerm (ctx ::> a) (Typ b))
 
 -- | Check that a constructor type is a pi-abstraction that takes as input an

--- a/saw-core/src/Verifier/SAW/Term/CtxTerm.hs
+++ b/saw-core/src/Verifier/SAW/Term/CtxTerm.hs
@@ -1,22 +1,3 @@
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE PolyKinds #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE PartialTypeSignatures #-}
-
 {- |
 Module      : Verifier.SAW.Term.CtxTerm
 Copyright   : Galois, Inc. 2018
@@ -35,6 +16,24 @@ really hard to track down. Although GADT programming can be a pain sometimes,
 this file is organized so at least you will always get the deBruijn indices
 right when you finally get GHC to accept your code. :)
 -}
+
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Verifier.SAW.Term.CtxTerm
   (

--- a/saw-core/src/Verifier/SAW/Term/Functor.hs
+++ b/saw-core/src/Verifier/SAW/Term/Functor.hs
@@ -189,7 +189,7 @@ data FlatTermF e
     -- | Array value includes type of elements followed by elements.
   | ArrayValue e (Vector e)
     -- | String literal
-  | StringLit !String
+  | StringLit !Text
 
     -- | An external constant with a name.
   | ExtCns !(ExtCns e)

--- a/saw-core/src/Verifier/SAW/Term/Functor.hs
+++ b/saw-core/src/Verifier/SAW/Term/Functor.hs
@@ -34,6 +34,7 @@ module Verifier.SAW.Term.Functor
     -- * Data types and definitions
   , DeBruijnIndex
   , FieldName
+  , LocalName
   , ExtCns(..)
   , VarIndex
   , NameInfo(..)
@@ -83,6 +84,7 @@ import qualified Verifier.SAW.TermNet as Net
 
 type DeBruijnIndex = Int
 type FieldName = Text
+type LocalName = Text
 
 instance (Hashable k, Hashable a) => Hashable (Map k a) where
     hashWithSalt x m = hashWithSalt x (Map.assocs m)
@@ -266,9 +268,9 @@ data TermF e
       -- ^ The atomic, or builtin, term constructs
     | App !e !e
       -- ^ Applications of functions
-    | Lambda !String !e !e
+    | Lambda !LocalName !e !e
       -- ^ Function abstractions
-    | Pi !String !e !e
+    | Pi !LocalName !e !e
       -- ^ The type of a (possibly) dependent function
     | LocalVar !DeBruijnIndex
       -- ^ Local variables are referenced by deBruijn index.

--- a/saw-core/src/Verifier/SAW/Typechecker.hs
+++ b/saw-core/src/Verifier/SAW/Typechecker.hs
@@ -264,7 +264,7 @@ typeInferCompleteTerm (Un.TypeConstraint t _ tp) =
 typeInferCompleteTerm (Un.NatLit _ i) =
   typeInferComplete (NatLit i :: FlatTermF TypedTerm)
 typeInferCompleteTerm (Un.StringLit _ str) =
-  typeInferComplete (StringLit str :: FlatTermF TypedTerm)
+  typeInferComplete (StringLit (Text.pack str) :: FlatTermF TypedTerm)
 typeInferCompleteTerm (Un.VecLit _ []) = throwTCError EmptyVectorLit
 typeInferCompleteTerm (Un.VecLit _ ts) =
   do typed_ts <- mapM typeInferComplete ts

--- a/saw-core/src/Verifier/SAW/TypedAST.hs
+++ b/saw-core/src/Verifier/SAW/TypedAST.hs
@@ -73,6 +73,7 @@ module Verifier.SAW.TypedAST
  , isIdent
  , DeBruijnIndex
  , FieldName
+ , LocalName
  , ExtCns(..)
  , VarIndex
    -- * Utility functions

--- a/saw-core/src/Verifier/SAW/UntypedAST.hs
+++ b/saw-core/src/Verifier/SAW/UntypedAST.hs
@@ -23,6 +23,7 @@ module Verifier.SAW.UntypedAST
   , Term(..)
   , TermVar(..)
   , termVarString
+  , termVarLocalName
   , TermCtx
   , asApp
   , asPiList
@@ -44,6 +45,7 @@ module Verifier.SAW.UntypedAST
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative ((<$>))
 #endif
+import qualified Data.Text as Text
 
 import qualified Language.Haskell.TH.Syntax as TH
 import Numeric.Natural
@@ -53,6 +55,7 @@ import Verifier.SAW.TypedAST
   ( ModuleName, mkModuleName
   , Sort, mkSort, propSort, sortOf
   , FieldName, DefQualifier
+  , LocalName
   )
 
 data Term
@@ -92,6 +95,11 @@ data TermVar
 termVarString :: TermVar -> String
 termVarString (TermVar (PosPair _ str)) = str
 termVarString (UnusedVar _) = "_"
+
+-- | Return the 'LocalName' associated with a 'TermVar'
+termVarLocalName :: TermVar -> LocalName
+termVarLocalName (TermVar (PosPair _ str)) = Text.pack str
+termVarLocalName (UnusedVar _) = Text.pack "_"
 
 -- | A context of 0 or more variable bindings, with types
 type TermCtx = [(TermVar,Term)]


### PR DESCRIPTION
We introduce a type synonym `LocalName = Text` for this purpose.

This is a step toward removing all uses of `String` in saw-core (#44).

See also #111.