### PR TITLE
Avoid calling slow `typeInferComplete` on already-typechecked terms.

### DIFF
--- a/saw-core/src/Verifier/SAW/Typechecker.hs
+++ b/saw-core/src/Verifier/SAW/Typechecker.hs
@@ -113,7 +113,7 @@ inferResolveNameApp n args =
          typeInferComplete (DataTypeApp (dtName dt) params ixs)
        (_, Just (ResolvedDef d)) ->
          do t <- liftTCM scGlobalDef (defIdent d)
-            f <- typeInferComplete t
+            f <- TypedTerm t <$> liftTCM scTypeOf t
             inferApplyAll f args
        (Nothing, Nothing) ->
          throwTCError $ UnboundName n


### PR DESCRIPTION
This fixes a performance problem that was exposed by #118:
`typeInferComplete` is actually very slow when called on
`Constant` terms, because instead of using the cached type,
it rechecks the well-formedness of the constant's definition.
Furthermore, its memoization for observable sharing is mostly
ineffective, because it resets the memo table whenever it
looks under a binder.

Switching from `typeInferComplete` to `scTypeOf` brings the
saw-script start-up time back to where it was before #118.