### PR TITLE
Change the sort of saw-core type `Eq` from `sort 1` to `Prop`.

### DIFF
--- a/saw-core/prelude/Prelude.sawcore
+++ b/saw-core/prelude/Prelude.sawcore
@@ -113,7 +113,7 @@ RecordType__rec
 --------------------------------------------------------------------------------
 -- Equality proofs.
 
-data Eq (t : sort 1) (x : t) : t -> sort 1 where {
+data Eq (t : sort 1) (x : t) : t -> Prop where {
     Refl : Eq t x x;
   }
 


### PR DESCRIPTION
With this the wip-heapster branch should be able to use `Eq` instead of a separate `EqP`.