### PR TITLE
Fix broken Read instance for type Ident.

### DIFF
--- a/saw-core/src/Verifier/SAW/Term/Functor.hs
+++ b/saw-core/src/Verifier/SAW/Term/Functor.hs
@@ -185,7 +185,7 @@ isCtor [] = False
 
 -- | Returns true if character can appear in identifier.
 isIdChar :: Char -> Bool
-isIdChar c = isAlphaNum c || (c == '_') || (c == '\'')
+isIdChar c = isAlphaNum c || (c == '_') || (c == '\'') || (c == '.')
 
 
 -- Sorts -----------------------------------------------------------------------


### PR DESCRIPTION
The Show instance produces strings that include dots,
but previously the Read instance would refuse them.