### PR TITLE
Add `OpenTerm` operations.

### DIFF
--- a/saw-core/src/Verifier/SAW/OpenTerm.hs
+++ b/saw-core/src/Verifier/SAW/OpenTerm.hs
@@ -26,6 +26,7 @@ module Verifier.SAW.OpenTerm (
   ctorOpenTerm, dataTypeOpenTerm, globalOpenTerm,
   applyOpenTerm, applyOpenTermMulti,
   lambdaOpenTerm, lambdaOpenTermMulti, piOpenTerm, piOpenTermMulti,
+  arrowOpenTerm,
   letOpenTerm,
   -- * Monadic operations for building terms with binders
   OpenTermM(..), completeOpenTermM,
@@ -185,6 +186,10 @@ piOpenTerm x (OpenTerm tpM) body_f = OpenTerm $
   do tp <- tpM
      body <- bindOpenTerm x tp body_f
      typeInferComplete $ Pi x tp body
+
+-- | Build a non-dependent function type.
+arrowOpenTerm :: LocalName -> OpenTerm -> OpenTerm -> OpenTerm
+arrowOpenTerm x tp body = piOpenTerm x tp (const body)
 
 -- | Build a nested sequence of Pi abstractions as an 'OpenTerm'
 piOpenTermMulti :: [(LocalName, OpenTerm)] -> ([OpenTerm] -> OpenTerm) ->

--- a/saw-core/src/Verifier/SAW/OpenTerm.hs
+++ b/saw-core/src/Verifier/SAW/OpenTerm.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 {- |
 Module      : Verifier.SAW.OpenTerm
@@ -21,6 +22,7 @@ module Verifier.SAW.OpenTerm (
   -- * Basic operations for building open terms
   closedOpenTerm, flatOpenTerm, sortOpenTerm, natOpenTerm,
   unitOpenTerm, unitTypeOpenTerm,
+  stringLitOpenTerm, stringTypeOpenTerm,
   pairOpenTerm, pairTypeOpenTerm, pairLeftOpenTerm, pairRightOpenTerm,
   tupleOpenTerm, tupleTypeOpenTerm, projTupleOpenTerm,
   ctorOpenTerm, dataTypeOpenTerm, globalOpenTerm,
@@ -36,6 +38,7 @@ module Verifier.SAW.OpenTerm (
 
 import Control.Monad
 import Control.Monad.IO.Class
+import Data.Text (Text)
 import Numeric.Natural
 
 import Verifier.SAW.Term.Functor
@@ -83,6 +86,14 @@ unitOpenTerm = flatOpenTerm UnitValue
 -- | The 'OpenTerm' for the unit type
 unitTypeOpenTerm :: OpenTerm
 unitTypeOpenTerm = flatOpenTerm UnitType
+
+-- | Build a SAW core string literal.
+stringLitOpenTerm :: Text -> OpenTerm
+stringLitOpenTerm = flatOpenTerm . StringLit
+
+-- | Return the SAW core type @String@ of strings.
+stringTypeOpenTerm :: OpenTerm
+stringTypeOpenTerm = globalOpenTerm "Prelude.String"
 
 -- | Build an 'OpenTerm' for a pair
 pairOpenTerm :: OpenTerm -> OpenTerm -> OpenTerm


### PR DESCRIPTION
This PR adds operations `arrowOpenTerm`, `stringLitOpenTerm`, and `stringTypeOpenTerm` to the `OpenTerm` module.

It seems that these operations were added in the `wip-heapster` branch only in the `TracedOpenTerm` module (04b49657e6816a2b365b9afbd1722867ca4a5321), but not in `OpenTerm` for some reason.