### PR TITLE
Remove the dodgy `eq` saw-core primitive

### DIFF
--- a/cryptol-saw-core/saw/Cryptol.sawcore
+++ b/cryptol-saw-core/saw/Cryptol.sawcore
@@ -458,11 +458,6 @@ vecCmp n a f xs ys k =
 unitCmp : #() -> #() -> Bool -> Bool;
 unitCmp _ _ _ = False;
 
-pairEq : (a b : sort 0) -> (a -> a -> Bool) -> (b -> b -> Bool) ->
-  a * b -> a * b -> Bool;
-pairEq a b f g x y =
-  and (f (fst a b x) (fst a b y)) (g (snd a b x) (snd a b y));
-
 pairCmp : (a b : sort 0) -> (a -> a -> Bool -> Bool) -> (b -> b -> Bool -> Bool)
         -> a * b -> a * b -> Bool -> Bool;
 pairCmp a b f g x12 y12 k =

--- a/saw-core/prelude/Prelude.sawcore
+++ b/saw-core/prelude/Prelude.sawcore
@@ -35,7 +35,6 @@ data UnitType : sort 0 where {
 UnitType__rec (p : UnitType -> sort 0) (f1 : p Unit) (u : UnitType) : p u
   = UnitType#rec p f1 u;
 
-
 --------------------------------------------------------------------------------
 -- Pair types
 
@@ -71,7 +70,6 @@ snd a b tup = tup.(2);
 
 uncurry (a b c : sort 0) (f : a -> b -> c) : a * b -> c
   = (\ (x : a * b) -> f x.(1) x.(2));
-
 
 --------------------------------------------------------------------------------
 -- String values
@@ -263,7 +261,6 @@ ite_false (a : sort 1) (x y : a) : Eq a (ite a False x y) y =
   trans a (ite a False x y) (iteDep (\ (b:Bool) -> a) False x y) y
         (ite_eq_iteDep a False x y) (iteDep_False (\ (_:Bool) -> a) x y);
 
-
 --
 -- Converting between Bools and Bits (cause why not?)
 --
@@ -317,6 +314,15 @@ implies = \ (a:Bool) (b:Bool) -> or (not a) b;
 -- FIXME: this rule should be derived by scDefRewriteRules
 implies__eq : (a b:Bool) -> Eq Bool (implies a b) (or (not a) b);
 implies__eq a b = Refl Bool (implies a b);
+
+
+
+unitEq : UnitType -> UnitType -> Bool;
+unitEq _ _ = True;
+
+pairEq : (a b : sort 0) -> (a -> a -> Bool) -> (b -> b -> Bool) -> a * b -> a * b -> Bool;
+pairEq a b f g x y = and ( f x.(1) y.(1) ) ( g x.(2) y.(2) );
+
 
 --
 -- Rewrite rules for booleans
@@ -654,26 +660,6 @@ impliesI (x y : Bool) : (EqTrue x -> EqTrue y) -> EqTrue (implies x y) =
 
 
 --------------------------------------------------------------------------------
--- Decidable equality
-
--- FIXME: replace universal decidable equality with a typeclass that determines
--- which types have an equality tester
-
-primitive eq : (a : sort 0) -> a -> a -> Bool;
-
-axiom eq_refl : (a : sort 0) -> (x : a) -> Eq Bool (eq a x x) True;
-
-axiom eq_Bool : Eq (Bool -> Bool -> Bool) (eq Bool) boolEq;
-
-axiom ite_eq_cong_1 : (a : sort 0)
-              -> (b : Bool) -> (x : a) -> (y : a) -> (z : a)
-              -> Eq Bool (eq a (ite a b x y) z) (ite Bool b (eq a x z) (eq a y z));
-axiom ite_eq_cong_2 : (a : sort 0)
-              -> (b : Bool) -> (x : a) -> (y : a) -> (z : a)
-              -> Eq Bool (eq a z (ite a b x y)) (ite Bool b (eq a z x) (eq a z y));
-
-
---------------------------------------------------------------------------------
 -- Either
 
 data Either (s t : sort 0) : sort 0 where {
@@ -850,9 +836,6 @@ maxNat x y =
 -- | Width(n) = 1 + floor(log_2(n))
 primitive widthNat : Nat -> Nat;
 
--- | Axiom: equalNat implements *the* equality on type Nat.
-axiom eq_Nat : Eq (Nat -> Nat -> Bool) (eq Nat) equalNat;
-
 -- | Natural exponentiation
 expNat : Nat -> Nat -> Nat;
 expNat b e =
@@ -947,9 +930,6 @@ vecEq : (n : Nat) -> (a : sort 0) -> (a -> a -> Bool)
       -> Vec n a -> Vec n a -> Bool;
 vecEq n a eqFn x y =
   foldr Bool Bool n and True (zipWith a a Bool eqFn n x y);
-
-axiom eq_Vec : (n : Nat) -> (a : sort 0)
-       -> Eq (Vec n a -> Vec n a -> Bool) (eq (Vec n a)) (vecEq n a (eq a));
 
 -- | Take a prefix of a vector.
 take : (a : sort 0) -> (m n : Nat) -> Vec (addNat m n) a -> Vec m a;
@@ -1183,16 +1163,6 @@ bvEq : (n : Nat) -> Vec n Bool -> Vec n Bool -> Bool;
 bvEq n x y = vecEq n Bool boolEq x y;
 
 axiom bvEq_refl : (n : Nat) -> (x : Vec n Bool) -> Eq Bool (bvEq n x x) True;
-
--- | Axiom: bvEq implements *the* equality operation on bitvectors.
-axiom eq_bitvector : (n : Nat) -> Eq (Vec n Bool -> Vec n Bool -> Bool) (eq (Vec n Bool)) (bvEq n);
-
-axiom eq_VecBool : (n : Nat) -> Eq (Vec n Bool -> Vec n Bool -> Bool) (eq (Vec n Bool)) (bvEq n);
-
-axiom eq_VecVec : (n : Nat) -> (m : Nat) -> (a : sort 0)
-          -> Eq (Vec n (Vec m a) -> Vec n (Vec m a) -> Bool)
-                (eq (Vec n (Vec m a)))
-                (vecEq n (Vec m a) (eq (Vec m a)));
 
 axiom equalNat_bv : (n : Nat) -> (x : Vec n Bool) -> (i : Nat) ->
                Eq Bool (equalNat i (bvToNat n x)) (bvEq n (bvNat n i) x);
@@ -1554,7 +1524,7 @@ primitive Array : sort 0 -> sort 0 -> sort 0;
 primitive arrayConstant : (a b : sort 0) -> b -> (Array a b);
 primitive arrayLookup : (a b : sort 0) -> (Array a b) -> a -> b;
 primitive arrayUpdate : (a b : sort 0) -> (Array a b) -> a -> b -> (Array a b);
-
+primitive arrayEq     : (a b : sort 0) -> (Array a b) -> (Array a b) -> Bool;
 
 --------------------------------------------------------------------------------
 -- General axioms

--- a/saw-core/src/Verifier/SAW/Prelude.hs
+++ b/saw-core/src/Verifier/SAW/Prelude.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 {- |
@@ -16,21 +17,124 @@ module Verifier.SAW.Prelude
   , module Verifier.SAW.Prelude.Constants
   ) where
 
+import qualified Data.Map as Map
+
 import Verifier.SAW.ParserUtils
 import Verifier.SAW.Prelude.Constants
 import Verifier.SAW.SharedTerm
+import Verifier.SAW.FiniteValue
 
 $(defineModuleFromFileWithFns
   "preludeModule" "scLoadPreludeModule" "prelude/Prelude.sawcore")
 
+-- | Given two terms, compute a term representing a decidable
+--   equality test between them.  The terms are assumed to
+--   be of the same type, which must be a first-order type.
+--   The returned term will be of type @Bool@.
 scEq :: SharedContext -> Term -> Term -> IO Term
 scEq sc x y = do
   xty <- scTypeOf sc x
-  scApplyPrelude_eq sc xty x y
+  fot <- asFirstOrderType sc xty
+  scDecEq sc fot (Just (x,y))
+
+-- | Given a first-order type, return the decidable equality
+--   operation on that type.  If arguments are provided, they
+--   will be applied, returning a value of type @Bool@.  If no
+--   arguments are provided a function of type @tp -> tp -> Bool@
+--   will be returned.
+scDecEq ::
+  SharedContext ->
+  FirstOrderType    {- ^ Type of elements to test for equality -} ->
+  Maybe (Term,Term) {- ^ optional arguments to apply -} ->
+  IO Term
+scDecEq sc fot args = case fot of
+  FOTBit ->
+    do fn <- scGlobalDef sc "Prelude.boolEq"
+       case args of
+         Nothing    -> return fn
+         Just (x,y) -> scApplyAll sc fn [x,y]
+
+  FOTInt ->
+    do fn <- scGlobalDef sc "Prelude.intEq"
+       case args of
+         Nothing    -> return fn
+         Just (x,y) -> scApplyAll sc fn [x,y]
+
+  FOTIntMod m ->
+    do fn <- scGlobalDef sc "Prelude.intModEq"
+       m' <- scNat sc m
+       case args of
+         Nothing    -> scApply sc fn m'
+         Just (x,y) -> scApplyAll sc fn [m',x,y]
+
+  FOTVec w FOTBit ->
+    do fn <- scGlobalDef sc "Prelude.bvEq"
+       w' <- scNat sc w
+       case args of
+         Nothing    -> scApply sc fn w'
+         Just (x,y) -> scApplyAll sc fn [w',x,y]
+
+  FOTVec w t ->
+    do fn <- scGlobalDef sc "Prelude.vecEq"
+       w' <- scNat sc w
+       t' <- scFirstOrderType sc t
+       subFn <- scDecEq sc t Nothing
+       case args of
+         Nothing    -> scApplyAll sc fn [w',t',subFn]
+         Just (x,y) -> scApplyAll sc fn [w',t',subFn,x,y]
+
+  FOTArray a b ->
+    do a' <- scFirstOrderType sc a
+       b' <- scFirstOrderType sc b
+       fn <- scGlobalDef sc "Prelude.arrayEq"
+       case args of
+         Nothing    -> scApplyAll sc fn [a',b']
+         Just (x,y) -> scApplyAll sc fn [a',b',x,y]
+
+  FOTTuple []  ->
+    case args of
+      Nothing -> scGlobalDef sc "Prelude.unitEq"
+      Just _  -> scBool sc True
+
+  FOTTuple [t] -> scDecEq sc t args
+
+  FOTTuple (t:ts) ->
+    do fnLeft  <- scDecEq sc t Nothing
+       fnRight <- scDecEq sc (FOTTuple ts) Nothing
+       fn      <- scGlobalDef sc "Prelude.pairEq"
+       t'      <- scFirstOrderType sc t
+       ts'     <- scFirstOrderType sc (FOTTuple ts)
+       case args of
+         Nothing    -> scApplyAll sc fn [t',ts',fnLeft,fnRight]
+         Just (x,y) -> scApplyAll sc fn [t',ts',fnLeft,fnRight,x,y]
+
+  FOTRec fs ->
+    case args of
+      Just (x,y) ->
+           mkRecordEqBody (Map.toList fs) x y
+
+      Nothing -> 
+        do x <- scLocalVar sc 1
+           y <- scLocalVar sc 0
+           tp   <- scFirstOrderType sc fot
+           body <-  mkRecordEqBody (Map.toList fs) x y
+           scLambdaList sc [("x",tp),("y",tp)] body
+
+ where
+  mkRecordEqBody [] _x _y = scBool sc True
+  mkRecordEqBody [(f,tp)] x y =
+     do xf <- scRecordSelect sc x f
+        yf <- scRecordSelect sc y f
+        scDecEq sc tp (Just (xf,yf))
+  mkRecordEqBody ((f,tp):fs) x y =
+     do xf   <- scRecordSelect sc x f
+        yf   <- scRecordSelect sc y f
+        fp  <- scDecEq sc tp (Just (xf,yf))
+        fsp <- mkRecordEqBody fs x y
+        scAnd sc fp fsp
 
 -- | For backwards compatibility: @Bool@ used to be a datatype, and so its
 -- creation function was called @scPrelude_Bool@ instead of
 -- @scApplyPrelude_Bool@
 scPrelude_Bool :: SharedContext -> IO Term
 scPrelude_Bool = scApplyPrelude_Bool
-

--- a/saw-core/src/Verifier/SAW/Prelude.hs
+++ b/saw-core/src/Verifier/SAW/Prelude.hs
@@ -24,6 +24,10 @@ import Verifier.SAW.Prelude.Constants
 import Verifier.SAW.SharedTerm
 import Verifier.SAW.FiniteValue
 
+import Verifier.SAW.Simulator.Concrete (evalSharedTerm)
+import Verifier.SAW.Simulator.Value (asFirstOrderTypeValue)
+
+
 $(defineModuleFromFileWithFns
   "preludeModule" "scLoadPreludeModule" "prelude/Prelude.sawcore")
 
@@ -34,8 +38,10 @@ $(defineModuleFromFileWithFns
 scEq :: SharedContext -> Term -> Term -> IO Term
 scEq sc x y = do
   xty <- scTypeOf sc x
-  fot <- asFirstOrderType sc xty
-  scDecEq sc fot (Just (x,y))
+  mmap <- scGetModuleMap sc
+  case asFirstOrderTypeValue (evalSharedTerm mmap mempty xty) of
+    Just fot -> scDecEq sc fot (Just (x,y))
+    Nothing  -> fail ("scEq: expected first order type, but got: " ++ showTerm xty)
 
 -- | Given a first-order type, return the decidable equality
 --   operation on that type.  If arguments are provided, they

--- a/saw-core/src/Verifier/SAW/Rewriter.hs
+++ b/saw-core/src/Verifier/SAW/Rewriter.hs
@@ -267,9 +267,6 @@ scMatch sc pat term =
 eqIdent :: Ident
 eqIdent = mkIdent (mkModuleName ["Prelude"]) "Eq"
 
-eqIdent' :: Ident
-eqIdent' = mkIdent (mkModuleName ["Prelude"]) "eq"
-
 ecEqIdent :: Ident
 ecEqIdent = mkIdent (mkModuleName ["Cryptol"]) "ecEq"
 
@@ -281,6 +278,9 @@ boolEqIdent = mkIdent (mkModuleName ["Prelude"]) "boolEq"
 
 vecEqIdent :: Ident
 vecEqIdent = mkIdent (mkModuleName ["Prelude"]) "vecEq"
+
+equalNatIdent :: Ident
+equalNatIdent = mkIdent (mkModuleName ["Prelude"]) "equalNat"
 
 -- | Converts a universally quantified equality proposition from a
 -- Term representation to a RewriteRule.
@@ -309,11 +309,12 @@ ruleOfProp (R.asPi -> Just (_, ty, body)) =
 ruleOfProp (R.asLambda -> Just (_, ty, body)) =
   do rule <- ruleOfProp body
      Just rule { ctxt = ty : ctxt rule }
-ruleOfProp (R.asApplyAll -> (R.isGlobalDef eqIdent' -> Just (), [_, x, y])) =
-  Just RewriteRule { ctxt = [], lhs = x, rhs = y }
+
 ruleOfProp (R.asApplyAll -> (R.isGlobalDef ecEqIdent -> Just (), [_, _, x, y])) =
   Just RewriteRule { ctxt = [], lhs = x, rhs = y }
 ruleOfProp (R.asApplyAll -> (R.isGlobalDef bvEqIdent -> Just (), [_, x, y])) =
+  Just RewriteRule { ctxt = [], lhs = x, rhs = y }
+ruleOfProp (R.asApplyAll -> (R.isGlobalDef equalNatIdent -> Just (), [x, y])) =
   Just RewriteRule { ctxt = [], lhs = x, rhs = y }
 ruleOfProp (R.asApplyAll -> (R.isGlobalDef boolEqIdent -> Just (), [x, y])) =
   Just RewriteRule { ctxt = [], lhs = x, rhs = y }

--- a/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Concrete.hs
@@ -16,7 +16,7 @@ Portability : non-portable (language extensions)
 
 module Verifier.SAW.Simulator.Concrete
        ( evalSharedTerm
-       , CValue, Concrete, Value(..), TValue(..), toTValue
+       , CValue, Concrete, Value(..), TValue(..)
        , CExtra(..)
        , toBool
        , toWord

--- a/saw-core/src/Verifier/SAW/Simulator/Prims.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Prims.hs
@@ -253,7 +253,6 @@ constMap bp = Map.fromList
   , ("Prelude.error", errorOp)
   , ("Prelude.fix", fixOp)
   -- Overloaded
-  , ("Prelude.eq", eqOp bp)
   , ("Prelude.ite", iteOp bp)
   , ("Prelude.iteDep", iteOp bp)
   -- SMT Arrays
@@ -261,6 +260,7 @@ constMap bp = Map.fromList
   , ("Prelude.arrayConstant", arrayConstantOp bp)
   , ("Prelude.arrayLookup", arrayLookupOp bp)
   , ("Prelude.arrayUpdate", arrayUpdateOp bp)
+  , ("Prelude.arrayEq", arrayEqOp bp)
   ]
 
 -- | Call this function to indicate that a programming error has
@@ -1337,3 +1337,14 @@ arrayUpdateOp bp =
   strictFun $ \e -> do
     f' <- toArray f
     VArray <$> (bpArrayUpdate bp) f' i e
+
+-- arrayEq : (a b : sort 0) -> (Array a b) -> (Array a b) -> Bool;
+arrayEqOp :: (VMonad l, Show (Extra l)) => BasePrims l -> Value l
+arrayEqOp bp =
+  constFun $
+  constFun $
+  pureFun $ \x ->
+  strictFun $ \y -> do
+    x' <- toArray x
+    y' <- toArray y
+    VBool <$> bpArrayEq bp x' y'

--- a/saw-core/src/Verifier/SAW/Simulator/Value.hs
+++ b/saw-core/src/Verifier/SAW/Simulator/Value.hs
@@ -32,6 +32,7 @@ import qualified Data.Text as Text
 import Data.Vector (Vector)
 import qualified Data.Vector as V
 import Numeric.Natural
+import GHC.Stack
 
 import Verifier.SAW.FiniteValue (FiniteType(..), FirstOrderType(..))
 import Verifier.SAW.SharedTerm
@@ -140,7 +141,7 @@ pureFun f = VFun (\x -> liftM f (force x))
 constFun :: VMonad l => Value l -> Value l
 constFun x = VFun (\_ -> return x)
 
-toTValue :: Value l -> TValue l
+toTValue :: HasCallStack => Value l -> TValue l
 toTValue (TValue x) = x
 toTValue _ = panic "Verifier.SAW.Simulator.Value.toTValue" ["Not a type value"]
 
@@ -212,18 +213,18 @@ vTupleType [] = VUnitType
 vTupleType [t] = t
 vTupleType (t : ts) = VPairType t (vTupleType ts)
 
-valPairLeft :: (VMonad l, Show (Extra l)) => Value l -> MValue l
+valPairLeft :: (HasCallStack, VMonad l, Show (Extra l)) => Value l -> MValue l
 valPairLeft (VPair t1 _) = force t1
 valPairLeft v = panic "Verifier.SAW.Simulator.Value.valPairLeft" ["Not a pair value:", show v]
 
-valPairRight :: (VMonad l, Show (Extra l)) => Value l -> MValue l
+valPairRight :: (HasCallStack, VMonad l, Show (Extra l)) => Value l -> MValue l
 valPairRight (VPair _ t2) = force t2
 valPairRight v = panic "Verifier.SAW.Simulator.Value.valPairRight" ["Not a pair value:", show v]
 
 vRecord :: Map FieldName (Thunk l) -> Value l
 vRecord m = VRecordValue (Map.assocs m)
 
-valRecordProj :: (VMonad l, Show (Extra l)) => Value l -> FieldName -> MValue l
+valRecordProj :: (HasCallStack, VMonad l, Show (Extra l)) => Value l -> FieldName -> MValue l
 valRecordProj (VRecordValue fld_map) fld
   | Just t <- lookup fld fld_map = force t
 valRecordProj v@(VRecordValue _) fld =
@@ -233,7 +234,7 @@ valRecordProj v _ =
   panic "Verifier.SAW.Simulator.Value.valRecordProj"
   ["Not a record value:", show v]
 
-apply :: (VMonad l, Show (Extra l)) => Value l -> Thunk l -> MValue l
+apply :: (HasCallStack, VMonad l, Show (Extra l)) => Value l -> Thunk l -> MValue l
 apply (VFun f) x = f x
 apply (TValue (VPiType _ f)) x = TValue <$> f x
 apply v _x = panic "Verifier.SAW.Simulator.Value.apply" ["Not a function value:", show v]


### PR DESCRIPTION
Replace it instead with an operation that examines the type
of the arguments and selects the appropriate equality function.