### PR TITLE
Check types in context of private symbols

### DIFF
--- a/cryptol-saw-core/src/Verifier/SAW/CryptolEnv.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/CryptolEnv.hs
@@ -238,7 +238,8 @@ getNamingEnv env = eExtraNames env `MR.shadowing` nameEnv
     nameEnv = mconcat $ fromMaybe [] $ traverse loadImport (eImports env)
     loadImport i = do
       lm <- ME.lookupModule (T.iModule i) (eModuleEnv env)
-      return $ MN.interpImport i (MI.ifPublic (ME.lmInterface lm))
+      let ifc = ME.lmInterface lm
+      return $ MN.interpImport i (MI.ifPublic ifc `mappend` M.ifPrivate ifc)
 
 getAllIfaceDecls :: ME.ModuleEnv -> M.IfaceDecls
 getAllIfaceDecls me = mconcat (map (both . ME.lmInterface) (ME.getLoadedModules (ME.meLoadedModules me)))

--- a/cryptol-saw-core/test/CryptolVerifierTC.hs
+++ b/cryptol-saw-core/test/CryptolVerifierTC.hs
@@ -27,9 +27,9 @@ main =
      let ?fileReader = BS.readFile
      cenv0 <- CEnv.initCryptolEnv sc
      putStrLn "Translated Cryptol.cry!"
-     cenv1 <- CEnv.importModule sc cenv0 (Right N.floatName) Nothing Nothing
+     cenv1 <- CEnv.importModule sc cenv0 (Right N.floatName) Nothing OnlyPublic Nothing
      putStrLn "Translated Float.cry!"
-     cenv2 <- CEnv.importModule sc cenv1 (Right N.arrayName) Nothing Nothing
+     cenv2 <- CEnv.importModule sc cenv1 (Right N.arrayName) Nothing OnlyPublic Nothing
      putStrLn "Translated Array.cry!"
      cenv3 <- CEnv.parseDecls sc cenv2 (CEnv.InputText superclassContents "superclass.cry" 1 1)
      putStrLn "Translated superclass.cry!"

--- a/cryptol-saw-core/test/CryptolVerifierTC.hs
+++ b/cryptol-saw-core/test/CryptolVerifierTC.hs
@@ -27,9 +27,9 @@ main =
      let ?fileReader = BS.readFile
      cenv0 <- CEnv.initCryptolEnv sc
      putStrLn "Translated Cryptol.cry!"
-     cenv1 <- CEnv.importModule sc cenv0 (Right N.floatName) Nothing OnlyPublic Nothing
+     cenv1 <- CEnv.importModule sc cenv0 (Right N.floatName) Nothing CEnv.OnlyPublic Nothing
      putStrLn "Translated Float.cry!"
-     cenv2 <- CEnv.importModule sc cenv1 (Right N.arrayName) Nothing OnlyPublic Nothing
+     cenv2 <- CEnv.importModule sc cenv1 (Right N.arrayName) Nothing CEnv.OnlyPublic Nothing
      putStrLn "Translated Array.cry!"
      cenv3 <- CEnv.parseDecls sc cenv2 (CEnv.InputText superclassContents "superclass.cry" 1 1)
      putStrLn "Translated superclass.cry!"


### PR DESCRIPTION
Include both public and private symbols from imported modules when type checking. This addresses saw-script#971.

@brianhuffman, do you think this would have any undesirable side effects?