### PR TITLE
Name module

### DIFF
--- a/saw-core/saw-core.cabal
+++ b/saw-core/saw-core.cabal
@@ -64,6 +64,7 @@ library
      Verifier.SAW.Grammar
      Verifier.SAW.Lexer
      Verifier.SAW.Module
+     Verifier.SAW.Name
      Verifier.SAW.ParserUtils
      Verifier.SAW.Position
      Verifier.SAW.Prelude

--- a/saw-core/src/Verifier/SAW/Name.hs
+++ b/saw-core/src/Verifier/SAW/Name.hs
@@ -42,6 +42,11 @@ module Verifier.SAW.Name
   , scFreshNameURI
     -- * Naming Environments
   , SAWNamingEnv(..)
+  , emptySAWNamingEnv
+  , registerName
+  , resolveURI
+  , resolveName
+  , bestAlias
   ) where
 
 import           Control.Exception (assert)
@@ -50,9 +55,10 @@ import           Data.Hashable
 import           Data.List
 import           Data.List.NonEmpty (NonEmpty(..))
 import           Data.Map (Map)
--- import qualified Data.Map as Map
+import qualified Data.Map as Map
 import           Data.Maybe
 import           Data.Set (Set)
+import qualified Data.Set as Set
 import           Data.String (IsString(..))
 import           Data.Text (Text)
 import qualified Data.Text as Text
@@ -251,3 +257,59 @@ data SAWNamingEnv = SAWNamingEnv
   , absoluteNames :: !(Map URI VarIndex)
   , aliasNames    :: !(Map Text (Set VarIndex))
   }
+-- Invariants: The 'resolvedNames' and 'absoluteNames' maps should be
+-- inverses of each other. That is, 'resolvedNames' maps @i@ to @n@ if
+-- and only if 'absoluteNames' maps @nameURI n@ to @i@. Also, every
+-- 'VarIndex' appearing in 'aliasNames' must be present as a key in
+-- 'resolvedNames'.
+
+emptySAWNamingEnv :: SAWNamingEnv
+emptySAWNamingEnv = SAWNamingEnv mempty mempty mempty
+
+-- | Add a new name entry in a 'SAWNamingEnv'. Returns 'Left' if
+-- there is already an entry under the same URI.
+registerName :: VarIndex -> NameInfo -> SAWNamingEnv -> Either URI SAWNamingEnv
+registerName i nmi env =
+  case Map.lookup uri (absoluteNames env) of
+    Just _ -> Left uri
+    Nothing ->
+      Right $
+      SAWNamingEnv
+      { resolvedNames = Map.insert i nmi (resolvedNames env)
+      , absoluteNames = Map.insert uri i (absoluteNames env)
+      , aliasNames    = foldr insertAlias (aliasNames env) aliases
+      }
+  where
+    uri = nameURI nmi
+    aliases = render uri : nameAliases nmi
+
+    insertAlias :: Text -> Map Text (Set VarIndex) -> Map Text (Set VarIndex)
+    insertAlias x m = Map.insertWith Set.union x (Set.singleton i) m
+
+resolveURI :: SAWNamingEnv -> URI -> Maybe VarIndex
+resolveURI env uri = Map.lookup uri (absoluteNames env)
+
+resolveName :: SAWNamingEnv -> Text -> [(VarIndex, NameInfo)]
+resolveName env nm =
+  case Map.lookup nm (aliasNames env) of
+    Nothing -> []
+    Just vs -> [ (v, findName v (resolvedNames env)) | v <- Set.toList vs ]
+  where
+    findName v m =
+      case Map.lookup v m of
+        Just nmi -> nmi
+        Nothing -> panic "resolveName" ["Unbound VarIndex when resolving name", show nm, show v]
+
+-- | Return the first alias (according to 'nameAliases') that is
+-- unambiguous in the naming environment. If there is no unambiguous
+-- alias, then return the URI.
+bestAlias :: SAWNamingEnv -> NameInfo -> Either URI Text
+bestAlias env nmi = go (nameAliases nmi)
+  where
+    go [] = Left (nameURI nmi)
+    go (x : xs) =
+      case Map.lookup x (aliasNames env) of
+        Nothing -> go xs
+        Just vs
+          | Set.size vs == 1 -> Right x
+          | otherwise -> go xs

--- a/saw-core/src/Verifier/SAW/Name.hs
+++ b/saw-core/src/Verifier/SAW/Name.hs
@@ -1,0 +1,195 @@
+{- |
+Module      : Verifier.SAW.Name
+Copyright   : Galois, Inc. 2012-2015
+License     : BSD3
+Maintainer  : huffman@galois.com
+Stability   : experimental
+Portability : non-portable (language extensions)
+
+Various kinds of names.
+-}
+
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Verifier.SAW.Name
+  ( -- * Module names
+    ModuleName, mkModuleName
+  , preludeName
+  , moduleNameText
+  , moduleNamePieces
+   -- * Identifiers
+  , Ident(identModule, identBaseName), identName, mkIdent
+  , parseIdent
+  , isIdent
+  , identText
+  , identPieces
+    -- * NameInfo
+  , NameInfo(..)
+  , toShortName
+  , toAbsoluteName
+  , moduleIdentToURI
+  , nameURI
+  , nameAliases
+  ) where
+
+import           Control.Exception (assert)
+import           Data.Char
+import           Data.Hashable
+import           Data.List
+import           Data.List.NonEmpty (NonEmpty(..))
+import           Data.Maybe
+import           Data.String (IsString(..))
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import           GHC.Generics (Generic)
+import           Text.URI
+import qualified Language.Haskell.TH.Syntax as TH
+import           Instances.TH.Lift () -- for instance TH.Lift Text
+
+import Verifier.SAW.Utils (panic, internalError)
+
+
+-- Module Names ----------------------------------------------------------------
+
+newtype ModuleName = ModuleName Text
+  deriving (Eq, Ord, Generic, TH.Lift)
+
+instance Hashable ModuleName -- automatically derived
+
+instance Show ModuleName where
+  show (ModuleName s) = Text.unpack s
+
+
+moduleNameText :: ModuleName -> Text
+moduleNameText (ModuleName x) = x
+
+moduleNamePieces :: ModuleName -> [Text]
+moduleNamePieces (ModuleName x) = Text.splitOn (Text.pack ".") x
+
+-- | Create a module name given a list of strings with the top-most
+-- module name given first.
+mkModuleName :: [String] -> ModuleName
+mkModuleName [] = error "internal: mkModuleName given empty module name"
+mkModuleName nms = assert (all isCtor nms) $ ModuleName (Text.pack s)
+  where s = intercalate "." (reverse nms)
+
+preludeName :: ModuleName
+preludeName = mkModuleName ["Prelude"]
+
+
+-- Identifiers -----------------------------------------------------------------
+
+data Ident =
+  Ident
+  { identModule :: ModuleName
+  , identBaseName :: Text
+  }
+  deriving (Eq, Ord, Generic)
+
+instance Hashable Ident -- automatically derived
+
+instance Show Ident where
+  show (Ident m s) = shows m ('.' : Text.unpack s)
+
+identText :: Ident -> Text
+identText i = moduleNameText (identModule i) <> Text.pack "." <> identBaseName i
+
+identPieces :: Ident -> NonEmpty Text
+identPieces i =
+  case moduleNamePieces (identModule i) of
+    [] -> identBaseName i :| []
+    (x:xs) -> x :| (xs ++ [identBaseName i])
+
+identName :: Ident -> String
+identName = Text.unpack . identBaseName
+
+instance Read Ident where
+  readsPrec _ str =
+    let (str1, str2) = break (not . isIdChar) str in
+    [(parseIdent str1, str2)]
+
+mkIdent :: ModuleName -> String -> Ident
+mkIdent m s = Ident m (Text.pack s)
+
+-- | Parse a fully qualified identifier.
+parseIdent :: String -> Ident
+parseIdent s0 =
+    case reverse (breakEach s0) of
+      (_:[]) -> internalError $ "parseIdent given empty module name."
+      (nm:rMod) -> mkIdent (mkModuleName (reverse rMod)) nm
+      _ -> internalError $ "parseIdent given bad identifier " ++ show s0
+  where breakEach s =
+          case break (=='.') s of
+            (h,[]) -> [h]
+            (h,'.':r) -> h : breakEach r
+            _ -> internalError "parseIdent.breakEach failed"
+
+instance IsString Ident where
+  fromString = parseIdent
+
+isIdent :: String -> Bool
+isIdent (c:l) = isAlpha c && all isIdChar l
+isIdent [] = False
+
+isCtor :: String -> Bool
+isCtor (c:l) = isUpper c && all isIdChar l
+isCtor [] = False
+
+-- | Returns true if character can appear in identifier.
+isIdChar :: Char -> Bool
+isIdChar c = isAlphaNum c || (c == '_') || (c == '\'') || (c == '.')
+
+
+--------------------------------------------------------------------------------
+-- NameInfo
+
+
+-- | Descriptions of the origins of names that may be in scope
+data NameInfo
+  = -- | This name arises from an exported declaration from a module
+    ModuleIdentifier Ident
+
+  | -- | This name was imported from some other programming language/scope
+    ImportedName
+      URI      -- ^ An absolutely-qualified name, which is required to be unique
+      [Text]   -- ^ A collection of aliases for this name.  Sorter or "less-qualified"
+               --   aliases should be nearer the front of the list
+
+ deriving (Eq,Ord,Show)
+
+nameURI :: NameInfo -> URI
+nameURI =
+  \case
+    ModuleIdentifier i -> moduleIdentToURI i
+    ImportedName uri _ -> uri
+
+nameAliases :: NameInfo -> [Text]
+nameAliases =
+  \case
+    ModuleIdentifier i -> [identBaseName i, identText i]
+    ImportedName _ aliases -> aliases
+
+toShortName :: NameInfo -> Text
+toShortName (ModuleIdentifier i) = identBaseName i
+toShortName (ImportedName uri []) = render uri
+toShortName (ImportedName _ (x:_)) = x
+
+toAbsoluteName :: NameInfo -> Text
+toAbsoluteName (ModuleIdentifier i) = identText i
+toAbsoluteName (ImportedName uri _) = render uri
+
+moduleIdentToURI :: Ident -> URI
+moduleIdentToURI ident = fromMaybe (panic "moduleIdentToURI" ["Failed to constructed ident URI", show ident]) $
+  do sch  <- mkScheme "sawcore"
+     path <- mapM mkPathPiece (identPieces ident)
+     pure URI
+       { uriScheme = Just sch
+       , uriAuthority = Left True -- absolute path
+       , uriPath   = Just (False, path)
+       , uriQuery  = []
+       , uriFragment = Nothing
+       }
+

--- a/saw-core/src/Verifier/SAW/SharedTerm.hs
+++ b/saw-core/src/Verifier/SAW/SharedTerm.hs
@@ -366,18 +366,12 @@ scResolveUnambiguous sc nm =
        do nms <- mapM (scFindBestName sc . snd) xs
           fail $ unlines (("Ambiguous name " ++ show nm ++ " might refer to any of the following:") : map show nms)
 
--- TODO: This differs from 'Verifier.SAW.Name.bestAlias' in the
--- 'ModuleIdentifier' case. Should we redefine this to match?
 scFindBestName :: SharedContext -> NameInfo -> IO Text
-scFindBestName _sc (ModuleIdentifier nm) = pure (identText nm)
-scFindBestName sc (ImportedName uri as) = go as
-  where
-  go [] = pure (render uri)
-  go (x:xs) =
-    do vs <- scResolveName sc x
-       case vs of
-         [_] -> return x
-         _   -> go xs
+scFindBestName sc nmi =
+  do env <- readIORef (scNamingEnv sc)
+     case bestAlias env nmi of
+       Left uri -> pure (render uri)
+       Right nm -> pure nm
 
 scResolveNameByURI :: SharedContext -> URI -> IO (Maybe VarIndex)
 scResolveNameByURI sc uri =

--- a/saw-core/src/Verifier/SAW/SharedTerm.hs
+++ b/saw-core/src/Verifier/SAW/SharedTerm.hs
@@ -256,7 +256,6 @@ import Data.Maybe
 import qualified Data.Foldable as Fold
 import Data.Foldable (foldl', foldlM, foldrM, maximum)
 import Data.HashMap.Strict (HashMap)
-import Data.List.NonEmpty ( NonEmpty(..) )
 import qualified Data.HashMap.Strict as HMap
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
@@ -330,12 +329,6 @@ insertTFM tf x tfm =
 ----------------------------------------------------------------------
 -- SharedContext: a high-level interface for building Terms.
 
-data SAWNamingEnv = SAWNamingEnv
-  { resolvedNames :: !(Map VarIndex NameInfo)
-  , absoluteNames :: !(Map URI VarIndex)
-  , aliasNames    :: !(Map Text (Set VarIndex))
-  }
-
 data SharedContext = SharedContext
   { scModuleMap      :: IORef ModuleMap
   , scTermF          :: TermF Term -> IO Term
@@ -350,19 +343,6 @@ scFlatTermF sc ftf = scTermF sc (FTermF ftf)
 -- | Create a 'Term' from an 'ExtCns'.
 scExtCns :: SharedContext -> ExtCns Term -> IO Term
 scExtCns sc ec = scFlatTermF sc (ExtCns ec)
-
-scFreshNameURI :: Text -> VarIndex -> URI
-scFreshNameURI nm i = fromMaybe (panic "scFreshNameURI" ["Failed to constructed name URI", show nm, show i]) $
-  do sch <- mkScheme "fresh"
-     nm' <- mkPathPiece (if Text.null nm then "_" else nm)
-     i'  <- mkFragment (Text.pack (show i))
-     pure URI
-       { uriScheme = Just sch
-       , uriAuthority = Left False -- relative path
-       , uriPath   = Just (False, (nm' :| []))
-       , uriQuery  = []
-       , uriFragment = Just i'
-       }
 
 data DuplicateNameException = DuplicateNameException URI
 instance Exception DuplicateNameException

--- a/saw-core/src/Verifier/SAW/Term/Functor.hs
+++ b/saw-core/src/Verifier/SAW/Term/Functor.hs
@@ -58,16 +58,12 @@ module Verifier.SAW.Term.Functor
   , looseVars, smallestFreeVar
   ) where
 
-import Control.Exception (assert)
 import Data.Bits
-import Data.Char
 #if !MIN_VERSION_base(4,8,0)
 import Data.Foldable (Foldable)
 #endif
-import qualified Data.Foldable as Foldable (all, and, foldl')
+import qualified Data.Foldable as Foldable (and, foldl')
 import Data.Hashable
-import Data.List (intercalate)
-import Data.List.NonEmpty (NonEmpty(..))
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Text (Text)
@@ -77,15 +73,13 @@ import Data.Vector (Vector)
 import qualified Data.Vector as V
 import Data.Word
 import GHC.Generics (Generic)
-import GHC.Exts (IsString(..))
 import Numeric.Natural
-import Text.URI
 
 import qualified Language.Haskell.TH.Syntax as TH
 import Instances.TH.Lift () -- for instance TH.Lift Text
 
+import Verifier.SAW.Name
 import qualified Verifier.SAW.TermNet as Net
-import Verifier.SAW.Utils (internalError)
 
 type DeBruijnIndex = Int
 type FieldName = Text
@@ -95,97 +89,6 @@ instance (Hashable k, Hashable a) => Hashable (Map k a) where
 
 instance Hashable a => Hashable (Vector a) where
     hashWithSalt x v = hashWithSalt x (V.toList v)
-
-
--- Module Names ----------------------------------------------------------------
-
-newtype ModuleName = ModuleName Text
-  deriving (Eq, Ord, Generic, TH.Lift)
-
-instance Hashable ModuleName -- automatically derived
-
-instance Show ModuleName where
-  show (ModuleName s) = Text.unpack s
-
-
-moduleNameText :: ModuleName -> Text
-moduleNameText (ModuleName x) = x
-
-moduleNamePieces :: ModuleName -> [Text]
-moduleNamePieces (ModuleName x) = Text.splitOn (Text.pack ".") x
-
--- | Create a module name given a list of strings with the top-most
--- module name given first.
-mkModuleName :: [String] -> ModuleName
-mkModuleName [] = error "internal: mkModuleName given empty module name"
-mkModuleName nms = assert (Foldable.all isCtor nms) $ ModuleName (Text.pack s)
-  where s = intercalate "." (reverse nms)
-
-preludeName :: ModuleName
-preludeName = mkModuleName ["Prelude"]
-
-
--- Identifiers -----------------------------------------------------------------
-
-data Ident =
-  Ident
-  { identModule :: ModuleName
-  , identBaseName :: Text
-  }
-  deriving (Eq, Ord, Generic)
-
-instance Hashable Ident -- automatically derived
-
-instance Show Ident where
-  show (Ident m s) = shows m ('.' : Text.unpack s)
-
-identText :: Ident -> Text
-identText i = moduleNameText (identModule i) <> Text.pack "." <> identBaseName i
-
-identPieces :: Ident -> NonEmpty Text
-identPieces i =
-  case moduleNamePieces (identModule i) of
-    [] -> identBaseName i :| []
-    (x:xs) -> x :| (xs ++ [identBaseName i])
-
-identName :: Ident -> String
-identName = Text.unpack . identBaseName
-
-instance Read Ident where
-  readsPrec _ str =
-    let (str1, str2) = break (not . isIdChar) str in
-    [(parseIdent str1, str2)]
-
-mkIdent :: ModuleName -> String -> Ident
-mkIdent m s = Ident m (Text.pack s)
-
--- | Parse a fully qualified identifier.
-parseIdent :: String -> Ident
-parseIdent s0 =
-    case reverse (breakEach s0) of
-      (_:[]) -> internalError $ "parseIdent given empty module name."
-      (nm:rMod) -> mkIdent (mkModuleName (reverse rMod)) nm
-      _ -> internalError $ "parseIdent given bad identifier " ++ show s0
-  where breakEach s =
-          case break (=='.') s of
-            (h,[]) -> [h]
-            (h,'.':r) -> h : breakEach r
-            _ -> internalError "parseIdent.breakEach failed"
-
-instance IsString Ident where
-  fromString = parseIdent
-
-isIdent :: String -> Bool
-isIdent (c:l) = isAlpha c && Foldable.all isIdChar l
-isIdent [] = False
-
-isCtor :: String -> Bool
-isCtor (c:l) = isUpper c && Foldable.all isIdChar l
-isCtor [] = False
-
--- | Returns true if character can appear in identifier.
-isIdChar :: Char -> Bool
-isIdChar c = isAlphaNum c || (c == '_') || (c == '\'') || (c == '.')
 
 
 -- Sorts -----------------------------------------------------------------------
@@ -232,19 +135,6 @@ maxSort ss = maximum ss
 
 type VarIndex = Word64
 
--- | Descriptions of the origins of names that may be in scope
-data NameInfo
-  = -- | This name arises from an exported declaration from a module
-    ModuleIdentifier Ident
-
-  | -- | This name was imported from some other programming language/scope
-    ImportedName
-      URI      -- ^ An absolutely-qualified name, which is required to be unique
-      [Text]   -- ^ A collection of aliases for this name.  Sorter or "less-qualified"
-               --   aliases should be nearer the front of the list
-
- deriving (Eq,Ord,Show)
-
 -- | An external constant with a name.
 -- Names are not necessarily unique, but the var index should be.
 data ExtCns e =
@@ -254,15 +144,6 @@ data ExtCns e =
   , ecType :: !e
   }
   deriving (Show, Functor, Foldable, Traversable)
-
-toShortName :: NameInfo -> Text
-toShortName (ModuleIdentifier i) = identBaseName i
-toShortName (ImportedName uri []) = render uri
-toShortName (ImportedName _ (x:_)) = x
-
-toAbsoluteName :: NameInfo -> Text
-toAbsoluteName (ModuleIdentifier i) = identText i
-toAbsoluteName (ImportedName uri _) = render uri
 
 instance Eq (ExtCns e) where
   x == y = ecVarIndex x == ecVarIndex y

--- a/saw-core/src/Verifier/SAW/Term/Functor.hs
+++ b/saw-core/src/Verifier/SAW/Term/Functor.hs
@@ -131,30 +131,6 @@ maxSort [] = propSort
 maxSort ss = maximum ss
 
 
--- External Constants ----------------------------------------------------------
-
-type VarIndex = Word64
-
--- | An external constant with a name.
--- Names are not necessarily unique, but the var index should be.
-data ExtCns e =
-  EC
-  { ecVarIndex :: !VarIndex
-  , ecName :: !NameInfo
-  , ecType :: !e
-  }
-  deriving (Show, Functor, Foldable, Traversable)
-
-instance Eq (ExtCns e) where
-  x == y = ecVarIndex x == ecVarIndex y
-
-instance Ord (ExtCns e) where
-  compare x y = compare (ecVarIndex x) (ecVarIndex y)
-
-instance Hashable (ExtCns e) where
-  hashWithSalt x ec = hashWithSalt x (ecVarIndex ec)
-
-
 -- Flat Terms ------------------------------------------------------------------
 
 -- | The "flat terms", which are the built-in atomic constructs of SAW core.


### PR DESCRIPTION
Move name-related datatypes and functions into a new module, `Verifier.SAW.Name`.