### PR TITLE
Convert more uses of `String` to `Text`.

### DIFF
--- a/saw-core/src/Verifier/SAW/Name.hs
+++ b/saw-core/src/Verifier/SAW/Name.hs
@@ -25,6 +25,7 @@ module Verifier.SAW.Name
   , moduleNamePieces
    -- * Identifiers
   , Ident(identModule, identBaseName), identName, mkIdent
+  , mkIdentText
   , parseIdent
   , isIdent
   , identText
@@ -132,6 +133,9 @@ instance Read Ident where
 
 mkIdent :: ModuleName -> String -> Ident
 mkIdent m s = Ident m (Text.pack s)
+
+mkIdentText :: ModuleName -> Text -> Ident
+mkIdentText m s = Ident m s
 
 -- | Parse a fully qualified identifier.
 parseIdent :: String -> Ident

--- a/saw-core/src/Verifier/SAW/ParserUtils.hs
+++ b/saw-core/src/Verifier/SAW/ParserUtils.hs
@@ -32,6 +32,8 @@ import qualified Data.ByteString.Lazy as BL
 #if !MIN_VERSION_template_haskell(2,8,0)
 import qualified Data.ByteString.Lazy.UTF8 as UTF8
 #endif
+import Data.Text (Text)
+import qualified Data.Text as Text
 import Language.Haskell.TH
 #if MIN_VERSION_template_haskell(2,7,0)
 import Language.Haskell.TH.Syntax (qAddDependentFile)
@@ -135,13 +137,13 @@ declareTermApplyFun nm n tf =
 --
 -- The number of 'Term's to take as arguments is given by the arity of @tp@,
 -- i.e., the number of nested pi-abstractions it contains at top level.
-declareTypedNameFun :: Q Exp -> ModuleName -> String -> Bool -> Un.Term ->
+declareTypedNameFun :: Q Exp -> ModuleName -> Text -> Bool -> Un.Term ->
                        DecWriter ()
 declareTypedNameFun sc_fun mnm nm apply_p tp =
-  let th_nm = (if apply_p then "scApply" else "sc") ++ show mnm ++ "_" ++ nm in
+  let th_nm = (if apply_p then "scApply" else "sc") ++ show mnm ++ "_" ++ Text.unpack nm in
   declareTermApplyFun th_nm (length $ fst $ Un.asPiList tp) $ \sc ts ->
   [| $(sc_fun) $(varE sc)
-   (mkIdent mnm $(stringE nm))
+   (mkIdent mnm $(stringE (Text.unpack nm)))
    $(ts) |]
 
 -- | Declare a Haskell function
@@ -150,7 +152,7 @@ declareTypedNameFun sc_fun mnm nm apply_p tp =
 --
 -- for declared name (primitive, axiom, or definition) @d@ with type @tp@ in
 -- module @MMM@
-declareDefFun :: ModuleName -> String -> Un.Term -> DecWriter ()
+declareDefFun :: ModuleName -> Text -> Un.Term -> DecWriter ()
 declareDefFun mnm d tp =
   declareTypedNameFun [| scGlobalApply |] mnm d True tp
 
@@ -159,7 +161,7 @@ declareDefFun mnm d tp =
 -- > scMMM_d :: SharedContext -> Term -> ... -> Term -> IO Term
 --
 -- for datatype @d@ with parameters @p_ctx@ and type @tp@ in module @MMM@
-declareDataTypeFun :: ModuleName -> String -> Un.Term -> DecWriter ()
+declareDataTypeFun :: ModuleName -> Text -> Un.Term -> DecWriter ()
 declareDataTypeFun mnm d tp =
   declareTypedNameFun [| scDataTypeApp |] mnm d False tp
 
@@ -168,7 +170,7 @@ declareDataTypeFun mnm d tp =
 -- > scApplyMMM_c :: SharedContext -> Term -> ... -> Term -> IO Term
 --
 -- for constructor @c@ with type (including parameters) @tp@ in module @MMM@
-declareCtorFun :: ModuleName -> String -> Un.Term -> DecWriter ()
+declareCtorFun :: ModuleName -> Text -> Un.Term -> DecWriter ()
 declareCtorFun mnm c tp =
   declareTypedNameFun [| scCtorApp |] mnm c True tp
 

--- a/saw-core/src/Verifier/SAW/SCTypeCheck.hs
+++ b/saw-core/src/Verifier/SAW/SCTypeCheck.hs
@@ -49,6 +49,7 @@ import Control.Monad.Reader
 import Data.List ( (\\) )
 import Data.Map (Map)
 import qualified Data.Map as Map
+import Data.Text (Text)
 #if !MIN_VERSION_base(4,8,0)
 import Data.Traversable (Traversable(..))
 #endif
@@ -148,7 +149,7 @@ data TCError
   | NotRecordType TypedTerm
   | BadRecordField FieldName Term
   | DanglingVar Int
-  | UnboundName String
+  | UnboundName Text
   | SubtypeFailure TypedTerm Term
   | EmptyVectorLit
   | NoSuchDataType Ident
@@ -157,7 +158,7 @@ data TCError
   | BadParamsOrArgsLength Bool Ident [Term] [Term]
   | BadConstType NameInfo Term Term
   | MalformedRecursor Term String
-  | DeclError String String
+  | DeclError Text String
   | ErrorPos Pos TCError
   | ErrorCtx LocalName Term TCError
 
@@ -202,7 +203,7 @@ prettyTCError e = runReader (helper e) ([], Nothing) where
                 , ishow ty ]
   helper (DanglingVar n) =
       ppWithPos [ return ("Dangling bound variable index: " ++ show n)]
-  helper (UnboundName str) = ppWithPos [ return ("Unbound name: " ++ str)]
+  helper (UnboundName str) = ppWithPos [ return ("Unbound name: " ++ show str)]
   helper (SubtypeFailure trm tp2) =
       ppWithPos [ return "Inferred type", ishow (typedType trm),
                   return "Not a subtype of expected type", ishow tp2,
@@ -228,7 +229,7 @@ prettyTCError e = runReader (helper e) ([], Nothing) where
       ppWithPos [ return "Malformed recursor application",
                   ishow trm, return reason ]
   helper (DeclError nm reason) =
-    ppWithPos [ return ("Malformed declaration for " ++ nm), return reason ]
+    ppWithPos [ return ("Malformed declaration for " ++ show nm), return reason ]
   helper (ErrorPos p err) =
     local (\(ctx,_) -> (ctx, Just p)) $ helper err
   helper (ErrorCtx x _ err) =

--- a/saw-core/src/Verifier/SAW/SharedTerm.hs
+++ b/saw-core/src/Verifier/SAW/SharedTerm.hs
@@ -510,7 +510,7 @@ scFindModule sc name =
 -- | Look up a definition by its identifier
 scFindDef :: SharedContext -> Ident -> IO (Maybe Def)
 scFindDef sc i =
-  findDef <$> scFindModule sc (identModule i) <*> return (identName i)
+  findDef <$> scFindModule sc (identModule i) <*> pure (identBaseName i)
 
 -- | Look up a 'Def' by its identifier, throwing an error if it is not found
 scRequireDef :: SharedContext -> Ident -> IO Def
@@ -523,7 +523,7 @@ scRequireDef sc i =
 -- | Look up a datatype by its identifier
 scFindDataType :: SharedContext -> Ident -> IO (Maybe DataType)
 scFindDataType sc i =
-  findDataType <$> scFindModule sc (identModule i) <*> return (identName i)
+  findDataType <$> scFindModule sc (identModule i) <*> pure (identBaseName i)
 
 -- | Look up a datatype by its identifier, throwing an error if it is not found
 scRequireDataType :: SharedContext -> Ident -> IO DataType
@@ -536,7 +536,7 @@ scRequireDataType sc i =
 -- | Look up a constructor by its identifier
 scFindCtor :: SharedContext -> Ident -> IO (Maybe Ctor)
 scFindCtor sc i =
-  findCtor <$> scFindModule sc (identModule i) <*> return (identName i)
+  findCtor <$> scFindModule sc (identModule i) <*> pure (identBaseName i)
 
 -- | Look up a constructor by its identifier, throwing an error if not found
 scRequireCtor :: SharedContext -> Ident -> IO Ctor


### PR DESCRIPTION
This pushes the `Text` type into the untyped AST, the `Module` type,
and much of the saw-script parser.

Fixes #124.