### PR TITLE
Naming-aware term pretty-printing.

### DIFF
--- a/saw-core/src/Verifier/SAW/SharedTerm.hs
+++ b/saw-core/src/Verifier/SAW/SharedTerm.hs
@@ -44,6 +44,7 @@ module Verifier.SAW.SharedTerm
   , scResolveNameByURI
   , scResolveUnambiguous
   , scFindBestName
+  , scShowTerm
   , DuplicateNameException(..)
     -- * Re-exported pretty-printing functions
   , PPOpts(..)
@@ -384,6 +385,11 @@ scResolveName :: SharedContext -> Text -> IO [(VarIndex, NameInfo)]
 scResolveName sc nm =
   do env <- readIORef (scNamingEnv sc)
      pure (resolveName env nm)
+
+scShowTerm :: SharedContext -> PPOpts -> Term -> IO String
+scShowTerm sc opts t =
+  do env <- readIORef (scNamingEnv sc)
+     pure (showTermWithNames opts env t)
 
 -- | Create a global variable with the given identifier (which may be "_") and type.
 scFreshEC :: SharedContext -> String -> Term -> IO (ExtCns Term)


### PR DESCRIPTION
Add some new functions for pretty-printing shared terms using information from the `SAWNamingEnv` to choose best aliases for names.

This PR avoids changing the types or behavior of any existing functions, in order to avoid requiring PRs for five other packages.