### PR TITLE
wip-heapster changes to Prelude to fix saw-core-coq's `make`

### DIFF
--- a/saw-core-coq/coq/generated/CryptolToCoq/CryptolPrimitivesForSAWCore.v
+++ b/saw-core-coq/coq/generated/CryptolToCoq/CryptolPrimitivesForSAWCore.v
@@ -18,8 +18,8 @@ Definition const : forall (a : Type), forall (b : Type), a -> b -> a :=
 Definition compose : forall (a : Type), forall (b : Type), forall (c : Type), (b -> c) -> (a -> b) -> a -> c :=
   fun (_1 : Type) (_2 : Type) (_3 : Type) (f : _2 -> _3) (g : _1 -> _2) (x : _1) => f (g x).
 
-Definition bvExp : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool :=
-  fun (n : @SAWCoreScaffolding.Nat) (x : @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) (y : @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) => @SAWCoreVectorsAsCoqVectors.foldr @SAWCoreScaffolding.Bool (@SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) n (fun (b : @SAWCoreScaffolding.Bool) (a : @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) => if b then @SAWCoreVectorsAsCoqVectors.bvMul n x (@SAWCoreVectorsAsCoqVectors.bvMul n a a) else @SAWCoreVectorsAsCoqVectors.bvMul n a a) (@SAWCoreVectorsAsCoqVectors.bvNat n 1) (@SAWCorePrelude.reverse n @SAWCoreScaffolding.Bool y).
+Definition bvExp : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) :=
+  fun (n : @SAWCoreScaffolding.Nat) (x : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) (y : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) => @SAWCoreVectorsAsCoqVectors.foldr (@SAWCoreScaffolding.Bool) (@SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) n (fun (b : @SAWCoreScaffolding.Bool) (a : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) => if b then @SAWCoreVectorsAsCoqVectors.bvMul n x (@SAWCoreVectorsAsCoqVectors.bvMul n a a) else @SAWCoreVectorsAsCoqVectors.bvMul n a a) (@SAWCoreVectorsAsCoqVectors.bvNat n 1) (@SAWCorePrelude.reverse n (@SAWCoreScaffolding.Bool) y).
 
 Definition updFst : forall (a : Type), forall (b : Type), (a -> a) -> prod a b -> prod a b :=
   fun (a : Type) (b : Type) (f : a -> a) (x : prod a b) => pair (f (SAWCoreScaffolding.fst x)) (SAWCoreScaffolding.snd x).
@@ -35,10 +35,10 @@ Inductive Num : Type :=
 (* Cryptol.Num_rec was skipped *)
 
 Definition getFinNat : forall (n : @Num), @SAWCoreScaffolding.Nat :=
-  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @SAWCoreScaffolding.Nat) (fun (n1 : @SAWCoreScaffolding.Nat) => n) (@SAWCoreScaffolding.error @SAWCoreScaffolding.Nat "Unexpected Fin constraint violation!"%string) n.
+  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @SAWCoreScaffolding.Nat) (fun (n1 : @SAWCoreScaffolding.Nat) => n1) (@SAWCoreScaffolding.error (@SAWCoreScaffolding.Nat) "Unexpected Fin constraint violation!"%string) n.
 
 Definition finNumRec : forall (p : @Num -> Type), (forall (n : @SAWCoreScaffolding.Nat), p (@TCNum n)) -> forall (n : @Num), p n :=
-  fun (p : @Num -> Type) (f : forall (n : @SAWCoreScaffolding.Nat), p (@TCNum n)) (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect p f (@SAWCoreScaffolding.error (p @TCInf) "Unexpected Fin constraint violation!"%string) n.
+  fun (p : @Num -> Type) (f : forall (n : @SAWCoreScaffolding.Nat), p (@TCNum n)) (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect p f (@SAWCoreScaffolding.error (p (@TCInf)) "Unexpected Fin constraint violation!"%string) n.
 
 Definition finNumRec2 : forall (p : @Num -> @Num -> Type), (forall (m : @SAWCoreScaffolding.Nat), forall (n : @SAWCoreScaffolding.Nat), p (@TCNum m) (@TCNum n)) -> forall (m : @Num), forall (n : @Num), p m n :=
   fun (p : @Num -> @Num -> Type) (f : forall (m : @SAWCoreScaffolding.Nat), forall (n : @SAWCoreScaffolding.Nat), p (@TCNum m) (@TCNum n)) => @finNumRec (fun (m : @Num) => forall (n : @Num), p m n) (fun (m : @SAWCoreScaffolding.Nat) => @finNumRec (p (@TCNum m)) (f m)).
@@ -50,16 +50,16 @@ Definition ternaryNumFun : (@SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat -
   fun (f1 : @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat) (f2 : @Num) (num1 : @Num) (num2 : @Num) (num3 : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (num1' : @Num) => @Num) (fun (n1 : @SAWCoreScaffolding.Nat) => CryptolPrimitivesForSAWCore.Num_rect (fun (num2' : @Num) => @Num) (fun (n2 : @SAWCoreScaffolding.Nat) => CryptolPrimitivesForSAWCore.Num_rect (fun (num3' : @Num) => @Num) (fun (n3 : @SAWCoreScaffolding.Nat) => @TCNum (f1 n1 n2 n3)) f2 num3) f2 num2) f2 num1.
 
 Definition tcWidth : @Num -> @Num :=
-  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @Num) (fun (x : @SAWCoreScaffolding.Nat) => @TCNum (@SAWCoreScaffolding.widthNat x)) @TCInf n.
+  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @Num) (fun (x : @SAWCoreScaffolding.Nat) => @TCNum (@SAWCoreScaffolding.widthNat x)) (@TCInf) n.
 
 Definition tcAdd : @Num -> @Num -> @Num :=
-  @binaryNumFun @SAWCorePrelude.addNat (fun (x : @SAWCoreScaffolding.Nat) => @TCInf) (fun (y : @SAWCoreScaffolding.Nat) => @TCInf) @TCInf.
+  @binaryNumFun addNat (fun (x : @SAWCoreScaffolding.Nat) => @TCInf) (fun (y : @SAWCoreScaffolding.Nat) => @TCInf) (@TCInf).
 
 Definition tcSub : @Num -> @Num -> @Num :=
-  @binaryNumFun @SAWCorePrelude.subNat (fun (x : @SAWCoreScaffolding.Nat) => @TCNum 0) (fun (y : @SAWCoreScaffolding.Nat) => @TCInf) (@TCNum 0).
+  @binaryNumFun subNat (fun (x : @SAWCoreScaffolding.Nat) => @TCNum 0) (fun (y : @SAWCoreScaffolding.Nat) => @TCInf) (@TCNum 0).
 
 Definition tcMul : @Num -> @Num -> @Num :=
-  @binaryNumFun @SAWCorePrelude.mulNat (fun (x : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.if0Nat @Num x (@TCNum 0) @TCInf) (fun (y : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.if0Nat @Num y (@TCNum 0) @TCInf) @TCInf.
+  @binaryNumFun mulNat (fun (x : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.if0Nat (@Num) x (@TCNum 0) (@TCInf)) (fun (y : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.if0Nat (@Num) y (@TCNum 0) (@TCInf)) (@TCInf).
 
 Definition tcDiv : @Num -> @Num -> @Num :=
   @binaryNumFun (fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.divNat x y) (fun (x : @SAWCoreScaffolding.Nat) => @TCNum 0) (fun (y : @SAWCoreScaffolding.Nat) => @TCInf) (@TCNum 1).
@@ -68,13 +68,13 @@ Definition tcMod : @Num -> @Num -> @Num :=
   @binaryNumFun (fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.modNat x y) (fun (x : @SAWCoreScaffolding.Nat) => @TCNum 0) (fun (y : @SAWCoreScaffolding.Nat) => @TCNum 0) (@TCNum 0).
 
 Definition tcExp : @Num -> @Num -> @Num :=
-  @binaryNumFun @SAWCorePrelude.expNat (fun (x : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.natCase (fun (_1 : @SAWCoreScaffolding.Nat) => @Num) (@TCNum 0) (fun (x_minus_1 : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.if0Nat @Num x_minus_1 (@TCNum 1) @TCInf) x) (fun (y : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.if0Nat @Num y (@TCNum 1) @TCInf) @TCInf.
+  @binaryNumFun expNat (fun (x : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.natCase (fun (_1 : @SAWCoreScaffolding.Nat) => @Num) (@TCNum 0) (fun (x_minus_1 : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.if0Nat (@Num) x_minus_1 (@TCNum 1) (@TCInf)) x) (fun (y : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.if0Nat (@Num) y (@TCNum 1) (@TCInf)) (@TCInf).
 
 Definition tcMin : @Num -> @Num -> @Num :=
-  @binaryNumFun @SAWCorePrelude.minNat (fun (x : @SAWCoreScaffolding.Nat) => @TCNum x) (fun (y : @SAWCoreScaffolding.Nat) => @TCNum y) @TCInf.
+  @binaryNumFun minNat (fun (x : @SAWCoreScaffolding.Nat) => @TCNum x) (fun (y : @SAWCoreScaffolding.Nat) => @TCNum y) (@TCInf).
 
 Definition tcMax : @Num -> @Num -> @Num :=
-  @binaryNumFun @SAWCorePrelude.maxNat (fun (x : @SAWCoreScaffolding.Nat) => @TCInf) (fun (y : @SAWCoreScaffolding.Nat) => @TCInf) @TCInf.
+  @binaryNumFun maxNat (fun (x : @SAWCoreScaffolding.Nat) => @TCInf) (fun (y : @SAWCoreScaffolding.Nat) => @TCInf) (@TCInf).
 
 Definition ceilDivNat : @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat :=
   fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.divNat (@SAWCorePrelude.addNat x (@SAWCorePrelude.subNat y 1)) y.
@@ -83,16 +83,16 @@ Definition ceilModNat : @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat -> @S
   fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.subNat (@SAWCorePrelude.mulNat (@ceilDivNat x y) y) x.
 
 Definition tcCeilDiv : @Num -> @Num -> @Num :=
-  @binaryNumFun @ceilDivNat (fun (x : @SAWCoreScaffolding.Nat) => @TCNum 0) (fun (y : @SAWCoreScaffolding.Nat) => @TCInf) @TCInf.
+  @binaryNumFun ceilDivNat (fun (x : @SAWCoreScaffolding.Nat) => @TCNum 0) (fun (y : @SAWCoreScaffolding.Nat) => @TCInf) (@TCInf).
 
 Definition tcCeilMod : @Num -> @Num -> @Num :=
-  @binaryNumFun @ceilModNat (fun (x : @SAWCoreScaffolding.Nat) => @TCNum 0) (fun (y : @SAWCoreScaffolding.Nat) => @TCInf) @TCInf.
+  @binaryNumFun ceilModNat (fun (x : @SAWCoreScaffolding.Nat) => @TCNum 0) (fun (y : @SAWCoreScaffolding.Nat) => @TCInf) (@TCInf).
 
 Definition tcLenFromThenTo_Nat : @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat :=
   fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) (z : @SAWCoreScaffolding.Nat) => if @SAWCorePrelude.ltNat x y then if @SAWCorePrelude.ltNat z x then 0 else @SAWCorePrelude.addNat (@SAWCorePrelude.divNat (@SAWCorePrelude.subNat z x) (@SAWCorePrelude.subNat y x)) 1 else if @SAWCorePrelude.ltNat x z then 0 else @SAWCorePrelude.addNat (@SAWCorePrelude.divNat (@SAWCorePrelude.subNat x z) (@SAWCorePrelude.subNat x y)) 1.
 
 Definition tcLenFromThenTo : @Num -> @Num -> @Num -> @Num :=
-  @ternaryNumFun @tcLenFromThenTo_Nat @TCInf.
+  @ternaryNumFun tcLenFromThenTo_Nat (@TCInf).
 
 Definition seq : @Num -> Type -> Type :=
   fun (num : @Num) (a : Type) => CryptolPrimitivesForSAWCore.Num_rect (fun (num1 : @Num) => Type) (fun (n : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.Vec n a) (@SAWCorePrelude.Stream a) num.
@@ -100,50 +100,53 @@ Definition seq : @Num -> Type -> Type :=
 Definition seq_TCNum : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), @SAWCoreScaffolding.Eq Type (@seq (@TCNum n) a) (@SAWCoreVectorsAsCoqVectors.Vec n a) :=
   fun (n : @SAWCoreScaffolding.Nat) (a : Type) => @SAWCoreScaffolding.Refl Type (@SAWCoreVectorsAsCoqVectors.Vec n a).
 
-Definition seq_TCInf : forall (a : Type), @SAWCoreScaffolding.Eq Type (@seq @TCInf a) (@SAWCorePrelude.Stream a) :=
+Definition seq_TCInf : forall (a : Type), @SAWCoreScaffolding.Eq Type (@seq (@TCInf) a) (@SAWCorePrelude.Stream a) :=
   fun (a : Type) => @SAWCoreScaffolding.Refl Type (@SAWCorePrelude.Stream a).
 
 Definition seqMap : forall (a : Type), forall (b : Type), forall (n : @Num), (a -> b) -> @seq n a -> @seq n b :=
   fun (a : Type) (b : Type) (num : @Num) (f : a -> b) => CryptolPrimitivesForSAWCore.Num_rect (fun (n : @Num) => @seq n a -> @seq n b) (@SAWCorePrelude.map a b f) (@SAWCorePrelude.streamMap a b f) num.
 
 Definition seqConst : forall (n : @Num), forall (a : Type), a -> @seq n a :=
-  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => forall (a : Type), a -> @seq n a) @SAWCorePrelude.replicate @SAWCorePrelude.streamConst n.
+  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => forall (a : Type), a -> @seq n1 a) replicate streamConst n.
 
 Definition IntModNum : forall (num : @Num), Type :=
-  fun (num : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n : @Num) => Type) @SAWCoreScaffolding.IntMod @SAWCoreScaffolding.Integer num.
+  fun (num : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n : @Num) => Type) (@SAWCoreScaffolding.IntMod) (@SAWCoreScaffolding.Integer) num.
 
 Definition Rational : Type :=
   unit.
 
-Definition ecRatio : @SAWCoreScaffolding.Integer -> @SAWCoreScaffolding.Integer -> @Rational :=
+Definition ecRatio : @SAWCoreScaffolding.Integer -> @SAWCoreScaffolding.Integer -> Rational :=
   fun (x : @SAWCoreScaffolding.Integer) (y : @SAWCoreScaffolding.Integer) => tt.
 
-Definition eqRational : @Rational -> @Rational -> @SAWCoreScaffolding.Bool :=
-  fun (x : unit) (y : unit) => @SAWCoreScaffolding.error @SAWCoreScaffolding.Bool "Unimplemented: (==) Rational"%string.
+Definition eqRational : Rational -> Rational -> @SAWCoreScaffolding.Bool :=
+  fun (x : unit) (y : unit) => @SAWCoreScaffolding.error (@SAWCoreScaffolding.Bool) "Unimplemented: (==) Rational"%string.
 
-Definition ltRational : @Rational -> @Rational -> @SAWCoreScaffolding.Bool :=
-  fun (x : unit) (y : unit) => @SAWCoreScaffolding.error @SAWCoreScaffolding.Bool "Unimplemented: (<) Rational"%string.
+Definition ltRational : Rational -> Rational -> @SAWCoreScaffolding.Bool :=
+  fun (x : unit) (y : unit) => @SAWCoreScaffolding.error (@SAWCoreScaffolding.Bool) "Unimplemented: (<) Rational"%string.
 
-Definition addRational : @Rational -> @Rational -> @Rational :=
-  fun (x : unit) (y : unit) => @SAWCoreScaffolding.error @Rational "Unimplemented: (+) Rational"%string.
+Definition addRational : Rational -> Rational -> Rational :=
+  fun (x : unit) (y : unit) => @SAWCoreScaffolding.error Rational "Unimplemented: (+) Rational"%string.
 
-Definition subRational : @Rational -> @Rational -> @Rational :=
-  fun (x : unit) (y : unit) => @SAWCoreScaffolding.error @Rational "Unimplemented: (-) Rational"%string.
+Definition subRational : Rational -> Rational -> Rational :=
+  fun (x : unit) (y : unit) => @SAWCoreScaffolding.error Rational "Unimplemented: (-) Rational"%string.
 
-Definition mulRational : @Rational -> @Rational -> @Rational :=
-  fun (x : unit) (y : unit) => @SAWCoreScaffolding.error @Rational "Unimplemented: (*) Rational"%string.
+Definition mulRational : Rational -> Rational -> Rational :=
+  fun (x : unit) (y : unit) => @SAWCoreScaffolding.error Rational "Unimplemented: (*) Rational"%string.
 
-Definition negRational : @Rational -> @Rational :=
-  fun (x : unit) => @SAWCoreScaffolding.error @Rational "Unimplemented: negate Rational"%string.
+Definition negRational : Rational -> Rational :=
+  fun (x : unit) => @SAWCoreScaffolding.error Rational "Unimplemented: negate Rational"%string.
 
-Definition integerToRational : @SAWCoreScaffolding.Integer -> @Rational :=
-  fun (x : @SAWCoreScaffolding.Integer) => @SAWCoreScaffolding.error @Rational "Unimplemented: fromInteger Rational"%string.
+Definition integerToRational : @SAWCoreScaffolding.Integer -> Rational :=
+  fun (x : @SAWCoreScaffolding.Integer) => @SAWCoreScaffolding.error Rational "Unimplemented: fromInteger Rational"%string.
 
-Definition seq_cong : forall (m : @Num), forall (n : @Num), forall (a : Type), forall (b : Type), @SAWCoreScaffolding.Eq @Num m n -> @SAWCoreScaffolding.Eq Type a b -> @SAWCoreScaffolding.Eq Type (@seq m a) (@seq n b) :=
-  fun (m : @Num) (n : @Num) (a : Type) (b : Type) (eq_mn : @SAWCoreScaffolding.Eq @Num m n) (eq_ab : @SAWCoreScaffolding.Eq Type a b) => @SAWCorePrelude.trans Type (@seq m a) (@seq n a) (@seq n b) (@SAWCorePrelude.eq_cong @Num m n eq_mn Type (fun (x : @Num) => @seq x a)) (@SAWCorePrelude.eq_cong Type a b eq_ab Type (fun (x : Type) => @seq n x)).
+Definition seq_cong : forall (m : @Num), forall (n : @Num), forall (a : Type), forall (b : Type), @SAWCoreScaffolding.Eq (@Num) m n -> @SAWCoreScaffolding.Eq Type a b -> @SAWCoreScaffolding.Eq Type (@seq m a) (@seq n b) :=
+  fun (m : @Num) (n : @Num) (a : Type) (b : Type) (eq_mn : @SAWCoreScaffolding.Eq (@Num) m n) (eq_ab : @SAWCoreScaffolding.Eq Type a b) => @SAWCorePrelude.trans Type (@seq m a) (@seq n a) (@seq n b) (@SAWCorePrelude.eq_cong (@Num) m n eq_mn Type (fun (x : @Num) => @seq x a)) (@SAWCorePrelude.eq_cong Type a b eq_ab Type (fun (x : Type) => @seq n x)).
 
-Definition seq_cong1 : forall (m : @Num), forall (n : @Num), forall (a : Type), @SAWCoreScaffolding.Eq @Num m n -> @SAWCoreScaffolding.Eq Type (@seq m a) (@seq n a) :=
-  fun (m : @Num) (n : @Num) (a : Type) (eq_mn : @SAWCoreScaffolding.Eq @Num m n) => @SAWCorePrelude.eq_cong @Num m n eq_mn Type (fun (x : @Num) => @seq x a).
+Definition seq_cong1 : forall (m : @Num), forall (n : @Num), forall (a : Type), @SAWCoreScaffolding.Eq (@Num) m n -> @SAWCoreScaffolding.Eq Type (@seq m a) (@seq n a) :=
+  fun (m : @Num) (n : @Num) (a : Type) (eq_mn : @SAWCoreScaffolding.Eq (@Num) m n) => @SAWCorePrelude.eq_cong (@Num) m n eq_mn Type (fun (x : @Num) => @seq x a).
+
+Definition IntModNum_cong : forall (m : @Num), forall (n : @Num), @SAWCoreScaffolding.Eq (@Num) m n -> @SAWCoreScaffolding.Eq Type (@IntModNum m) (@IntModNum n) :=
+  fun (m : @Num) (n : @Num) (eq_mn : @SAWCoreScaffolding.Eq (@Num) m n) => @SAWCorePrelude.eq_cong (@Num) m n eq_mn Type IntModNum.
 
 Definition fun_cong : forall (a : Type), forall (b : Type), forall (c : Type), forall (d : Type), @SAWCoreScaffolding.Eq Type a b -> @SAWCoreScaffolding.Eq Type c d -> @SAWCoreScaffolding.Eq Type (a -> c) (b -> d) :=
   fun (a : Type) (b : Type) (c : Type) (d : Type) (eq_ab : @SAWCoreScaffolding.Eq Type a b) (eq_cd : @SAWCoreScaffolding.Eq Type c d) => @SAWCorePrelude.trans Type (a -> c) (b -> c) (b -> d) (@SAWCorePrelude.eq_cong Type a b eq_ab Type (fun (x : Type) => x -> c)) (@SAWCorePrelude.eq_cong Type c d eq_cd Type (fun (x : Type) => b -> x)).
@@ -160,16 +163,16 @@ Definition pair_cong2 : forall (a : Type), forall (b : Type), forall (b' : Type)
 (* Cryptol.unsafeAssert_same_Num was skipped *)
 
 Definition eListSel : forall (a : Type), forall (n : @Num), @seq n a -> @SAWCoreScaffolding.Nat -> a :=
-  fun (a : Type) (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (num : @Num) => @seq num a -> @SAWCoreScaffolding.Nat -> a) (fun (n1 : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.sawAt n a) (@SAWCorePrelude.streamGet a) n.
+  fun (a : Type) (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (num : @Num) => @seq num a -> @SAWCoreScaffolding.Nat -> a) (fun (n1 : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.sawAt n1 a) (@SAWCorePrelude.streamGet a) n.
 
 Definition from : forall (a : Type), forall (b : Type), forall (m : @Num), forall (n : @Num), @seq m a -> (a -> @seq n b) -> @seq (@tcMul m n) (prod a b) :=
-  fun (a : Type) (b : Type) (m : @Num) (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (m1 : @Num) => @seq m a -> (a -> @seq n b) -> @seq (@tcMul m n) (prod a b)) (fun (m1 : @SAWCoreScaffolding.Nat) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @SAWCoreVectorsAsCoqVectors.Vec m a -> (a -> @seq n b) -> @seq (@tcMul (@TCNum m) n) (prod a b)) (fun (n1 : @SAWCoreScaffolding.Nat) (xs : @SAWCoreVectorsAsCoqVectors.Vec m a) (k : a -> @SAWCoreVectorsAsCoqVectors.Vec n1 b) => @SAWCorePrelude.join m n (prod a b) (@SAWCorePrelude.map a (@SAWCoreVectorsAsCoqVectors.Vec n (prod a b)) (fun (x : a) => @SAWCorePrelude.map b (prod a b) (fun (y : b) => pair x y) n (k x)) m xs)) (@SAWCorePrelude.natCase (fun (m' : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.Vec m' a -> (a -> @SAWCorePrelude.Stream b) -> @seq (@SAWCorePrelude.if0Nat @Num m' (@TCNum 0) @TCInf) (prod a b)) (fun (xs : @SAWCoreVectorsAsCoqVectors.Vec 0 a) (k : a -> @SAWCorePrelude.Stream b) => @SAWCoreVectorsAsCoqVectors.EmptyVec (prod a b)) (fun (m' : @SAWCoreScaffolding.Nat) (xs : @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ m') a) (k : a -> @SAWCorePrelude.Stream b) => (fun (x : a) => @SAWCorePrelude.streamMap b (prod a b) (fun (y : b) => pair x y) (k x)) (@SAWCorePrelude.sawAt (@SAWCoreScaffolding.Succ m') a xs 0)) m) n) (CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @SAWCorePrelude.Stream a -> (a -> @seq n b) -> @seq (@tcMul @TCInf n) (prod a b)) (fun (n1 : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.natCase (fun (n' : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.Stream a -> (a -> @SAWCoreVectorsAsCoqVectors.Vec n' b) -> @seq (@SAWCorePrelude.if0Nat @Num n' (@TCNum 0) @TCInf) (prod a b)) (fun (xs : @SAWCorePrelude.Stream a) (k : a -> @SAWCoreVectorsAsCoqVectors.Vec 0 b) => @SAWCoreVectorsAsCoqVectors.EmptyVec (prod a b)) (fun (n' : @SAWCoreScaffolding.Nat) (xs : @SAWCorePrelude.Stream a) (k : a -> @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n') b) => @SAWCorePrelude.streamJoin (prod a b) n' (@SAWCorePrelude.streamMap a (@SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n') (prod a b)) (fun (x : a) => @SAWCorePrelude.map b (prod a b) (fun (y : b) => pair x y) (@SAWCoreScaffolding.Succ n') (k x)) xs)) n) (fun (xs : @SAWCorePrelude.Stream a) (k : a -> @SAWCorePrelude.Stream b) => (fun (x : a) => @SAWCorePrelude.streamMap b (prod a b) (fun (y : b) => pair x y) (k x)) (@SAWCorePrelude.streamGet a xs 0)) n) m.
+  fun (a : Type) (b : Type) (m : @Num) (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (m1 : @Num) => @seq m1 a -> (a -> @seq n b) -> @seq (@tcMul m1 n) (prod a b)) (fun (m1 : @SAWCoreScaffolding.Nat) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @SAWCoreVectorsAsCoqVectors.Vec m1 a -> (a -> @seq n1 b) -> @seq (@tcMul (@TCNum m1) n1) (prod a b)) (fun (n1 : @SAWCoreScaffolding.Nat) (xs : @SAWCoreVectorsAsCoqVectors.Vec m1 a) (k : a -> @SAWCoreVectorsAsCoqVectors.Vec n1 b) => @SAWCorePrelude.join m1 n1 (prod a b) (@SAWCorePrelude.map a (@SAWCoreVectorsAsCoqVectors.Vec n1 (prod a b)) (fun (x : a) => @SAWCorePrelude.map b (prod a b) (fun (y : b) => pair x y) n1 (k x)) m1 xs)) (@SAWCorePrelude.natCase (fun (m' : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.Vec m' a -> (a -> @SAWCorePrelude.Stream b) -> @seq (@SAWCorePrelude.if0Nat (@Num) m' (@TCNum 0) (@TCInf)) (prod a b)) (fun (xs : @SAWCoreVectorsAsCoqVectors.Vec 0 a) (k : a -> @SAWCorePrelude.Stream b) => @SAWCoreVectorsAsCoqVectors.EmptyVec (prod a b)) (fun (m' : @SAWCoreScaffolding.Nat) (xs : @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ m') a) (k : a -> @SAWCorePrelude.Stream b) => (fun (x : a) => @SAWCorePrelude.streamMap b (prod a b) (fun (y : b) => pair x y) (k x)) (@SAWCorePrelude.sawAt (@SAWCoreScaffolding.Succ m') a xs 0)) m1) n) (CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @SAWCorePrelude.Stream a -> (a -> @seq n1 b) -> @seq (@tcMul (@TCInf) n1) (prod a b)) (fun (n1 : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.natCase (fun (n' : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.Stream a -> (a -> @SAWCoreVectorsAsCoqVectors.Vec n' b) -> @seq (@SAWCorePrelude.if0Nat (@Num) n' (@TCNum 0) (@TCInf)) (prod a b)) (fun (xs : @SAWCorePrelude.Stream a) (k : a -> @SAWCoreVectorsAsCoqVectors.Vec 0 b) => @SAWCoreVectorsAsCoqVectors.EmptyVec (prod a b)) (fun (n' : @SAWCoreScaffolding.Nat) (xs : @SAWCorePrelude.Stream a) (k : a -> @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n') b) => @SAWCorePrelude.streamJoin (prod a b) n' (@SAWCorePrelude.streamMap a (@SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n') (prod a b)) (fun (x : a) => @SAWCorePrelude.map b (prod a b) (fun (y : b) => pair x y) (@SAWCoreScaffolding.Succ n') (k x)) xs)) n1) (fun (xs : @SAWCorePrelude.Stream a) (k : a -> @SAWCorePrelude.Stream b) => (fun (x : a) => @SAWCorePrelude.streamMap b (prod a b) (fun (y : b) => pair x y) (k x)) (@SAWCorePrelude.streamGet a xs 0)) n) m.
 
 Definition mlet : forall (a : Type), forall (b : Type), forall (n : @Num), a -> (a -> @seq n b) -> @seq n (prod a b) :=
-  fun (a : Type) (b : Type) (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => a -> (a -> @seq n b) -> @seq n (prod a b)) (fun (n1 : @SAWCoreScaffolding.Nat) (x : a) (f : a -> @SAWCoreVectorsAsCoqVectors.Vec n1 b) => @SAWCorePrelude.map b (prod a b) (fun (y : b) => pair x y) n (f x)) (fun (x : a) (f : a -> @SAWCorePrelude.Stream b) => @SAWCorePrelude.streamMap b (prod a b) (fun (y : b) => pair x y) (f x)) n.
+  fun (a : Type) (b : Type) (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => a -> (a -> @seq n1 b) -> @seq n1 (prod a b)) (fun (n1 : @SAWCoreScaffolding.Nat) (x : a) (f : a -> @SAWCoreVectorsAsCoqVectors.Vec n1 b) => @SAWCorePrelude.map b (prod a b) (fun (y : b) => pair x y) n1 (f x)) (fun (x : a) (f : a -> @SAWCorePrelude.Stream b) => @SAWCorePrelude.streamMap b (prod a b) (fun (y : b) => pair x y) (f x)) n.
 
 Definition seqZip : forall (a : Type), forall (b : Type), forall (m : @Num), forall (n : @Num), @seq m a -> @seq n b -> @seq (@tcMin m n) (prod a b) :=
-  fun (a : Type) (b : Type) (m : @Num) (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (m1 : @Num) => @seq m a -> @seq n b -> @seq (@tcMin m n) (prod a b)) (fun (m1 : @SAWCoreScaffolding.Nat) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @SAWCoreVectorsAsCoqVectors.Vec m a -> @seq n b -> @seq (@tcMin (@TCNum m) n) (prod a b)) (fun (n1 : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.zip a b m n) (fun (xs : @SAWCoreVectorsAsCoqVectors.Vec m a) (ys : @SAWCorePrelude.Stream b) => @SAWCoreVectorsAsCoqVectors.gen m (prod a b) (fun (i : @SAWCoreScaffolding.Nat) => pair (@SAWCorePrelude.sawAt m a xs i) (@SAWCorePrelude.streamGet b ys i))) n) (CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @SAWCorePrelude.Stream a -> @seq n b -> @seq (@tcMin @TCInf n) (prod a b)) (fun (n1 : @SAWCoreScaffolding.Nat) (xs : @SAWCorePrelude.Stream a) (ys : @SAWCoreVectorsAsCoqVectors.Vec n1 b) => @SAWCoreVectorsAsCoqVectors.gen n (prod a b) (fun (i : @SAWCoreScaffolding.Nat) => pair (@SAWCorePrelude.streamGet a xs i) (@SAWCorePrelude.sawAt n b ys i))) (@SAWCorePrelude.streamMap2 a b (prod a b) (fun (x : a) (y : b) => pair x y)) n) m.
+  fun (a : Type) (b : Type) (m : @Num) (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (m1 : @Num) => @seq m1 a -> @seq n b -> @seq (@tcMin m1 n) (prod a b)) (fun (m1 : @SAWCoreScaffolding.Nat) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @SAWCoreVectorsAsCoqVectors.Vec m1 a -> @seq n1 b -> @seq (@tcMin (@TCNum m1) n1) (prod a b)) (fun (n1 : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.zip a b m1 n1) (fun (xs : @SAWCoreVectorsAsCoqVectors.Vec m1 a) (ys : @SAWCorePrelude.Stream b) => @SAWCoreVectorsAsCoqVectors.gen m1 (prod a b) (fun (i : @SAWCoreScaffolding.Nat) => pair (@SAWCorePrelude.sawAt m1 a xs i) (@SAWCorePrelude.streamGet b ys i))) n) (CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @SAWCorePrelude.Stream a -> @seq n1 b -> @seq (@tcMin (@TCInf) n1) (prod a b)) (fun (n1 : @SAWCoreScaffolding.Nat) (xs : @SAWCorePrelude.Stream a) (ys : @SAWCoreVectorsAsCoqVectors.Vec n1 b) => @SAWCoreVectorsAsCoqVectors.gen n1 (prod a b) (fun (i : @SAWCoreScaffolding.Nat) => pair (@SAWCorePrelude.streamGet a xs i) (@SAWCorePrelude.sawAt n1 b ys i))) (@SAWCorePrelude.streamMap2 a b (prod a b) (fun (x : a) (y : b) => pair x y)) n) m.
 
 Definition seqBinary : forall (n : @Num), forall (a : Type), (a -> a -> a) -> @seq n a -> @seq n a -> @seq n a :=
   fun (num : @Num) (a : Type) (f : a -> a -> a) => CryptolPrimitivesForSAWCore.Num_rect (fun (n : @Num) => @seq n a -> @seq n a -> @seq n a) (fun (n : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.zipWith a a a f n) (@SAWCorePrelude.streamMap2 a a a f) num.
@@ -201,23 +204,20 @@ Definition boolCmp : @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool -> @SA
 Definition integerCmp : @SAWCoreScaffolding.Integer -> @SAWCoreScaffolding.Integer -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool :=
   fun (x : @SAWCoreScaffolding.Integer) (y : @SAWCoreScaffolding.Integer) (k : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.or (@SAWCoreScaffolding.intLt x y) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.intEq x y) k).
 
-Definition rationalCmp : @Rational -> @Rational -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool :=
+Definition rationalCmp : Rational -> Rational -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool :=
   fun (x : unit) (y : unit) (k : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.or (@ltRational x y) (@SAWCoreScaffolding.and (@eqRational x y) k).
 
-Definition bvCmp : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool :=
-  fun (n : @SAWCoreScaffolding.Nat) (x : @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) (y : @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) (k : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.or (@SAWCoreVectorsAsCoqVectors.bvult n x y) (@SAWCoreScaffolding.and (@SAWCorePrelude.bvEq n x y) k).
+Definition bvCmp : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool :=
+  fun (n : @SAWCoreScaffolding.Nat) (x : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) (y : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) (k : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.or (@SAWCoreVectorsAsCoqVectors.bvult n x y) (@SAWCoreScaffolding.and (@SAWCorePrelude.bvEq n x y) k).
 
-Definition bvSCmp : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool :=
-  fun (n : @SAWCoreScaffolding.Nat) (x : @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) (y : @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) (k : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.or (@SAWCoreVectorsAsCoqVectors.bvslt n x y) (@SAWCoreScaffolding.and (@SAWCorePrelude.bvEq n x y) k).
+Definition bvSCmp : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool :=
+  fun (n : @SAWCoreScaffolding.Nat) (x : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) (y : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) (k : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.or (@SAWCoreVectorsAsCoqVectors.bvslt n x y) (@SAWCoreScaffolding.and (@SAWCorePrelude.bvEq n x y) k).
 
 Definition vecCmp : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), (a -> a -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n a -> @SAWCoreVectorsAsCoqVectors.Vec n a -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool :=
-  fun (n : @SAWCoreScaffolding.Nat) (a : Type) (f : a -> a -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) (xs : @SAWCoreVectorsAsCoqVectors.Vec n a) (ys : @SAWCoreVectorsAsCoqVectors.Vec n a) (k : @SAWCoreScaffolding.Bool) => @SAWCoreVectorsAsCoqVectors.foldr (@SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) @SAWCoreScaffolding.Bool n (fun (f1 : @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) => f) k (@SAWCorePrelude.zipWith a a (@SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) f n xs ys).
+  fun (n : @SAWCoreScaffolding.Nat) (a : Type) (f : a -> a -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) (xs : @SAWCoreVectorsAsCoqVectors.Vec n a) (ys : @SAWCoreVectorsAsCoqVectors.Vec n a) (k : @SAWCoreScaffolding.Bool) => @SAWCoreVectorsAsCoqVectors.foldr (@SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.Bool) n (fun (f1 : @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) => f1) k (@SAWCorePrelude.zipWith a a (@SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) f n xs ys).
 
 Definition unitCmp : unit -> unit -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool :=
   fun (_1 : unit) (_2 : unit) (_3 : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.false.
-
-Definition pairEq : forall (a : Type), forall (b : Type), (a -> a -> @SAWCoreScaffolding.Bool) -> (b -> b -> @SAWCoreScaffolding.Bool) -> prod a b -> prod a b -> @SAWCoreScaffolding.Bool :=
-  fun (a : Type) (b : Type) (f : a -> a -> @SAWCoreScaffolding.Bool) (g : b -> b -> @SAWCoreScaffolding.Bool) (x : prod a b) (y : prod a b) => @SAWCoreScaffolding.and (f (@SAWCoreScaffolding.fst a b x) (@SAWCoreScaffolding.fst a b y)) (g (@SAWCoreScaffolding.snd a b x) (@SAWCoreScaffolding.snd a b y)).
 
 Definition pairCmp : forall (a : Type), forall (b : Type), (a -> a -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) -> (b -> b -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) -> prod a b -> prod a b -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool :=
   fun (a : Type) (b : Type) (f : a -> a -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) (g : b -> b -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) (x12 : prod a b) (y12 : prod a b) (k : @SAWCoreScaffolding.Bool) => f (@SAWCoreScaffolding.fst a b x12) (@SAWCoreScaffolding.fst a b y12) (g (@SAWCoreScaffolding.snd a b x12) (@SAWCoreScaffolding.snd a b y12) k).
@@ -225,65 +225,65 @@ Definition pairCmp : forall (a : Type), forall (b : Type), (a -> a -> @SAWCoreSc
 Definition PEq : Type -> Type :=
   fun (a : Type) => RecordTypeCons "eq" (a -> a -> @SAWCoreScaffolding.Bool) RecordTypeNil.
 
-Definition PEqBit : @PEq @SAWCoreScaffolding.Bool :=
-  RecordCons "eq" @SAWCoreScaffolding.boolEq RecordNil.
+Definition PEqBit : @PEq (@SAWCoreScaffolding.Bool) :=
+  RecordCons "eq" (@SAWCoreScaffolding.boolEq) RecordNil.
 
-Definition PEqInteger : @PEq @SAWCoreScaffolding.Integer :=
-  RecordCons "eq" @SAWCoreScaffolding.intEq RecordNil.
+Definition PEqInteger : @PEq (@SAWCoreScaffolding.Integer) :=
+  RecordCons "eq" (@SAWCoreScaffolding.intEq) RecordNil.
 
-Definition PEqRational : @PEq @Rational :=
-  RecordCons "eq" @eqRational RecordNil.
+Definition PEqRational : @PEq Rational :=
+  RecordCons "eq" eqRational RecordNil.
 
 Definition PEqIntMod : forall (n : @SAWCoreScaffolding.Nat), @PEq (@SAWCoreScaffolding.IntMod n) :=
   fun (n : @SAWCoreScaffolding.Nat) => RecordCons "eq" (@SAWCoreScaffolding.intModEq n) RecordNil.
 
 Definition PEqIntModNum : forall (num : @Num), @PEq (@IntModNum num) :=
-  fun (num : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n : @Num) => @PEq (@IntModNum n)) @PEqIntMod @PEqInteger num.
+  fun (num : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n : @Num) => @PEq (@IntModNum n)) PEqIntMod PEqInteger num.
 
 Definition PEqVec : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), @PEq a -> @PEq (@SAWCoreVectorsAsCoqVectors.Vec n a) :=
   fun (n : @SAWCoreScaffolding.Nat) (a : Type) (pa : RecordTypeCons "eq" (a -> a -> @SAWCoreScaffolding.Bool) RecordTypeNil) => RecordCons "eq" (@SAWCorePrelude.vecEq n a (RecordProj pa "eq")) RecordNil.
 
 Definition PEqSeq : forall (n : @Num), forall (a : Type), @PEq a -> @PEq (@seq n a) :=
-  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => forall (a : Type), @PEq a -> @PEq (@seq n a)) (fun (n1 : @SAWCoreScaffolding.Nat) => @PEqVec n) (fun (a : Type) (pa : RecordTypeCons "eq" (a -> a -> @SAWCoreScaffolding.Bool) RecordTypeNil) => @SAWCoreScaffolding.error (@PEq (@SAWCorePrelude.Stream a)) "invalid Eq instance"%string) n.
+  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => forall (a : Type), @PEq a -> @PEq (@seq n1 a)) (fun (n1 : @SAWCoreScaffolding.Nat) => @PEqVec n1) (fun (a : Type) (pa : RecordTypeCons "eq" (a -> a -> @SAWCoreScaffolding.Bool) RecordTypeNil) => @SAWCoreScaffolding.error (@PEq (@SAWCorePrelude.Stream a)) "invalid Eq instance"%string) n.
 
-Definition PEqWord : forall (n : @SAWCoreScaffolding.Nat), @PEq (@SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) :=
+Definition PEqWord : forall (n : @SAWCoreScaffolding.Nat), @PEq (@SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) :=
   fun (n : @SAWCoreScaffolding.Nat) => RecordCons "eq" (@SAWCorePrelude.bvEq n) RecordNil.
 
-Definition PEqSeqBool : forall (n : @Num), @PEq (@seq n @SAWCoreScaffolding.Bool) :=
-  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @PEq (@seq n @SAWCoreScaffolding.Bool)) (fun (n1 : @SAWCoreScaffolding.Nat) => @PEqWord n) (@SAWCoreScaffolding.error (@PEq (@SAWCorePrelude.Stream @SAWCoreScaffolding.Bool)) "invalid Eq instance"%string) n.
+Definition PEqSeqBool : forall (n : @Num), @PEq (@seq n (@SAWCoreScaffolding.Bool)) :=
+  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @PEq (@seq n1 (@SAWCoreScaffolding.Bool))) (fun (n1 : @SAWCoreScaffolding.Nat) => @PEqWord n1) (@SAWCoreScaffolding.error (@PEq (@SAWCorePrelude.Stream (@SAWCoreScaffolding.Bool))) "invalid Eq instance"%string) n.
 
 Definition PEqUnit : @PEq unit :=
   RecordCons "eq" (fun (x : unit) (y : unit) => @SAWCoreScaffolding.true) RecordNil.
 
 Definition PEqPair : forall (a : Type), forall (b : Type), @PEq a -> @PEq b -> @PEq (prod a b) :=
-  fun (a : Type) (b : Type) (pa : RecordTypeCons "eq" (a -> a -> @SAWCoreScaffolding.Bool) RecordTypeNil) (pb : RecordTypeCons "eq" (b -> b -> @SAWCoreScaffolding.Bool) RecordTypeNil) => RecordCons "eq" (@pairEq a b (RecordProj pa "eq") (RecordProj pb "eq")) RecordNil.
+  fun (a : Type) (b : Type) (pa : RecordTypeCons "eq" (a -> a -> @SAWCoreScaffolding.Bool) RecordTypeNil) (pb : RecordTypeCons "eq" (b -> b -> @SAWCoreScaffolding.Bool) RecordTypeNil) => RecordCons "eq" (@SAWCorePrelude.pairEq a b (RecordProj pa "eq") (RecordProj pb "eq")) RecordNil.
 
 Definition PCmp : Type -> Type :=
   fun (a : Type) => RecordTypeCons "cmp" (a -> a -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) (RecordTypeCons "cmpEq" (@PEq a) RecordTypeNil).
 
-Definition PCmpBit : @PCmp @SAWCoreScaffolding.Bool :=
-  RecordCons "cmp" @boolCmp (RecordCons "cmpEq" @PEqBit RecordNil).
+Definition PCmpBit : @PCmp (@SAWCoreScaffolding.Bool) :=
+  RecordCons "cmp" boolCmp (RecordCons "cmpEq" PEqBit RecordNil).
 
-Definition PCmpInteger : @PCmp @SAWCoreScaffolding.Integer :=
-  RecordCons "cmp" @integerCmp (RecordCons "cmpEq" @PEqInteger RecordNil).
+Definition PCmpInteger : @PCmp (@SAWCoreScaffolding.Integer) :=
+  RecordCons "cmp" integerCmp (RecordCons "cmpEq" PEqInteger RecordNil).
 
-Definition PCmpRational : @PCmp @Rational :=
-  RecordCons "cmp" @rationalCmp (RecordCons "cmpEq" @PEqRational RecordNil).
+Definition PCmpRational : @PCmp Rational :=
+  RecordCons "cmp" rationalCmp (RecordCons "cmpEq" PEqRational RecordNil).
 
 Definition PCmpVec : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), @PCmp a -> @PCmp (@SAWCoreVectorsAsCoqVectors.Vec n a) :=
   fun (n : @SAWCoreScaffolding.Nat) (a : Type) (pa : RecordTypeCons "cmp" (a -> a -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) (RecordTypeCons "cmpEq" (RecordTypeCons "eq" (a -> a -> @SAWCoreScaffolding.Bool) RecordTypeNil) RecordTypeNil)) => RecordCons "cmp" (@vecCmp n a (RecordProj pa "cmp")) (RecordCons "cmpEq" (@PEqVec n a (RecordProj pa "cmpEq")) RecordNil).
 
 Definition PCmpSeq : forall (n : @Num), forall (a : Type), @PCmp a -> @PCmp (@seq n a) :=
-  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => forall (a : Type), @PCmp a -> @PCmp (@seq n a)) (fun (n1 : @SAWCoreScaffolding.Nat) => @PCmpVec n) (fun (a : Type) (pa : RecordTypeCons "cmp" (a -> a -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) (RecordTypeCons "cmpEq" (RecordTypeCons "eq" (a -> a -> @SAWCoreScaffolding.Bool) RecordTypeNil) RecordTypeNil)) => @SAWCoreScaffolding.error (@PCmp (@SAWCorePrelude.Stream a)) "invalid Cmp instance"%string) n.
+  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => forall (a : Type), @PCmp a -> @PCmp (@seq n1 a)) (fun (n1 : @SAWCoreScaffolding.Nat) => @PCmpVec n1) (fun (a : Type) (pa : RecordTypeCons "cmp" (a -> a -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) (RecordTypeCons "cmpEq" (RecordTypeCons "eq" (a -> a -> @SAWCoreScaffolding.Bool) RecordTypeNil) RecordTypeNil)) => @SAWCoreScaffolding.error (@PCmp (@SAWCorePrelude.Stream a)) "invalid Cmp instance"%string) n.
 
-Definition PCmpWord : forall (n : @SAWCoreScaffolding.Nat), @PCmp (@SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) :=
+Definition PCmpWord : forall (n : @SAWCoreScaffolding.Nat), @PCmp (@SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) :=
   fun (n : @SAWCoreScaffolding.Nat) => RecordCons "cmp" (@bvCmp n) (RecordCons "cmpEq" (@PEqWord n) RecordNil).
 
-Definition PCmpSeqBool : forall (n : @Num), @PCmp (@seq n @SAWCoreScaffolding.Bool) :=
-  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @PCmp (@seq n @SAWCoreScaffolding.Bool)) (fun (n1 : @SAWCoreScaffolding.Nat) => @PCmpWord n) (@SAWCoreScaffolding.error (@PCmp (@SAWCorePrelude.Stream @SAWCoreScaffolding.Bool)) "invalid Cmp instance"%string) n.
+Definition PCmpSeqBool : forall (n : @Num), @PCmp (@seq n (@SAWCoreScaffolding.Bool)) :=
+  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @PCmp (@seq n1 (@SAWCoreScaffolding.Bool))) (fun (n1 : @SAWCoreScaffolding.Nat) => @PCmpWord n1) (@SAWCoreScaffolding.error (@PCmp (@SAWCorePrelude.Stream (@SAWCoreScaffolding.Bool))) "invalid Cmp instance"%string) n.
 
 Definition PCmpUnit : @PCmp unit :=
-  RecordCons "cmp" @unitCmp (RecordCons "cmpEq" @PEqUnit RecordNil).
+  RecordCons "cmp" unitCmp (RecordCons "cmpEq" PEqUnit RecordNil).
 
 Definition PCmpPair : forall (a : Type), forall (b : Type), @PCmp a -> @PCmp b -> @PCmp (prod a b) :=
   fun (a : Type) (b : Type) (pa : RecordTypeCons "cmp" (a -> a -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) (RecordTypeCons "cmpEq" (RecordTypeCons "eq" (a -> a -> @SAWCoreScaffolding.Bool) RecordTypeNil) RecordTypeNil)) (pb : RecordTypeCons "cmp" (b -> b -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) (RecordTypeCons "cmpEq" (RecordTypeCons "eq" (b -> b -> @SAWCoreScaffolding.Bool) RecordTypeNil) RecordTypeNil)) => RecordCons "cmp" (@pairCmp a b (RecordProj pa "cmp") (RecordProj pb "cmp")) (RecordCons "cmpEq" (@PEqPair a b (RecordProj pa "cmpEq") (RecordProj pb "cmpEq")) RecordNil).
@@ -295,16 +295,16 @@ Definition PSignedCmpVec : forall (n : @SAWCoreScaffolding.Nat), forall (a : Typ
   fun (n : @SAWCoreScaffolding.Nat) (a : Type) (pa : RecordTypeCons "scmp" (a -> a -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) (RecordTypeCons "signedCmpEq" (RecordTypeCons "eq" (a -> a -> @SAWCoreScaffolding.Bool) RecordTypeNil) RecordTypeNil)) => RecordCons "scmp" (@vecCmp n a (RecordProj pa "scmp")) (RecordCons "signedCmpEq" (@PEqVec n a (RecordProj pa "signedCmpEq")) RecordNil).
 
 Definition PSignedCmpSeq : forall (n : @Num), forall (a : Type), @PSignedCmp a -> @PSignedCmp (@seq n a) :=
-  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => forall (a : Type), @PSignedCmp a -> @PSignedCmp (@seq n a)) (fun (n1 : @SAWCoreScaffolding.Nat) => @PSignedCmpVec n) (fun (a : Type) (pa : RecordTypeCons "scmp" (a -> a -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) (RecordTypeCons "signedCmpEq" (RecordTypeCons "eq" (a -> a -> @SAWCoreScaffolding.Bool) RecordTypeNil) RecordTypeNil)) => @SAWCoreScaffolding.error (@PSignedCmp (@SAWCorePrelude.Stream a)) "invalid SignedCmp instance"%string) n.
+  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => forall (a : Type), @PSignedCmp a -> @PSignedCmp (@seq n1 a)) (fun (n1 : @SAWCoreScaffolding.Nat) => @PSignedCmpVec n1) (fun (a : Type) (pa : RecordTypeCons "scmp" (a -> a -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) (RecordTypeCons "signedCmpEq" (RecordTypeCons "eq" (a -> a -> @SAWCoreScaffolding.Bool) RecordTypeNil) RecordTypeNil)) => @SAWCoreScaffolding.error (@PSignedCmp (@SAWCorePrelude.Stream a)) "invalid SignedCmp instance"%string) n.
 
-Definition PSignedCmpWord : forall (n : @SAWCoreScaffolding.Nat), @PSignedCmp (@SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) :=
+Definition PSignedCmpWord : forall (n : @SAWCoreScaffolding.Nat), @PSignedCmp (@SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) :=
   fun (n : @SAWCoreScaffolding.Nat) => RecordCons "scmp" (@bvSCmp n) (RecordCons "signedCmpEq" (@PEqWord n) RecordNil).
 
-Definition PSignedCmpSeqBool : forall (n : @Num), @PSignedCmp (@seq n @SAWCoreScaffolding.Bool) :=
-  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @PSignedCmp (@seq n @SAWCoreScaffolding.Bool)) (fun (n1 : @SAWCoreScaffolding.Nat) => @PSignedCmpWord n) (@SAWCoreScaffolding.error (@PSignedCmp (@SAWCorePrelude.Stream @SAWCoreScaffolding.Bool)) "invalid SignedCmp instance"%string) n.
+Definition PSignedCmpSeqBool : forall (n : @Num), @PSignedCmp (@seq n (@SAWCoreScaffolding.Bool)) :=
+  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @PSignedCmp (@seq n1 (@SAWCoreScaffolding.Bool))) (fun (n1 : @SAWCoreScaffolding.Nat) => @PSignedCmpWord n1) (@SAWCoreScaffolding.error (@PSignedCmp (@SAWCorePrelude.Stream (@SAWCoreScaffolding.Bool))) "invalid SignedCmp instance"%string) n.
 
 Definition PSignedCmpUnit : @PSignedCmp unit :=
-  RecordCons "scmp" @unitCmp (RecordCons "signedCmpEq" @PEqUnit RecordNil).
+  RecordCons "scmp" unitCmp (RecordCons "signedCmpEq" PEqUnit RecordNil).
 
 Definition PSignedCmpPair : forall (a : Type), forall (b : Type), @PSignedCmp a -> @PSignedCmp b -> @PSignedCmp (prod a b) :=
   fun (a : Type) (b : Type) (pa : RecordTypeCons "scmp" (a -> a -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) (RecordTypeCons "signedCmpEq" (RecordTypeCons "eq" (a -> a -> @SAWCoreScaffolding.Bool) RecordTypeNil) RecordTypeNil)) (pb : RecordTypeCons "scmp" (b -> b -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) (RecordTypeCons "signedCmpEq" (RecordTypeCons "eq" (b -> b -> @SAWCoreScaffolding.Bool) RecordTypeNil) RecordTypeNil)) => RecordCons "scmp" (@pairCmp a b (RecordProj pa "scmp") (RecordProj pb "scmp")) (RecordCons "signedCmpEq" (@PEqPair a b (RecordProj pa "signedCmpEq") (RecordProj pb "signedCmpEq")) RecordNil).
@@ -312,26 +312,26 @@ Definition PSignedCmpPair : forall (a : Type), forall (b : Type), @PSignedCmp a 
 Definition PZero : Type -> Type :=
   fun (a : Type) => a.
 
-Definition PZeroBit : @PZero @SAWCoreScaffolding.Bool :=
+Definition PZeroBit : @PZero (@SAWCoreScaffolding.Bool) :=
   @SAWCoreScaffolding.false.
 
-Definition PZeroInteger : @PZero @SAWCoreScaffolding.Integer :=
-  @SAWCoreScaffolding.natToInt 0.
+Definition PZeroInteger : @PZero (@SAWCoreScaffolding.Integer) :=
+  0%Z.
 
 Definition PZeroIntMod : forall (n : @SAWCoreScaffolding.Nat), @PZero (@SAWCoreScaffolding.IntMod n) :=
-  fun (n : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.toIntMod n (@SAWCoreScaffolding.natToInt 0).
+  fun (n : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.toIntMod n 0%Z.
 
-Definition PZeroRational : @PZero @Rational :=
-  @integerToRational (@SAWCoreScaffolding.natToInt 0).
+Definition PZeroRational : @PZero Rational :=
+  @integerToRational 0%Z.
 
 Definition PZeroIntModNum : forall (num : @Num), @PZero (@IntModNum num) :=
-  fun (num : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n : @Num) => @PZero (@IntModNum n)) @PZeroIntMod @PZeroInteger num.
+  fun (num : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n : @Num) => @PZero (@IntModNum n)) PZeroIntMod PZeroInteger num.
 
 Definition PZeroSeq : forall (n : @Num), forall (a : Type), @PZero a -> @PZero (@seq n a) :=
   fun (n : @Num) (a : Type) (pa : a) => @seqConst n a pa.
 
-Definition PZeroSeqBool : forall (n : @Num), @PZero (@seq n @SAWCoreScaffolding.Bool) :=
-  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @PZero (@seq n @SAWCoreScaffolding.Bool)) (fun (n1 : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.bvNat n 0) (@SAWCorePrelude.streamConst @SAWCoreScaffolding.Bool @SAWCoreScaffolding.false) n.
+Definition PZeroSeqBool : forall (n : @Num), @PZero (@seq n (@SAWCoreScaffolding.Bool)) :=
+  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @PZero (@seq n1 (@SAWCoreScaffolding.Bool))) (fun (n1 : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.bvNat n1 0) (@SAWCorePrelude.streamConst (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.false)) n.
 
 Definition PZeroFun : forall (a : Type), forall (b : Type), @PZero b -> @PZero (a -> b) :=
   fun (a : Type) (b : Type) (pb : b) (_1 : a) => pb.
@@ -339,8 +339,8 @@ Definition PZeroFun : forall (a : Type), forall (b : Type), @PZero b -> @PZero (
 Definition PLogic : Type -> Type :=
   fun (a : Type) => RecordTypeCons "and" (a -> a -> a) (RecordTypeCons "logicZero" (@PZero a) (RecordTypeCons "not" (a -> a) (RecordTypeCons "or" (a -> a -> a) (RecordTypeCons "xor" (a -> a -> a) RecordTypeNil)))).
 
-Definition PLogicBit : @PLogic @SAWCoreScaffolding.Bool :=
-  RecordCons "and" @SAWCoreScaffolding.and (RecordCons "logicZero" @PZeroBit (RecordCons "not" @SAWCoreScaffolding.not (RecordCons "or" @SAWCoreScaffolding.or (RecordCons "xor" @SAWCoreScaffolding.xor RecordNil)))).
+Definition PLogicBit : @PLogic (@SAWCoreScaffolding.Bool) :=
+  RecordCons "and" (@SAWCoreScaffolding.and) (RecordCons "logicZero" PZeroBit (RecordCons "not" (@SAWCoreScaffolding.not) (RecordCons "or" (@SAWCoreScaffolding.or) (RecordCons "xor" (@SAWCoreScaffolding.xor) RecordNil)))).
 
 Definition PLogicVec : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), @PLogic a -> @PLogic (@SAWCoreVectorsAsCoqVectors.Vec n a) :=
   fun (n : @SAWCoreScaffolding.Nat) (a : Type) (pa : RecordTypeCons "and" (a -> a -> a) (RecordTypeCons "logicZero" a (RecordTypeCons "not" (a -> a) (RecordTypeCons "or" (a -> a -> a) (RecordTypeCons "xor" (a -> a -> a) RecordTypeNil))))) => RecordCons "and" (@SAWCorePrelude.zipWith a a a (RecordProj pa "and") n) (RecordCons "logicZero" (@SAWCorePrelude.replicate n a (RecordProj pa "logicZero")) (RecordCons "not" (@SAWCorePrelude.map a a (RecordProj pa "not") n) (RecordCons "or" (@SAWCorePrelude.zipWith a a a (RecordProj pa "or") n) (RecordCons "xor" (@SAWCorePrelude.zipWith a a a (RecordProj pa "xor") n) RecordNil)))).
@@ -349,19 +349,19 @@ Definition PLogicStream : forall (a : Type), @PLogic a -> @PLogic (@SAWCorePrelu
   fun (a : Type) (pa : RecordTypeCons "and" (a -> a -> a) (RecordTypeCons "logicZero" a (RecordTypeCons "not" (a -> a) (RecordTypeCons "or" (a -> a -> a) (RecordTypeCons "xor" (a -> a -> a) RecordTypeNil))))) => RecordCons "and" (@SAWCorePrelude.streamMap2 a a a (RecordProj pa "and")) (RecordCons "logicZero" (@SAWCorePrelude.streamConst a (RecordProj pa "logicZero")) (RecordCons "not" (@SAWCorePrelude.streamMap a a (RecordProj pa "not")) (RecordCons "or" (@SAWCorePrelude.streamMap2 a a a (RecordProj pa "or")) (RecordCons "xor" (@SAWCorePrelude.streamMap2 a a a (RecordProj pa "xor")) RecordNil)))).
 
 Definition PLogicSeq : forall (n : @Num), forall (a : Type), @PLogic a -> @PLogic (@seq n a) :=
-  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => forall (a : Type), @PLogic a -> @PLogic (@seq n a)) (fun (n1 : @SAWCoreScaffolding.Nat) => @PLogicVec n) @PLogicStream n.
+  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => forall (a : Type), @PLogic a -> @PLogic (@seq n1 a)) (fun (n1 : @SAWCoreScaffolding.Nat) => @PLogicVec n1) PLogicStream n.
 
-Definition PLogicWord : forall (n : @SAWCoreScaffolding.Nat), @PLogic (@SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) :=
+Definition PLogicWord : forall (n : @SAWCoreScaffolding.Nat), @PLogic (@SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) :=
   fun (n : @SAWCoreScaffolding.Nat) => RecordCons "and" (@SAWCorePrelude.bvAnd n) (RecordCons "logicZero" (@SAWCoreVectorsAsCoqVectors.bvNat n 0) (RecordCons "not" (@SAWCorePrelude.bvNot n) (RecordCons "or" (@SAWCorePrelude.bvOr n) (RecordCons "xor" (@SAWCorePrelude.bvXor n) RecordNil)))).
 
-Definition PLogicSeqBool : forall (n : @Num), @PLogic (@seq n @SAWCoreScaffolding.Bool) :=
-  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @PLogic (@seq n @SAWCoreScaffolding.Bool)) (fun (n1 : @SAWCoreScaffolding.Nat) => @PLogicWord n) (@PLogicStream @SAWCoreScaffolding.Bool @PLogicBit) n.
+Definition PLogicSeqBool : forall (n : @Num), @PLogic (@seq n (@SAWCoreScaffolding.Bool)) :=
+  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @PLogic (@seq n1 (@SAWCoreScaffolding.Bool))) (fun (n1 : @SAWCoreScaffolding.Nat) => @PLogicWord n1) (@PLogicStream (@SAWCoreScaffolding.Bool) PLogicBit) n.
 
 Definition PLogicFun : forall (a : Type), forall (b : Type), @PLogic b -> @PLogic (a -> b) :=
   fun (a : Type) (b : Type) (pb : RecordTypeCons "and" (b -> b -> b) (RecordTypeCons "logicZero" b (RecordTypeCons "not" (b -> b) (RecordTypeCons "or" (b -> b -> b) (RecordTypeCons "xor" (b -> b -> b) RecordTypeNil))))) => RecordCons "and" (@funBinary a b (RecordProj pb "and")) (RecordCons "logicZero" (@PZeroFun a b (RecordProj pb "logicZero")) (RecordCons "not" (@compose a b b (RecordProj pb "not")) (RecordCons "or" (@funBinary a b (RecordProj pb "or")) (RecordCons "xor" (@funBinary a b (RecordProj pb "xor")) RecordNil)))).
 
 Definition PLogicUnit : @PLogic unit :=
-  RecordCons "and" @unitBinary (RecordCons "logicZero" tt (RecordCons "not" @unitUnary (RecordCons "or" @unitBinary (RecordCons "xor" @unitBinary RecordNil)))).
+  RecordCons "and" unitBinary (RecordCons "logicZero" tt (RecordCons "not" unitUnary (RecordCons "or" unitBinary (RecordCons "xor" unitBinary RecordNil)))).
 
 Definition PLogicPair : forall (a : Type), forall (b : Type), @PLogic a -> @PLogic b -> @PLogic (prod a b) :=
   fun (a : Type) (b : Type) (pa : RecordTypeCons "and" (a -> a -> a) (RecordTypeCons "logicZero" a (RecordTypeCons "not" (a -> a) (RecordTypeCons "or" (a -> a -> a) (RecordTypeCons "xor" (a -> a -> a) RecordTypeNil))))) (pb : RecordTypeCons "and" (b -> b -> b) (RecordTypeCons "logicZero" b (RecordTypeCons "not" (b -> b) (RecordTypeCons "or" (b -> b -> b) (RecordTypeCons "xor" (b -> b -> b) RecordTypeNil))))) => RecordCons "and" (@pairBinary a b (RecordProj pa "and") (RecordProj pb "and")) (RecordCons "logicZero" (pair (RecordProj pa "logicZero") (RecordProj pb "logicZero")) (RecordCons "not" (@pairUnary a b (RecordProj pa "not") (RecordProj pb "not")) (RecordCons "or" (@pairBinary a b (RecordProj pa "or") (RecordProj pb "or")) (RecordCons "xor" (@pairBinary a b (RecordProj pa "xor") (RecordProj pb "xor")) RecordNil)))).
@@ -369,17 +369,17 @@ Definition PLogicPair : forall (a : Type), forall (b : Type), @PLogic a -> @PLog
 Definition PRing : Type -> Type :=
   fun (a : Type) => RecordTypeCons "add" (a -> a -> a) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> a) (RecordTypeCons "mul" (a -> a -> a) (RecordTypeCons "neg" (a -> a) (RecordTypeCons "ringZero" (@PZero a) (RecordTypeCons "sub" (a -> a -> a) RecordTypeNil))))).
 
-Definition PRingInteger : @PRing @SAWCoreScaffolding.Integer :=
-  RecordCons "add" @SAWCoreScaffolding.intAdd (RecordCons "int" (fun (i : @SAWCoreScaffolding.Integer) => i) (RecordCons "mul" @SAWCoreScaffolding.intMul (RecordCons "neg" @SAWCoreScaffolding.intNeg (RecordCons "ringZero" @PZeroInteger (RecordCons "sub" @SAWCoreScaffolding.intSub RecordNil))))).
+Definition PRingInteger : @PRing (@SAWCoreScaffolding.Integer) :=
+  RecordCons "add" (@SAWCoreScaffolding.intAdd) (RecordCons "int" (fun (i : @SAWCoreScaffolding.Integer) => i) (RecordCons "mul" (@SAWCoreScaffolding.intMul) (RecordCons "neg" (@SAWCoreScaffolding.intNeg) (RecordCons "ringZero" PZeroInteger (RecordCons "sub" (@SAWCoreScaffolding.intSub) RecordNil))))).
 
 Definition PRingIntMod : forall (n : @SAWCoreScaffolding.Nat), @PRing (@SAWCoreScaffolding.IntMod n) :=
   fun (n : @SAWCoreScaffolding.Nat) => RecordCons "add" (@SAWCoreScaffolding.intModAdd n) (RecordCons "int" (@SAWCoreScaffolding.toIntMod n) (RecordCons "mul" (@SAWCoreScaffolding.intModMul n) (RecordCons "neg" (@SAWCoreScaffolding.intModNeg n) (RecordCons "ringZero" (@PZeroIntMod n) (RecordCons "sub" (@SAWCoreScaffolding.intModSub n) RecordNil))))).
 
 Definition PRingIntModNum : forall (num : @Num), @PRing (@IntModNum num) :=
-  fun (num : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n : @Num) => @PRing (@IntModNum n)) @PRingIntMod @PRingInteger num.
+  fun (num : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n : @Num) => @PRing (@IntModNum n)) PRingIntMod PRingInteger num.
 
-Definition PRingRational : @PRing @Rational :=
-  RecordCons "add" @addRational (RecordCons "int" @integerToRational (RecordCons "mul" @mulRational (RecordCons "neg" @negRational (RecordCons "ringZero" @PZeroRational (RecordCons "sub" @subRational RecordNil))))).
+Definition PRingRational : @PRing Rational :=
+  RecordCons "add" addRational (RecordCons "int" integerToRational (RecordCons "mul" mulRational (RecordCons "neg" negRational (RecordCons "ringZero" PZeroRational (RecordCons "sub" subRational RecordNil))))).
 
 Definition PRingVec : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), @PRing a -> @PRing (@SAWCoreVectorsAsCoqVectors.Vec n a) :=
   fun (n : @SAWCoreScaffolding.Nat) (a : Type) (pa : RecordTypeCons "add" (a -> a -> a) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> a) (RecordTypeCons "mul" (a -> a -> a) (RecordTypeCons "neg" (a -> a) (RecordTypeCons "ringZero" a (RecordTypeCons "sub" (a -> a -> a) RecordTypeNil)))))) => RecordCons "add" (@SAWCorePrelude.zipWith a a a (RecordProj pa "add") n) (RecordCons "int" (fun (i : @SAWCoreScaffolding.Integer) => @SAWCorePrelude.replicate n a (RecordProj pa "int" i)) (RecordCons "mul" (@SAWCorePrelude.zipWith a a a (RecordProj pa "mul") n) (RecordCons "neg" (@SAWCorePrelude.map a a (RecordProj pa "neg") n) (RecordCons "ringZero" (@SAWCorePrelude.replicate n a (RecordProj pa "ringZero")) (RecordCons "sub" (@SAWCorePrelude.zipWith a a a (RecordProj pa "sub") n) RecordNil))))).
@@ -388,19 +388,19 @@ Definition PRingStream : forall (a : Type), @PRing a -> @PRing (@SAWCorePrelude.
   fun (a : Type) (pa : RecordTypeCons "add" (a -> a -> a) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> a) (RecordTypeCons "mul" (a -> a -> a) (RecordTypeCons "neg" (a -> a) (RecordTypeCons "ringZero" a (RecordTypeCons "sub" (a -> a -> a) RecordTypeNil)))))) => RecordCons "add" (@SAWCorePrelude.streamMap2 a a a (RecordProj pa "add")) (RecordCons "int" (fun (i : @SAWCoreScaffolding.Integer) => @SAWCorePrelude.streamConst a (RecordProj pa "int" i)) (RecordCons "mul" (@SAWCorePrelude.streamMap2 a a a (RecordProj pa "mul")) (RecordCons "neg" (@SAWCorePrelude.streamMap a a (RecordProj pa "neg")) (RecordCons "ringZero" (@SAWCorePrelude.streamConst a (RecordProj pa "ringZero")) (RecordCons "sub" (@SAWCorePrelude.streamMap2 a a a (RecordProj pa "sub")) RecordNil))))).
 
 Definition PRingSeq : forall (n : @Num), forall (a : Type), @PRing a -> @PRing (@seq n a) :=
-  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => forall (a : Type), @PRing a -> @PRing (@seq n a)) (fun (n1 : @SAWCoreScaffolding.Nat) => @PRingVec n) @PRingStream n.
+  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => forall (a : Type), @PRing a -> @PRing (@seq n1 a)) (fun (n1 : @SAWCoreScaffolding.Nat) => @PRingVec n1) PRingStream n.
 
-Definition PRingWord : forall (n : @SAWCoreScaffolding.Nat), @PRing (@SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) :=
-  fun (n : @SAWCoreScaffolding.Nat) => RecordCons "add" (@SAWCoreVectorsAsCoqVectors.bvAdd n) (RecordCons "int" (@SAWCorePrelude.intToBv n) (RecordCons "mul" (@SAWCoreVectorsAsCoqVectors.bvMul n) (RecordCons "neg" (@SAWCoreVectorsAsCoqVectors.bvNeg n) (RecordCons "ringZero" (@SAWCoreVectorsAsCoqVectors.bvNat n 0) (RecordCons "sub" (@SAWCoreVectorsAsCoqVectors.bvSub n) RecordNil))))).
+Definition PRingWord : forall (n : @SAWCoreScaffolding.Nat), @PRing (@SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) :=
+  fun (n : @SAWCoreScaffolding.Nat) => RecordCons "add" (@SAWCoreVectorsAsCoqVectors.bvAdd n) (RecordCons "int" (@SAWCoreVectorsAsCoqVectors.intToBv n) (RecordCons "mul" (@SAWCoreVectorsAsCoqVectors.bvMul n) (RecordCons "neg" (@SAWCoreVectorsAsCoqVectors.bvNeg n) (RecordCons "ringZero" (@SAWCoreVectorsAsCoqVectors.bvNat n 0) (RecordCons "sub" (@SAWCoreVectorsAsCoqVectors.bvSub n) RecordNil))))).
 
-Definition PRingSeqBool : forall (n : @Num), @PRing (@seq n @SAWCoreScaffolding.Bool) :=
-  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @PRing (@seq n @SAWCoreScaffolding.Bool)) (fun (n1 : @SAWCoreScaffolding.Nat) => @PRingWord n) (@SAWCoreScaffolding.error (@PRing (@SAWCorePrelude.Stream @SAWCoreScaffolding.Bool)) "PRingSeqBool: no instance for streams"%string) n.
+Definition PRingSeqBool : forall (n : @Num), @PRing (@seq n (@SAWCoreScaffolding.Bool)) :=
+  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @PRing (@seq n1 (@SAWCoreScaffolding.Bool))) (fun (n1 : @SAWCoreScaffolding.Nat) => @PRingWord n1) (@SAWCoreScaffolding.error (@PRing (@SAWCorePrelude.Stream (@SAWCoreScaffolding.Bool))) "PRingSeqBool: no instance for streams"%string) n.
 
 Definition PRingFun : forall (a : Type), forall (b : Type), @PRing b -> @PRing (a -> b) :=
   fun (a : Type) (b : Type) (pb : RecordTypeCons "add" (b -> b -> b) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> b) (RecordTypeCons "mul" (b -> b -> b) (RecordTypeCons "neg" (b -> b) (RecordTypeCons "ringZero" b (RecordTypeCons "sub" (b -> b -> b) RecordTypeNil)))))) => RecordCons "add" (@funBinary a b (RecordProj pb "add")) (RecordCons "int" (fun (i : @SAWCoreScaffolding.Integer) (_1 : a) => RecordProj pb "int" i) (RecordCons "mul" (@funBinary a b (RecordProj pb "mul")) (RecordCons "neg" (@compose a b b (RecordProj pb "neg")) (RecordCons "ringZero" (@PZeroFun a b (RecordProj pb "ringZero")) (RecordCons "sub" (@funBinary a b (RecordProj pb "sub")) RecordNil))))).
 
 Definition PRingUnit : @PRing unit :=
-  RecordCons "add" @unitBinary (RecordCons "int" (fun (i : @SAWCoreScaffolding.Integer) => tt) (RecordCons "mul" @unitBinary (RecordCons "neg" @unitUnary (RecordCons "ringZero" tt (RecordCons "sub" @unitBinary RecordNil))))).
+  RecordCons "add" unitBinary (RecordCons "int" (fun (i : @SAWCoreScaffolding.Integer) => tt) (RecordCons "mul" unitBinary (RecordCons "neg" unitUnary (RecordCons "ringZero" tt (RecordCons "sub" unitBinary RecordNil))))).
 
 Definition PRingPair : forall (a : Type), forall (b : Type), @PRing a -> @PRing b -> @PRing (prod a b) :=
   fun (a : Type) (b : Type) (pa : RecordTypeCons "add" (a -> a -> a) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> a) (RecordTypeCons "mul" (a -> a -> a) (RecordTypeCons "neg" (a -> a) (RecordTypeCons "ringZero" a (RecordTypeCons "sub" (a -> a -> a) RecordTypeNil)))))) (pb : RecordTypeCons "add" (b -> b -> b) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> b) (RecordTypeCons "mul" (b -> b -> b) (RecordTypeCons "neg" (b -> b) (RecordTypeCons "ringZero" b (RecordTypeCons "sub" (b -> b -> b) RecordTypeNil)))))) => RecordCons "add" (@pairBinary a b (RecordProj pa "add") (RecordProj pb "add")) (RecordCons "int" (fun (i : @SAWCoreScaffolding.Integer) => pair (RecordProj pa "int" i) (RecordProj pb "int" i)) (RecordCons "mul" (@pairBinary a b (RecordProj pa "mul") (RecordProj pb "mul")) (RecordCons "neg" (@pairUnary a b (RecordProj pa "neg") (RecordProj pb "neg")) (RecordCons "ringZero" (pair (RecordProj pa "ringZero") (RecordProj pb "ringZero")) (RecordCons "sub" (@pairBinary a b (RecordProj pa "sub") (RecordProj pb "sub")) RecordNil))))).
@@ -408,59 +408,59 @@ Definition PRingPair : forall (a : Type), forall (b : Type), @PRing a -> @PRing 
 Definition PIntegral : Type -> Type :=
   fun (a : Type) => RecordTypeCons "div" (a -> a -> a) (RecordTypeCons "integralRing" (@PRing a) (RecordTypeCons "mod" (a -> a -> a) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> a -> r) (RecordTypeCons "toInt" (a -> @SAWCoreScaffolding.Integer) RecordTypeNil)))).
 
-Definition PIntegralInteger : @PIntegral @SAWCoreScaffolding.Integer :=
-  RecordCons "div" @SAWCoreScaffolding.intDiv (RecordCons "integralRing" @PRingInteger (RecordCons "mod" @SAWCoreScaffolding.intMod (RecordCons "posNegCases" (fun (r : Type) (pos : @SAWCoreScaffolding.Nat -> r) (neg : @SAWCoreScaffolding.Nat -> r) (i : @SAWCoreScaffolding.Integer) => if @SAWCoreScaffolding.intLe (@SAWCoreScaffolding.natToInt 0) i then pos (@SAWCoreScaffolding.intToNat i) else neg (@SAWCoreScaffolding.intToNat (@SAWCoreScaffolding.intNeg i))) (RecordCons "toInt" (fun (i : @SAWCoreScaffolding.Integer) => i) RecordNil)))).
+Definition PIntegralInteger : @PIntegral (@SAWCoreScaffolding.Integer) :=
+  RecordCons "div" (@SAWCoreScaffolding.intDiv) (RecordCons "integralRing" PRingInteger (RecordCons "mod" (@SAWCoreScaffolding.intMod) (RecordCons "posNegCases" (fun (r : Type) (pos : @SAWCoreScaffolding.Nat -> r) (neg : @SAWCoreScaffolding.Nat -> r) (i : @SAWCoreScaffolding.Integer) => if @SAWCoreScaffolding.intLe 0%Z i then pos (@SAWCoreScaffolding.intToNat i) else neg (@SAWCoreScaffolding.intToNat (@SAWCoreScaffolding.intNeg i))) (RecordCons "toInt" (fun (i : @SAWCoreScaffolding.Integer) => i) RecordNil)))).
 
-Definition PIntegralWord : forall (n : @SAWCoreScaffolding.Nat), @PIntegral (@SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) :=
-  fun (n : @SAWCoreScaffolding.Nat) => RecordCons "div" (@SAWCoreVectorsAsCoqVectors.bvUDiv n) (RecordCons "integralRing" (@PRingWord n) (RecordCons "mod" (@SAWCoreVectorsAsCoqVectors.bvURem n) (RecordCons "posNegCases" (fun (r : Type) (pos : @SAWCoreScaffolding.Nat -> r) (neg : @SAWCoreScaffolding.Nat -> r) (i : @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) => pos (@SAWCoreVectorsAsCoqVectors.bvToNat n i)) (RecordCons "toInt" (@SAWCorePrelude.bvToInt n) RecordNil)))).
+Definition PIntegralWord : forall (n : @SAWCoreScaffolding.Nat), @PIntegral (@SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) :=
+  fun (n : @SAWCoreScaffolding.Nat) => RecordCons "div" (@SAWCoreVectorsAsCoqVectors.bvUDiv n) (RecordCons "integralRing" (@PRingWord n) (RecordCons "mod" (@SAWCoreVectorsAsCoqVectors.bvURem n) (RecordCons "posNegCases" (fun (r : Type) (pos : @SAWCoreScaffolding.Nat -> r) (neg : @SAWCoreScaffolding.Nat -> r) (i : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) => pos (@SAWCoreVectorsAsCoqVectors.bvToNat n i)) (RecordCons "toInt" (@SAWCoreVectorsAsCoqVectors.bvToInt n) RecordNil)))).
 
-Definition PIntegralSeqBool : forall (n : @Num), @PIntegral (@seq n @SAWCoreScaffolding.Bool) :=
-  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @PIntegral (@seq n @SAWCoreScaffolding.Bool)) (fun (n1 : @SAWCoreScaffolding.Nat) => @PIntegralWord n) (@SAWCoreScaffolding.error (@PIntegral (@SAWCorePrelude.Stream @SAWCoreScaffolding.Bool)) "PIntegralSeqBool: no instance for streams"%string) n.
+Definition PIntegralSeqBool : forall (n : @Num), @PIntegral (@seq n (@SAWCoreScaffolding.Bool)) :=
+  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @PIntegral (@seq n1 (@SAWCoreScaffolding.Bool))) (fun (n1 : @SAWCoreScaffolding.Nat) => @PIntegralWord n1) (@SAWCoreScaffolding.error (@PIntegral (@SAWCorePrelude.Stream (@SAWCoreScaffolding.Bool))) "PIntegralSeqBool: no instance for streams"%string) n.
 
 Definition PField : Type -> Type :=
   fun (a : Type) => RecordTypeCons "fieldDiv" (a -> a -> a) (RecordTypeCons "fieldRing" (@PRing a) (RecordTypeCons "recip" (a -> a) RecordTypeNil)).
 
-Definition PFieldRational : @PField @Rational :=
-  RecordCons "fieldDiv" (fun (x : unit) (y : unit) => @SAWCoreScaffolding.error @Rational "Unimplemented: (/.) Rational"%string) (RecordCons "fieldRing" @PRingRational (RecordCons "recip" (fun (x : unit) => @SAWCoreScaffolding.error @Rational "Unimplemented: recip Rational"%string) RecordNil)).
+Definition PFieldRational : @PField Rational :=
+  RecordCons "fieldDiv" (fun (x : unit) (y : unit) => @SAWCoreScaffolding.error Rational "Unimplemented: (/.) Rational"%string) (RecordCons "fieldRing" PRingRational (RecordCons "recip" (fun (x : unit) => @SAWCoreScaffolding.error Rational "Unimplemented: recip Rational"%string) RecordNil)).
 
 Definition PFieldIntMod : forall (n : @SAWCoreScaffolding.Nat), @PField (@SAWCoreScaffolding.IntMod n) :=
   fun (n : @SAWCoreScaffolding.Nat) => RecordCons "fieldDiv" (fun (x : @SAWCoreScaffolding.IntMod n) (y : @SAWCoreScaffolding.IntMod n) => @SAWCoreScaffolding.error (@SAWCoreScaffolding.IntMod n) "Unimplemented: (/.) IntMod"%string) (RecordCons "fieldRing" (@PRingIntMod n) (RecordCons "recip" (fun (x : @SAWCoreScaffolding.IntMod n) => @SAWCoreScaffolding.error (@SAWCoreScaffolding.IntMod n) "Unimplemented: recip IntMod"%string) RecordNil)).
 
 Definition PFieldIntModNum : forall (n : @Num), @PField (@IntModNum n) :=
-  fun (num : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n : @Num) => @PField (@IntModNum n)) @PFieldIntMod (@SAWCoreScaffolding.error (@PField (@IntModNum @TCInf)) "PFieldIntModNum: no instance for inf"%string) num.
+  fun (num : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n : @Num) => @PField (@IntModNum n)) PFieldIntMod (@SAWCoreScaffolding.error (@PField (@IntModNum (@TCInf))) "PFieldIntModNum: no instance for inf"%string) num.
 
 Definition PRound : Type -> Type :=
   fun (a : Type) => RecordTypeCons "ceiling" (a -> @SAWCoreScaffolding.Integer) (RecordTypeCons "floor" (a -> @SAWCoreScaffolding.Integer) (RecordTypeCons "roundAway" (a -> @SAWCoreScaffolding.Integer) (RecordTypeCons "roundCmp" (@PCmp a) (RecordTypeCons "roundField" (@PField a) (RecordTypeCons "roundToEven" (a -> @SAWCoreScaffolding.Integer) (RecordTypeCons "trunc" (a -> @SAWCoreScaffolding.Integer) RecordTypeNil)))))).
 
-Definition PRoundRational : @PRound @Rational :=
-  RecordCons "ceiling" (fun (x : unit) => @SAWCoreScaffolding.error @SAWCoreScaffolding.Integer "Unimplemented: ceiling Rational"%string) (RecordCons "floor" (fun (x : unit) => @SAWCoreScaffolding.error @SAWCoreScaffolding.Integer "Unimplemented: floor Rational"%string) (RecordCons "roundAway" (fun (x : unit) => @SAWCoreScaffolding.error @SAWCoreScaffolding.Integer "Unimplemented: roundAway Rational"%string) (RecordCons "roundCmp" @PCmpRational (RecordCons "roundField" @PFieldRational (RecordCons "roundToEven" (fun (x : unit) => @SAWCoreScaffolding.error @SAWCoreScaffolding.Integer "Unimplemented: roundToEven Rational"%string) (RecordCons "trunc" (fun (x : unit) => @SAWCoreScaffolding.error @SAWCoreScaffolding.Integer "Unimplemented: trunc Rational"%string) RecordNil)))))).
+Definition PRoundRational : @PRound Rational :=
+  RecordCons "ceiling" (fun (x : unit) => @SAWCoreScaffolding.error (@SAWCoreScaffolding.Integer) "Unimplemented: ceiling Rational"%string) (RecordCons "floor" (fun (x : unit) => @SAWCoreScaffolding.error (@SAWCoreScaffolding.Integer) "Unimplemented: floor Rational"%string) (RecordCons "roundAway" (fun (x : unit) => @SAWCoreScaffolding.error (@SAWCoreScaffolding.Integer) "Unimplemented: roundAway Rational"%string) (RecordCons "roundCmp" PCmpRational (RecordCons "roundField" PFieldRational (RecordCons "roundToEven" (fun (x : unit) => @SAWCoreScaffolding.error (@SAWCoreScaffolding.Integer) "Unimplemented: roundToEven Rational"%string) (RecordCons "trunc" (fun (x : unit) => @SAWCoreScaffolding.error (@SAWCoreScaffolding.Integer) "Unimplemented: trunc Rational"%string) RecordNil)))))).
 
 Definition PLiteral : forall (a : Type), Type :=
   fun (a : Type) => @SAWCoreScaffolding.Nat -> a.
 
-Definition PLiteralSeqBool : forall (n : @Num), @PLiteral (@seq n @SAWCoreScaffolding.Bool) :=
-  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @PLiteral (@seq n @SAWCoreScaffolding.Bool)) @SAWCoreVectorsAsCoqVectors.bvNat (@SAWCoreScaffolding.error (@PLiteral (@SAWCorePrelude.Stream @SAWCoreScaffolding.Bool)) "PLiteralSeqBool: no instance for streams"%string) n.
+Definition PLiteralSeqBool : forall (n : @Num), @PLiteral (@seq n (@SAWCoreScaffolding.Bool)) :=
+  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @PLiteral (@seq n1 (@SAWCoreScaffolding.Bool))) (@SAWCoreVectorsAsCoqVectors.bvNat) (@SAWCoreScaffolding.error (@PLiteral (@SAWCorePrelude.Stream (@SAWCoreScaffolding.Bool))) "PLiteralSeqBool: no instance for streams"%string) n.
 
-Definition PLiteralBit : @PLiteral @SAWCoreScaffolding.Bool :=
-  @SAWCorePrelude.Nat_cases @SAWCoreScaffolding.Bool @SAWCoreScaffolding.false (fun (n : @SAWCoreScaffolding.Nat) (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.true).
+Definition PLiteralBit : @PLiteral (@SAWCoreScaffolding.Bool) :=
+  @SAWCorePrelude.Nat_cases (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.false) (fun (n : @SAWCoreScaffolding.Nat) (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.true).
 
-Definition PLiteralInteger : @PLiteral @SAWCoreScaffolding.Integer :=
+Definition PLiteralInteger : @PLiteral (@SAWCoreScaffolding.Integer) :=
   @SAWCoreScaffolding.natToInt.
 
 Definition PLiteralIntMod : forall (n : @SAWCoreScaffolding.Nat), @PLiteral (@SAWCoreScaffolding.IntMod n) :=
   fun (n : @SAWCoreScaffolding.Nat) (x : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.toIntMod n (@SAWCoreScaffolding.natToInt x).
 
 Definition PLiteralIntModNum : forall (num : @Num), @PLiteral (@IntModNum num) :=
-  fun (num : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n : @Num) => @PLiteral (@IntModNum n)) @PLiteralIntMod @PLiteralInteger num.
+  fun (num : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n : @Num) => @PLiteral (@IntModNum n)) PLiteralIntMod PLiteralInteger num.
 
-Definition PLiteralRational : @PLiteral @Rational :=
-  fun (x : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.error @Rational "Unimplemented: Literal Rational"%string.
+Definition PLiteralRational : @PLiteral Rational :=
+  fun (x : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.error Rational "Unimplemented: Literal Rational"%string.
 
 Definition ecNumber : forall (val : @Num), forall (a : Type), @PLiteral a -> a :=
   fun (val : @Num) (a : Type) (pa : @SAWCoreScaffolding.Nat -> a) => CryptolPrimitivesForSAWCore.Num_rect (fun (_1 : @Num) => a) pa (pa 0) val.
 
 Definition ecFromZ : forall (n : @Num), @IntModNum n -> @SAWCoreScaffolding.Integer :=
-  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @IntModNum n -> @SAWCoreScaffolding.Integer) @SAWCoreScaffolding.fromIntMod (fun (x : @SAWCoreScaffolding.Integer) => x) n.
+  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @IntModNum n1 -> @SAWCoreScaffolding.Integer) (@SAWCoreScaffolding.fromIntMod) (fun (x : @SAWCoreScaffolding.Integer) => x) n.
 
 Definition ecFromInteger : forall (a : Type), @PRing a -> @SAWCoreScaffolding.Integer -> a :=
   fun (a : Type) (pa : RecordTypeCons "add" (a -> a -> a) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> a) (RecordTypeCons "mul" (a -> a -> a) (RecordTypeCons "neg" (a -> a) (RecordTypeCons "ringZero" a (RecordTypeCons "sub" (a -> a -> a) RecordTypeNil)))))) => RecordProj pa "int".
@@ -487,7 +487,7 @@ Definition ecMod : forall (a : Type), @PIntegral a -> a -> a -> a :=
   fun (a : Type) (pi : RecordTypeCons "div" (a -> a -> a) (RecordTypeCons "integralRing" (RecordTypeCons "add" (a -> a -> a) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> a) (RecordTypeCons "mul" (a -> a -> a) (RecordTypeCons "neg" (a -> a) (RecordTypeCons "ringZero" a (RecordTypeCons "sub" (a -> a -> a) RecordTypeNil)))))) (RecordTypeCons "mod" (a -> a -> a) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> a -> r) (RecordTypeCons "toInt" (a -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) => RecordProj pi "mod".
 
 Definition ecExp : forall (a : Type), forall (b : Type), @PRing a -> @PIntegral b -> a -> b -> a :=
-  fun (a : Type) (b : Type) (pa : RecordTypeCons "add" (a -> a -> a) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> a) (RecordTypeCons "mul" (a -> a -> a) (RecordTypeCons "neg" (a -> a) (RecordTypeCons "ringZero" a (RecordTypeCons "sub" (a -> a -> a) RecordTypeNil)))))) (pi : RecordTypeCons "div" (b -> b -> b) (RecordTypeCons "integralRing" (RecordTypeCons "add" (b -> b -> b) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> b) (RecordTypeCons "mul" (b -> b -> b) (RecordTypeCons "neg" (b -> b) (RecordTypeCons "ringZero" b (RecordTypeCons "sub" (b -> b -> b) RecordTypeNil)))))) (RecordTypeCons "mod" (b -> b -> b) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> b -> r) (RecordTypeCons "toInt" (b -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) (x : a) => RecordProj pi "posNegCases" a (@SAWCorePrelude.expByNat a (RecordProj pa "int" (@SAWCoreScaffolding.natToInt 1)) (RecordProj pa "mul") x) (fun (_1 : @SAWCoreScaffolding.Nat) => RecordProj pa "int" (@SAWCoreScaffolding.natToInt 1)).
+  fun (a : Type) (b : Type) (pa : RecordTypeCons "add" (a -> a -> a) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> a) (RecordTypeCons "mul" (a -> a -> a) (RecordTypeCons "neg" (a -> a) (RecordTypeCons "ringZero" a (RecordTypeCons "sub" (a -> a -> a) RecordTypeNil)))))) (pi : RecordTypeCons "div" (b -> b -> b) (RecordTypeCons "integralRing" (RecordTypeCons "add" (b -> b -> b) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> b) (RecordTypeCons "mul" (b -> b -> b) (RecordTypeCons "neg" (b -> b) (RecordTypeCons "ringZero" b (RecordTypeCons "sub" (b -> b -> b) RecordTypeNil)))))) (RecordTypeCons "mod" (b -> b -> b) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> b -> r) (RecordTypeCons "toInt" (b -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) (x : a) => RecordProj pi "posNegCases" a (@SAWCorePrelude.expByNat a (RecordProj pa "int" 1%Z) (RecordProj pa "mul") x) (fun (_1 : @SAWCoreScaffolding.Nat) => RecordProj pa "int" 1%Z).
 
 Definition ecRecip : forall (a : Type), @PField a -> a -> a :=
   fun (a : Type) (pf : RecordTypeCons "fieldDiv" (a -> a -> a) (RecordTypeCons "fieldRing" (RecordTypeCons "add" (a -> a -> a) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> a) (RecordTypeCons "mul" (a -> a -> a) (RecordTypeCons "neg" (a -> a) (RecordTypeCons "ringZero" a (RecordTypeCons "sub" (a -> a -> a) RecordTypeNil)))))) (RecordTypeCons "recip" (a -> a) RecordTypeNil))) => RecordProj pf "recip".
@@ -510,14 +510,14 @@ Definition ecRoundAway : forall (a : Type), @PRound a -> a -> @SAWCoreScaffoldin
 Definition ecRoundToEven : forall (a : Type), @PRound a -> a -> @SAWCoreScaffolding.Integer :=
   fun (a : Type) (pr : RecordTypeCons "ceiling" (a -> @SAWCoreScaffolding.Integer) (RecordTypeCons "floor" (a -> @SAWCoreScaffolding.Integer) (RecordTypeCons "roundAway" (a -> @SAWCoreScaffolding.Integer) (RecordTypeCons "roundCmp" (RecordTypeCons "cmp" (a -> a -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) (RecordTypeCons "cmpEq" (RecordTypeCons "eq" (a -> a -> @SAWCoreScaffolding.Bool) RecordTypeNil) RecordTypeNil)) (RecordTypeCons "roundField" (RecordTypeCons "fieldDiv" (a -> a -> a) (RecordTypeCons "fieldRing" (RecordTypeCons "add" (a -> a -> a) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> a) (RecordTypeCons "mul" (a -> a -> a) (RecordTypeCons "neg" (a -> a) (RecordTypeCons "ringZero" a (RecordTypeCons "sub" (a -> a -> a) RecordTypeNil)))))) (RecordTypeCons "recip" (a -> a) RecordTypeNil))) (RecordTypeCons "roundToEven" (a -> @SAWCoreScaffolding.Integer) (RecordTypeCons "trunc" (a -> @SAWCoreScaffolding.Integer) RecordTypeNil))))))) => RecordProj pr "roundToEven".
 
-Definition ecLg2 : forall (n : @Num), @seq n @SAWCoreScaffolding.Bool -> @seq n @SAWCoreScaffolding.Bool :=
-  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @seq n @SAWCoreScaffolding.Bool -> @seq n @SAWCoreScaffolding.Bool) @SAWCoreVectorsAsCoqVectors.bvLg2 (@SAWCoreScaffolding.error (@SAWCorePrelude.Stream @SAWCoreScaffolding.Bool -> @SAWCorePrelude.Stream @SAWCoreScaffolding.Bool) "ecLg2: expected finite word"%string) n.
+Definition ecLg2 : forall (n : @Num), @seq n (@SAWCoreScaffolding.Bool) -> @seq n (@SAWCoreScaffolding.Bool) :=
+  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @seq n1 (@SAWCoreScaffolding.Bool) -> @seq n1 (@SAWCoreScaffolding.Bool)) (@SAWCoreVectorsAsCoqVectors.bvLg2) (@SAWCoreScaffolding.error (@SAWCorePrelude.Stream (@SAWCoreScaffolding.Bool) -> @SAWCorePrelude.Stream (@SAWCoreScaffolding.Bool)) "ecLg2: expected finite word"%string) n.
 
-Definition ecSDiv : forall (n : @Num), @seq n @SAWCoreScaffolding.Bool -> @seq n @SAWCoreScaffolding.Bool -> @seq n @SAWCoreScaffolding.Bool :=
-  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @seq n @SAWCoreScaffolding.Bool -> @seq n @SAWCoreScaffolding.Bool -> @seq n @SAWCoreScaffolding.Bool) (@SAWCorePrelude.Nat__rec (fun (n1 : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.error (@SAWCoreVectorsAsCoqVectors.Vec 0 @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec 0 @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec 0 @SAWCoreScaffolding.Bool) "ecSDiv: illegal 0-width word"%string) (fun (n' : @SAWCoreScaffolding.Nat) (_1 : @SAWCoreVectorsAsCoqVectors.Vec n' @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n' @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n' @SAWCoreScaffolding.Bool) => @SAWCoreVectorsAsCoqVectors.bvSDiv n')) (@SAWCoreScaffolding.error (@SAWCorePrelude.Stream @SAWCoreScaffolding.Bool -> @SAWCorePrelude.Stream @SAWCoreScaffolding.Bool -> @SAWCorePrelude.Stream @SAWCoreScaffolding.Bool) "ecSDiv: expected finite word"%string) n.
+Definition ecSDiv : forall (n : @Num), @seq n (@SAWCoreScaffolding.Bool) -> @seq n (@SAWCoreScaffolding.Bool) -> @seq n (@SAWCoreScaffolding.Bool) :=
+  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @seq n1 (@SAWCoreScaffolding.Bool) -> @seq n1 (@SAWCoreScaffolding.Bool) -> @seq n1 (@SAWCoreScaffolding.Bool)) (@SAWCorePrelude.Nat__rec (fun (n1 : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.Vec n1 (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n1 (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n1 (@SAWCoreScaffolding.Bool)) (@SAWCoreScaffolding.error (@SAWCoreVectorsAsCoqVectors.Vec 0 (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec 0 (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec 0 (@SAWCoreScaffolding.Bool)) "ecSDiv: illegal 0-width word"%string) (fun (n' : @SAWCoreScaffolding.Nat) (_1 : @SAWCoreVectorsAsCoqVectors.Vec n' (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n' (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n' (@SAWCoreScaffolding.Bool)) => @SAWCoreVectorsAsCoqVectors.bvSDiv n')) (@SAWCoreScaffolding.error (@SAWCorePrelude.Stream (@SAWCoreScaffolding.Bool) -> @SAWCorePrelude.Stream (@SAWCoreScaffolding.Bool) -> @SAWCorePrelude.Stream (@SAWCoreScaffolding.Bool)) "ecSDiv: expected finite word"%string) n.
 
-Definition ecSMod : forall (n : @Num), @seq n @SAWCoreScaffolding.Bool -> @seq n @SAWCoreScaffolding.Bool -> @seq n @SAWCoreScaffolding.Bool :=
-  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @seq n @SAWCoreScaffolding.Bool -> @seq n @SAWCoreScaffolding.Bool -> @seq n @SAWCoreScaffolding.Bool) (@SAWCorePrelude.Nat__rec (fun (n1 : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.error (@SAWCoreVectorsAsCoqVectors.Vec 0 @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec 0 @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec 0 @SAWCoreScaffolding.Bool) "ecSMod: illegal 0-width word"%string) (fun (n' : @SAWCoreScaffolding.Nat) (_1 : @SAWCoreVectorsAsCoqVectors.Vec n' @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n' @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n' @SAWCoreScaffolding.Bool) => @SAWCoreVectorsAsCoqVectors.bvSRem n')) (@SAWCoreScaffolding.error (@SAWCorePrelude.Stream @SAWCoreScaffolding.Bool -> @SAWCorePrelude.Stream @SAWCoreScaffolding.Bool -> @SAWCorePrelude.Stream @SAWCoreScaffolding.Bool) "ecSMod: expected finite word"%string) n.
+Definition ecSMod : forall (n : @Num), @seq n (@SAWCoreScaffolding.Bool) -> @seq n (@SAWCoreScaffolding.Bool) -> @seq n (@SAWCoreScaffolding.Bool) :=
+  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @seq n1 (@SAWCoreScaffolding.Bool) -> @seq n1 (@SAWCoreScaffolding.Bool) -> @seq n1 (@SAWCoreScaffolding.Bool)) (@SAWCorePrelude.Nat__rec (fun (n1 : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.Vec n1 (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n1 (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n1 (@SAWCoreScaffolding.Bool)) (@SAWCoreScaffolding.error (@SAWCoreVectorsAsCoqVectors.Vec 0 (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec 0 (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec 0 (@SAWCoreScaffolding.Bool)) "ecSMod: illegal 0-width word"%string) (fun (n' : @SAWCoreScaffolding.Nat) (_1 : @SAWCoreVectorsAsCoqVectors.Vec n' (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n' (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n' (@SAWCoreScaffolding.Bool)) => @SAWCoreVectorsAsCoqVectors.bvSRem n')) (@SAWCoreScaffolding.error (@SAWCorePrelude.Stream (@SAWCoreScaffolding.Bool) -> @SAWCorePrelude.Stream (@SAWCoreScaffolding.Bool) -> @SAWCorePrelude.Stream (@SAWCoreScaffolding.Bool)) "ecSMod: expected finite word"%string) n.
 
 Definition ecEq : forall (a : Type), @PEq a -> a -> a -> @SAWCoreScaffolding.Bool :=
   fun (a : Type) (pa : RecordTypeCons "eq" (a -> a -> @SAWCoreScaffolding.Bool) RecordTypeNil) => RecordProj pa "eq".
@@ -526,7 +526,7 @@ Definition ecNotEq : forall (a : Type), @PEq a -> a -> a -> @SAWCoreScaffolding.
   fun (a : Type) (pa : RecordTypeCons "eq" (a -> a -> @SAWCoreScaffolding.Bool) RecordTypeNil) (x : a) (y : a) => @SAWCoreScaffolding.not (@ecEq a pa x y).
 
 Definition ecLt : forall (a : Type), @PCmp a -> a -> a -> @SAWCoreScaffolding.Bool :=
-  fun (a : Type) (pa : RecordTypeCons "cmp" (a -> a -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) (RecordTypeCons "cmpEq" (RecordTypeCons "eq" (a -> a -> @SAWCoreScaffolding.Bool) RecordTypeNil) RecordTypeNil)) (x : a) (y : a) => RecordProj pa "cmp" x y @SAWCoreScaffolding.false.
+  fun (a : Type) (pa : RecordTypeCons "cmp" (a -> a -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) (RecordTypeCons "cmpEq" (RecordTypeCons "eq" (a -> a -> @SAWCoreScaffolding.Bool) RecordTypeNil) RecordTypeNil)) (x : a) (y : a) => RecordProj pa "cmp" x y (@SAWCoreScaffolding.false).
 
 Definition ecGt : forall (a : Type), @PCmp a -> a -> a -> @SAWCoreScaffolding.Bool :=
   fun (a : Type) (pa : RecordTypeCons "cmp" (a -> a -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) (RecordTypeCons "cmpEq" (RecordTypeCons "eq" (a -> a -> @SAWCoreScaffolding.Bool) RecordTypeNil) RecordTypeNil)) (x : a) (y : a) => @ecLt a pa y x.
@@ -538,7 +538,7 @@ Definition ecGtEq : forall (a : Type), @PCmp a -> a -> a -> @SAWCoreScaffolding.
   fun (a : Type) (pa : RecordTypeCons "cmp" (a -> a -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) (RecordTypeCons "cmpEq" (RecordTypeCons "eq" (a -> a -> @SAWCoreScaffolding.Bool) RecordTypeNil) RecordTypeNil)) (x : a) (y : a) => @SAWCoreScaffolding.not (@ecLt a pa x y).
 
 Definition ecSLt : forall (a : Type), @PSignedCmp a -> a -> a -> @SAWCoreScaffolding.Bool :=
-  fun (a : Type) (pa : RecordTypeCons "scmp" (a -> a -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) (RecordTypeCons "signedCmpEq" (RecordTypeCons "eq" (a -> a -> @SAWCoreScaffolding.Bool) RecordTypeNil) RecordTypeNil)) (x : a) (y : a) => RecordProj pa "scmp" x y @SAWCoreScaffolding.false.
+  fun (a : Type) (pa : RecordTypeCons "scmp" (a -> a -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) (RecordTypeCons "signedCmpEq" (RecordTypeCons "eq" (a -> a -> @SAWCoreScaffolding.Bool) RecordTypeNil) RecordTypeNil)) (x : a) (y : a) => RecordProj pa "scmp" x y (@SAWCoreScaffolding.false).
 
 Definition ecAnd : forall (a : Type), @PLogic a -> a -> a -> a :=
   fun (a : Type) (pa : RecordTypeCons "and" (a -> a -> a) (RecordTypeCons "logicZero" a (RecordTypeCons "not" (a -> a) (RecordTypeCons "or" (a -> a -> a) (RecordTypeCons "xor" (a -> a -> a) RecordTypeNil))))) => RecordProj pa "and".
@@ -559,13 +559,13 @@ Definition ecFraction : forall (a : Type), a :=
   fun (a : Type) => @SAWCoreScaffolding.error a "Unimplemented: fraction"%string.
 
 Definition ecShiftL : forall (m : @Num), forall (ix : Type), forall (a : Type), @PIntegral ix -> @PZero a -> @seq m a -> ix -> @seq m a :=
-  fun (m : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (m1 : @Num) => forall (ix : Type), forall (a : Type), @PIntegral ix -> @PZero a -> @seq m a -> ix -> @seq m a) (fun (m1 : @SAWCoreScaffolding.Nat) (ix : Type) (a : Type) (pix : RecordTypeCons "div" (ix -> ix -> ix) (RecordTypeCons "integralRing" (RecordTypeCons "add" (ix -> ix -> ix) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> ix) (RecordTypeCons "mul" (ix -> ix -> ix) (RecordTypeCons "neg" (ix -> ix) (RecordTypeCons "ringZero" ix (RecordTypeCons "sub" (ix -> ix -> ix) RecordTypeNil)))))) (RecordTypeCons "mod" (ix -> ix -> ix) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> ix -> r) (RecordTypeCons "toInt" (ix -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) (pz : a) (xs : @SAWCoreVectorsAsCoqVectors.Vec m1 a) => RecordProj pix "posNegCases" (@SAWCoreVectorsAsCoqVectors.Vec m a) (@SAWCoreVectorsAsCoqVectors.shiftL m a (@ecZero a pz) xs) (@SAWCoreVectorsAsCoqVectors.shiftR m a (@ecZero a pz) xs)) (fun (ix : Type) (a : Type) (pix : RecordTypeCons "div" (ix -> ix -> ix) (RecordTypeCons "integralRing" (RecordTypeCons "add" (ix -> ix -> ix) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> ix) (RecordTypeCons "mul" (ix -> ix -> ix) (RecordTypeCons "neg" (ix -> ix) (RecordTypeCons "ringZero" ix (RecordTypeCons "sub" (ix -> ix -> ix) RecordTypeNil)))))) (RecordTypeCons "mod" (ix -> ix -> ix) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> ix -> r) (RecordTypeCons "toInt" (ix -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) (pz : a) (xs : @SAWCorePrelude.Stream a) => RecordProj pix "posNegCases" (@SAWCorePrelude.Stream a) (@SAWCorePrelude.streamShiftL a xs) (@SAWCorePrelude.streamShiftR a pz xs)) m.
+  fun (m : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (m1 : @Num) => forall (ix : Type), forall (a : Type), @PIntegral ix -> @PZero a -> @seq m1 a -> ix -> @seq m1 a) (fun (m1 : @SAWCoreScaffolding.Nat) (ix : Type) (a : Type) (pix : RecordTypeCons "div" (ix -> ix -> ix) (RecordTypeCons "integralRing" (RecordTypeCons "add" (ix -> ix -> ix) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> ix) (RecordTypeCons "mul" (ix -> ix -> ix) (RecordTypeCons "neg" (ix -> ix) (RecordTypeCons "ringZero" ix (RecordTypeCons "sub" (ix -> ix -> ix) RecordTypeNil)))))) (RecordTypeCons "mod" (ix -> ix -> ix) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> ix -> r) (RecordTypeCons "toInt" (ix -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) (pz : a) (xs : @SAWCoreVectorsAsCoqVectors.Vec m1 a) => RecordProj pix "posNegCases" (@SAWCoreVectorsAsCoqVectors.Vec m1 a) (@SAWCoreVectorsAsCoqVectors.shiftL m1 a (@ecZero a pz) xs) (@SAWCoreVectorsAsCoqVectors.shiftR m1 a (@ecZero a pz) xs)) (fun (ix : Type) (a : Type) (pix : RecordTypeCons "div" (ix -> ix -> ix) (RecordTypeCons "integralRing" (RecordTypeCons "add" (ix -> ix -> ix) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> ix) (RecordTypeCons "mul" (ix -> ix -> ix) (RecordTypeCons "neg" (ix -> ix) (RecordTypeCons "ringZero" ix (RecordTypeCons "sub" (ix -> ix -> ix) RecordTypeNil)))))) (RecordTypeCons "mod" (ix -> ix -> ix) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> ix -> r) (RecordTypeCons "toInt" (ix -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) (pz : a) (xs : @SAWCorePrelude.Stream a) => RecordProj pix "posNegCases" (@SAWCorePrelude.Stream a) (@SAWCorePrelude.streamShiftL a xs) (@SAWCorePrelude.streamShiftR a pz xs)) m.
 
 Definition ecShiftR : forall (m : @Num), forall (ix : Type), forall (a : Type), @PIntegral ix -> @PZero a -> @seq m a -> ix -> @seq m a :=
-  fun (m : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (m1 : @Num) => forall (ix : Type), forall (a : Type), @PIntegral ix -> @PZero a -> @seq m a -> ix -> @seq m a) (fun (m1 : @SAWCoreScaffolding.Nat) (ix : Type) (a : Type) (pix : RecordTypeCons "div" (ix -> ix -> ix) (RecordTypeCons "integralRing" (RecordTypeCons "add" (ix -> ix -> ix) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> ix) (RecordTypeCons "mul" (ix -> ix -> ix) (RecordTypeCons "neg" (ix -> ix) (RecordTypeCons "ringZero" ix (RecordTypeCons "sub" (ix -> ix -> ix) RecordTypeNil)))))) (RecordTypeCons "mod" (ix -> ix -> ix) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> ix -> r) (RecordTypeCons "toInt" (ix -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) (pz : a) (xs : @SAWCoreVectorsAsCoqVectors.Vec m1 a) => RecordProj pix "posNegCases" (@SAWCoreVectorsAsCoqVectors.Vec m a) (@SAWCoreVectorsAsCoqVectors.shiftR m a (@ecZero a pz) xs) (@SAWCoreVectorsAsCoqVectors.shiftL m a (@ecZero a pz) xs)) (fun (ix : Type) (a : Type) (pix : RecordTypeCons "div" (ix -> ix -> ix) (RecordTypeCons "integralRing" (RecordTypeCons "add" (ix -> ix -> ix) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> ix) (RecordTypeCons "mul" (ix -> ix -> ix) (RecordTypeCons "neg" (ix -> ix) (RecordTypeCons "ringZero" ix (RecordTypeCons "sub" (ix -> ix -> ix) RecordTypeNil)))))) (RecordTypeCons "mod" (ix -> ix -> ix) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> ix -> r) (RecordTypeCons "toInt" (ix -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) (pz : a) (xs : @SAWCorePrelude.Stream a) => RecordProj pix "posNegCases" (@SAWCorePrelude.Stream a) (@SAWCorePrelude.streamShiftR a pz xs) (@SAWCorePrelude.streamShiftL a xs)) m.
+  fun (m : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (m1 : @Num) => forall (ix : Type), forall (a : Type), @PIntegral ix -> @PZero a -> @seq m1 a -> ix -> @seq m1 a) (fun (m1 : @SAWCoreScaffolding.Nat) (ix : Type) (a : Type) (pix : RecordTypeCons "div" (ix -> ix -> ix) (RecordTypeCons "integralRing" (RecordTypeCons "add" (ix -> ix -> ix) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> ix) (RecordTypeCons "mul" (ix -> ix -> ix) (RecordTypeCons "neg" (ix -> ix) (RecordTypeCons "ringZero" ix (RecordTypeCons "sub" (ix -> ix -> ix) RecordTypeNil)))))) (RecordTypeCons "mod" (ix -> ix -> ix) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> ix -> r) (RecordTypeCons "toInt" (ix -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) (pz : a) (xs : @SAWCoreVectorsAsCoqVectors.Vec m1 a) => RecordProj pix "posNegCases" (@SAWCoreVectorsAsCoqVectors.Vec m1 a) (@SAWCoreVectorsAsCoqVectors.shiftR m1 a (@ecZero a pz) xs) (@SAWCoreVectorsAsCoqVectors.shiftL m1 a (@ecZero a pz) xs)) (fun (ix : Type) (a : Type) (pix : RecordTypeCons "div" (ix -> ix -> ix) (RecordTypeCons "integralRing" (RecordTypeCons "add" (ix -> ix -> ix) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> ix) (RecordTypeCons "mul" (ix -> ix -> ix) (RecordTypeCons "neg" (ix -> ix) (RecordTypeCons "ringZero" ix (RecordTypeCons "sub" (ix -> ix -> ix) RecordTypeNil)))))) (RecordTypeCons "mod" (ix -> ix -> ix) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> ix -> r) (RecordTypeCons "toInt" (ix -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) (pz : a) (xs : @SAWCorePrelude.Stream a) => RecordProj pix "posNegCases" (@SAWCorePrelude.Stream a) (@SAWCorePrelude.streamShiftR a pz xs) (@SAWCorePrelude.streamShiftL a xs)) m.
 
-Definition ecSShiftR : forall (n : @Num), forall (ix : Type), @PIntegral ix -> @seq n @SAWCoreScaffolding.Bool -> ix -> @seq n @SAWCoreScaffolding.Bool :=
-  @finNumRec (fun (n : @Num) => forall (ix : Type), @PIntegral ix -> @seq n @SAWCoreScaffolding.Bool -> ix -> @seq n @SAWCoreScaffolding.Bool) (fun (n : @SAWCoreScaffolding.Nat) (ix : Type) (pix : RecordTypeCons "div" (ix -> ix -> ix) (RecordTypeCons "integralRing" (RecordTypeCons "add" (ix -> ix -> ix) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> ix) (RecordTypeCons "mul" (ix -> ix -> ix) (RecordTypeCons "neg" (ix -> ix) (RecordTypeCons "ringZero" ix (RecordTypeCons "sub" (ix -> ix -> ix) RecordTypeNil)))))) (RecordTypeCons "mod" (ix -> ix -> ix) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> ix -> r) (RecordTypeCons "toInt" (ix -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) => @SAWCorePrelude.natCase (fun (w : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.Vec w @SAWCoreScaffolding.Bool -> ix -> @SAWCoreVectorsAsCoqVectors.Vec w @SAWCoreScaffolding.Bool) (fun (xs : @SAWCoreVectorsAsCoqVectors.Vec 0 @SAWCoreScaffolding.Bool) (_1 : ix) => xs) (fun (w : @SAWCoreScaffolding.Nat) (xs : @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ w) @SAWCoreScaffolding.Bool) => RecordProj pix "posNegCases" (@SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ w) @SAWCoreScaffolding.Bool) (@SAWCoreVectorsAsCoqVectors.bvSShr w xs) (@SAWCoreVectorsAsCoqVectors.bvShl (@SAWCoreScaffolding.Succ w) xs)) n).
+Definition ecSShiftR : forall (n : @Num), forall (ix : Type), @PIntegral ix -> @seq n (@SAWCoreScaffolding.Bool) -> ix -> @seq n (@SAWCoreScaffolding.Bool) :=
+  @finNumRec (fun (n : @Num) => forall (ix : Type), @PIntegral ix -> @seq n (@SAWCoreScaffolding.Bool) -> ix -> @seq n (@SAWCoreScaffolding.Bool)) (fun (n : @SAWCoreScaffolding.Nat) (ix : Type) (pix : RecordTypeCons "div" (ix -> ix -> ix) (RecordTypeCons "integralRing" (RecordTypeCons "add" (ix -> ix -> ix) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> ix) (RecordTypeCons "mul" (ix -> ix -> ix) (RecordTypeCons "neg" (ix -> ix) (RecordTypeCons "ringZero" ix (RecordTypeCons "sub" (ix -> ix -> ix) RecordTypeNil)))))) (RecordTypeCons "mod" (ix -> ix -> ix) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> ix -> r) (RecordTypeCons "toInt" (ix -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) => @SAWCorePrelude.natCase (fun (w : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.Vec w (@SAWCoreScaffolding.Bool) -> ix -> @SAWCoreVectorsAsCoqVectors.Vec w (@SAWCoreScaffolding.Bool)) (fun (xs : @SAWCoreVectorsAsCoqVectors.Vec 0 (@SAWCoreScaffolding.Bool)) (_1 : ix) => xs) (fun (w : @SAWCoreScaffolding.Nat) (xs : @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ w) (@SAWCoreScaffolding.Bool)) => RecordProj pix "posNegCases" (@SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ w) (@SAWCoreScaffolding.Bool)) (@SAWCoreVectorsAsCoqVectors.bvSShr w xs) (@SAWCoreVectorsAsCoqVectors.bvShl (@SAWCoreScaffolding.Succ w) xs)) n).
 
 Definition ecRotL : forall (m : @Num), forall (ix : Type), forall (a : Type), @PIntegral ix -> @seq m a -> ix -> @seq m a :=
   @finNumRec (fun (m : @Num) => forall (ix : Type), forall (a : Type), @PIntegral ix -> @seq m a -> ix -> @seq m a) (fun (m : @SAWCoreScaffolding.Nat) (ix : Type) (a : Type) (pix : RecordTypeCons "div" (ix -> ix -> ix) (RecordTypeCons "integralRing" (RecordTypeCons "add" (ix -> ix -> ix) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> ix) (RecordTypeCons "mul" (ix -> ix -> ix) (RecordTypeCons "neg" (ix -> ix) (RecordTypeCons "ringZero" ix (RecordTypeCons "sub" (ix -> ix -> ix) RecordTypeNil)))))) (RecordTypeCons "mod" (ix -> ix -> ix) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> ix -> r) (RecordTypeCons "toInt" (ix -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) (xs : @SAWCoreVectorsAsCoqVectors.Vec m a) => RecordProj pix "posNegCases" (@SAWCoreVectorsAsCoqVectors.Vec m a) (@SAWCoreVectorsAsCoqVectors.rotateL m a xs) (@SAWCoreVectorsAsCoqVectors.rotateR m a xs)).
@@ -580,22 +580,22 @@ Definition ecSplitAt : forall (m : @Num), forall (n : @Num), forall (a : Type), 
   @finNumRec (fun (m : @Num) => forall (n : @Num), forall (a : Type), @seq (@tcAdd m n) a -> prod (@seq m a) (@seq n a)) (fun (m : @SAWCoreScaffolding.Nat) => @CryptolPrimitivesForSAWCORE.Num_rect (fun (n : @Num) => forall (a : Type), @seq (@tcAdd (@TCNum m) n) a -> prod (@SAWCoreVectorsAsCoqVectors.Vec m a) (@seq n a)) (fun (n : @SAWCoreScaffolding.Nat) (a : Type) (xs : @SAWCoreVectorsAsCoqVectors.Vec (@SAWCorePrelude.addNat m n) a) => pair (@SAWCorePrelude.take a m n xs) (@SAWCorePrelude.drop a m n xs)) (fun (a : Type) (xs : @SAWCorePrelude.Stream a) => pair (@SAWCorePrelude.streamTake a m xs) (@SAWCorePrelude.streamDrop a m xs))).
 
 Definition ecJoin : forall (m : @Num), forall (n : @Num), forall (a : Type), @seq m (@seq n a) -> @seq (@tcMul m n) a :=
-  fun (m : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (m1 : @Num) => forall (n : @Num), forall (a : Type), @seq m (@seq n a) -> @seq (@tcMul m n) a) (fun (m1 : @SAWCoreScaffolding.Nat) => @finNumRec (fun (n : @Num) => forall (a : Type), @SAWCoreVectorsAsCoqVectors.Vec m (@seq n a) -> @seq (@tcMul (@TCNum m) n) a) (fun (n : @SAWCoreScaffolding.Nat) (a : Type) => @SAWCorePrelude.join m n a)) (@finNumRec (fun (n : @Num) => forall (a : Type), @SAWCorePrelude.Stream (@seq n a) -> @seq (@tcMul @TCInf n) a) (fun (n : @SAWCoreScaffolding.Nat) (a : Type) => @SAWCorePrelude.natCase (fun (n' : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.Stream (@SAWCoreVectorsAsCoqVectors.Vec n' a) -> @seq (@SAWCorePrelude.if0Nat @Num n' (@TCNum 0) @TCInf) a) (fun (s : @SAWCorePrelude.Stream (@SAWCoreVectorsAsCoqVectors.Vec 0 a)) => @SAWCoreVectorsAsCoqVectors.EmptyVec a) (fun (n' : @SAWCoreScaffolding.Nat) (s : @SAWCorePrelude.Stream (@SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n') a)) => @SAWCorePrelude.streamJoin a n' s) n)) m.
+  fun (m : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (m1 : @Num) => forall (n : @Num), forall (a : Type), @seq m1 (@seq n a) -> @seq (@tcMul m1 n) a) (fun (m1 : @SAWCoreScaffolding.Nat) => @finNumRec (fun (n : @Num) => forall (a : Type), @SAWCoreVectorsAsCoqVectors.Vec m1 (@seq n a) -> @seq (@tcMul (@TCNum m1) n) a) (fun (n : @SAWCoreScaffolding.Nat) (a : Type) => @SAWCorePrelude.join m1 n a)) (@finNumRec (fun (n : @Num) => forall (a : Type), @SAWCorePrelude.Stream (@seq n a) -> @seq (@tcMul (@TCInf) n) a) (fun (n : @SAWCoreScaffolding.Nat) (a : Type) => @SAWCorePrelude.natCase (fun (n' : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.Stream (@SAWCoreVectorsAsCoqVectors.Vec n' a) -> @seq (@SAWCorePrelude.if0Nat (@Num) n' (@TCNum 0) (@TCInf)) a) (fun (s : @SAWCorePrelude.Stream (@SAWCoreVectorsAsCoqVectors.Vec 0 a)) => @SAWCoreVectorsAsCoqVectors.EmptyVec a) (fun (n' : @SAWCoreScaffolding.Nat) (s : @SAWCorePrelude.Stream (@SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n') a)) => @SAWCorePrelude.streamJoin a n' s) n)) m.
 
 Definition ecSplit : forall (m : @Num), forall (n : @Num), forall (a : Type), @seq (@tcMul m n) a -> @seq m (@seq n a) :=
-  fun (m : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (m1 : @Num) => forall (n : @Num), forall (a : Type), @seq (@tcMul m n) a -> @seq m (@seq n a)) (fun (m1 : @SAWCoreScaffolding.Nat) => @finNumRec (fun (n : @Num) => forall (a : Type), @seq (@tcMul (@TCNum m) n) a -> @SAWCoreVectorsAsCoqVectors.Vec m (@seq n a)) (fun (n : @SAWCoreScaffolding.Nat) (a : Type) => @SAWCorePrelude.split m n a)) (@finNumRec (fun (n : @Num) => forall (a : Type), @seq (@tcMul @TCInf n) a -> @SAWCorePrelude.Stream (@seq n a)) (fun (n : @SAWCoreScaffolding.Nat) (a : Type) => @SAWCorePrelude.natCase (fun (n' : @SAWCoreScaffolding.Nat) => @seq (@SAWCorePrelude.if0Nat @Num n' (@TCNum 0) @TCInf) a -> @SAWCorePrelude.Stream (@SAWCoreVectorsAsCoqVectors.Vec n' a)) (@SAWCorePrelude.streamConst (@SAWCoreVectorsAsCoqVectors.Vec 0 a)) (fun (n' : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.streamSplit a (@SAWCoreScaffolding.Succ n')) n)) m.
+  fun (m : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (m1 : @Num) => forall (n : @Num), forall (a : Type), @seq (@tcMul m1 n) a -> @seq m1 (@seq n a)) (fun (m1 : @SAWCoreScaffolding.Nat) => @finNumRec (fun (n : @Num) => forall (a : Type), @seq (@tcMul (@TCNum m1) n) a -> @SAWCoreVectorsAsCoqVectors.Vec m1 (@seq n a)) (fun (n : @SAWCoreScaffolding.Nat) (a : Type) => @SAWCorePrelude.split m1 n a)) (@finNumRec (fun (n : @Num) => forall (a : Type), @seq (@tcMul (@TCInf) n) a -> @SAWCorePrelude.Stream (@seq n a)) (fun (n : @SAWCoreScaffolding.Nat) (a : Type) => @SAWCorePrelude.natCase (fun (n' : @SAWCoreScaffolding.Nat) => @seq (@SAWCorePrelude.if0Nat (@Num) n' (@TCNum 0) (@TCInf)) a -> @SAWCorePrelude.Stream (@SAWCoreVectorsAsCoqVectors.Vec n' a)) (@SAWCorePrelude.streamConst (@SAWCoreVectorsAsCoqVectors.Vec 0 a)) (fun (n' : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.streamSplit a (@SAWCoreScaffolding.Succ n')) n)) m.
 
 Definition ecReverse : forall (n : @Num), forall (a : Type), @seq n a -> @seq n a :=
-  @finNumRec (fun (n : @Num) => forall (a : Type), @seq n a -> @seq n a) @SAWCorePrelude.reverse.
+  @finNumRec (fun (n : @Num) => forall (a : Type), @seq n a -> @seq n a) reverse.
 
 Definition ecTranspose : forall (m : @Num), forall (n : @Num), forall (a : Type), @seq m (@seq n a) -> @seq n (@seq m a) :=
-  fun (m : @Num) (n : @Num) (a : Type) => CryptolPrimitivesForSAWCore.Num_rect (fun (m1 : @Num) => @seq m (@seq n a) -> @seq n (@seq m a)) (fun (m1 : @SAWCoreScaffolding.Nat) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @SAWCoreVectorsAsCoqVectors.Vec m (@seq n a) -> @seq n (@SAWCoreVectorsAsCoqVectors.Vec m a)) (fun (n1 : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.transpose m n a) (fun (xss : @SAWCoreVectorsAsCoqVectors.Vec m (@SAWCorePrelude.Stream a)) => @SAWCorePrelude.MkStream (@SAWCoreVectorsAsCoqVectors.Vec m a) (fun (i : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.gen m a (fun (j : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.streamGet a (@SAWCorePrelude.sawAt m (@SAWCorePrelude.Stream a) xss j) i))) n) (CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @SAWCorePrelude.Stream (@seq n a) -> @seq n (@SAWCorePrelude.Stream a)) (fun (n1 : @SAWCoreScaffolding.Nat) (xss : @SAWCorePrelude.Stream (@SAWCoreVectorsAsCoqVectors.Vec n1 a)) => @SAWCoreVectorsAsCoqVectors.gen n (@SAWCorePrelude.Stream a) (fun (i : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.MkStream a (fun (j : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.sawAt n a (@SAWCorePrelude.streamGet (@SAWCoreVectorsAsCoqVectors.Vec n a) xss j) i))) (fun (xss : @SAWCorePrelude.Stream (@SAWCorePrelude.Stream a)) => @SAWCorePrelude.MkStream (@SAWCorePrelude.Stream a) (fun (i : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.MkStream a (fun (j : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.streamGet a (@SAWCorePrelude.streamGet (@SAWCorePrelude.Stream a) xss j) i))) n) m.
+  fun (m : @Num) (n : @Num) (a : Type) => CryptolPrimitivesForSAWCore.Num_rect (fun (m1 : @Num) => @seq m1 (@seq n a) -> @seq n (@seq m1 a)) (fun (m1 : @SAWCoreScaffolding.Nat) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @SAWCoreVectorsAsCoqVectors.Vec m1 (@seq n1 a) -> @seq n1 (@SAWCoreVectorsAsCoqVectors.Vec m1 a)) (fun (n1 : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.transpose m1 n1 a) (fun (xss : @SAWCoreVectorsAsCoqVectors.Vec m1 (@SAWCorePrelude.Stream a)) => @SAWCorePrelude.MkStream (@SAWCoreVectorsAsCoqVectors.Vec m1 a) (fun (i : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.gen m1 a (fun (j : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.streamGet a (@SAWCorePrelude.sawAt m1 (@SAWCorePrelude.Stream a) xss j) i))) n) (CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @SAWCorePrelude.Stream (@seq n1 a) -> @seq n1 (@SAWCorePrelude.Stream a)) (fun (n1 : @SAWCoreScaffolding.Nat) (xss : @SAWCorePrelude.Stream (@SAWCoreVectorsAsCoqVectors.Vec n1 a)) => @SAWCoreVectorsAsCoqVectors.gen n1 (@SAWCorePrelude.Stream a) (fun (i : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.MkStream a (fun (j : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.sawAt n1 a (@SAWCorePrelude.streamGet (@SAWCoreVectorsAsCoqVectors.Vec n1 a) xss j) i))) (fun (xss : @SAWCorePrelude.Stream (@SAWCorePrelude.Stream a)) => @SAWCorePrelude.MkStream (@SAWCorePrelude.Stream a) (fun (i : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.MkStream a (fun (j : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.streamGet a (@SAWCorePrelude.streamGet (@SAWCorePrelude.Stream a) xss j) i))) n) m.
 
 Definition ecAt : forall (n : @Num), forall (a : Type), forall (ix : Type), @PIntegral ix -> @seq n a -> ix -> a :=
-  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => forall (a : Type), forall (ix : Type), @PIntegral ix -> @seq n a -> ix -> a) (fun (n1 : @SAWCoreScaffolding.Nat) (a : Type) (ix : Type) (pix : RecordTypeCons "div" (ix -> ix -> ix) (RecordTypeCons "integralRing" (RecordTypeCons "add" (ix -> ix -> ix) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> ix) (RecordTypeCons "mul" (ix -> ix -> ix) (RecordTypeCons "neg" (ix -> ix) (RecordTypeCons "ringZero" ix (RecordTypeCons "sub" (ix -> ix -> ix) RecordTypeNil)))))) (RecordTypeCons "mod" (ix -> ix -> ix) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> ix -> r) (RecordTypeCons "toInt" (ix -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) (xs : @SAWCoreVectorsAsCoqVectors.Vec n1 a) => RecordProj pix "posNegCases" a (@SAWCorePrelude.sawAt n a xs) (fun (_1 : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.sawAt n a xs 0)) (fun (a : Type) (ix : Type) (pix : RecordTypeCons "div" (ix -> ix -> ix) (RecordTypeCons "integralRing" (RecordTypeCons "add" (ix -> ix -> ix) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> ix) (RecordTypeCons "mul" (ix -> ix -> ix) (RecordTypeCons "neg" (ix -> ix) (RecordTypeCons "ringZero" ix (RecordTypeCons "sub" (ix -> ix -> ix) RecordTypeNil)))))) (RecordTypeCons "mod" (ix -> ix -> ix) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> ix -> r) (RecordTypeCons "toInt" (ix -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) (xs : @SAWCorePrelude.Stream a) => RecordProj pix "posNegCases" a (@SAWCorePrelude.streamGet a xs) (fun (_1 : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.streamGet a xs 0)) n.
+  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => forall (a : Type), forall (ix : Type), @PIntegral ix -> @seq n1 a -> ix -> a) (fun (n1 : @SAWCoreScaffolding.Nat) (a : Type) (ix : Type) (pix : RecordTypeCons "div" (ix -> ix -> ix) (RecordTypeCons "integralRing" (RecordTypeCons "add" (ix -> ix -> ix) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> ix) (RecordTypeCons "mul" (ix -> ix -> ix) (RecordTypeCons "neg" (ix -> ix) (RecordTypeCons "ringZero" ix (RecordTypeCons "sub" (ix -> ix -> ix) RecordTypeNil)))))) (RecordTypeCons "mod" (ix -> ix -> ix) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> ix -> r) (RecordTypeCons "toInt" (ix -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) (xs : @SAWCoreVectorsAsCoqVectors.Vec n1 a) => RecordProj pix "posNegCases" a (@SAWCorePrelude.sawAt n1 a xs) (fun (_1 : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.sawAt n1 a xs 0)) (fun (a : Type) (ix : Type) (pix : RecordTypeCons "div" (ix -> ix -> ix) (RecordTypeCons "integralRing" (RecordTypeCons "add" (ix -> ix -> ix) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> ix) (RecordTypeCons "mul" (ix -> ix -> ix) (RecordTypeCons "neg" (ix -> ix) (RecordTypeCons "ringZero" ix (RecordTypeCons "sub" (ix -> ix -> ix) RecordTypeNil)))))) (RecordTypeCons "mod" (ix -> ix -> ix) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> ix -> r) (RecordTypeCons "toInt" (ix -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) (xs : @SAWCorePrelude.Stream a) => RecordProj pix "posNegCases" a (@SAWCorePrelude.streamGet a xs) (fun (_1 : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.streamGet a xs 0)) n.
 
 Definition ecAtBack : forall (n : @Num), forall (a : Type), forall (ix : Type), @PIntegral ix -> @seq n a -> ix -> a :=
-  fun (n : @Num) (a : Type) (ix : Type) (pix : RecordTypeCons "div" (ix -> ix -> ix) (RecordTypeCons "integralRing" (RecordTypeCons "add" (ix -> ix -> ix) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> ix) (RecordTypeCons "mul" (ix -> ix -> ix) (RecordTypeCons "neg" (ix -> ix) (RecordTypeCons "ringZero" ix (RecordTypeCons "sub" (ix -> ix -> ix) RecordTypeNil)))))) (RecordTypeCons "mod" (ix -> ix -> ix) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> ix -> r) (RecordTypeCons "toInt" (ix -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) (xs : CryptolPrimitivesForSAWCore.Num_rect (fun (num : @Num) => Type) (fun (n1 : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.Vec n a) (@SAWCorePrelude.Stream a) n) => @ecAt n a ix pix (@ecReverse n a xs).
+  fun (n : @Num) (a : Type) (ix : Type) (pix : RecordTypeCons "div" (ix -> ix -> ix) (RecordTypeCons "integralRing" (RecordTypeCons "add" (ix -> ix -> ix) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> ix) (RecordTypeCons "mul" (ix -> ix -> ix) (RecordTypeCons "neg" (ix -> ix) (RecordTypeCons "ringZero" ix (RecordTypeCons "sub" (ix -> ix -> ix) RecordTypeNil)))))) (RecordTypeCons "mod" (ix -> ix -> ix) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> ix -> r) (RecordTypeCons "toInt" (ix -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) (xs : CryptolPrimitivesForSAWCore.Num_rect (fun (num : @Num) => Type) (fun (n1 : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.Vec n1 a) (@SAWCorePrelude.Stream a) n) => @ecAt n a ix pix (@ecReverse n a xs).
 
 Definition ecFromTo : forall (first : @Num), forall (last : @Num), forall (a : Type), @PLiteral a -> @PLiteral a -> @seq (@tcAdd (@TCNum 1) (@tcSub last first)) a :=
   @finNumRec (fun (first : @Num) => forall (last : @Num), forall (a : Type), @PLiteral a -> @PLiteral a -> @seq (@tcAdd (@TCNum 1) (@tcSub last first)) a) (fun (first : @SAWCoreScaffolding.Nat) => @finNumRec (fun (last : @Num) => forall (a : Type), @PLiteral a -> @PLiteral a -> @seq (@tcAdd (@TCNum 1) (@tcSub last (@TCNum first))) a) (fun (last : @SAWCoreScaffolding.Nat) (a : Type) (pa : @SAWCoreScaffolding.Nat -> a) (_1 : @SAWCoreScaffolding.Nat -> a) => @SAWCoreVectorsAsCoqVectors.gen (@SAWCorePrelude.addNat 1 (@SAWCorePrelude.subNat last first)) a (fun (i : @SAWCoreScaffolding.Nat) => pa (@SAWCorePrelude.addNat i first)))).
@@ -603,29 +603,29 @@ Definition ecFromTo : forall (first : @Num), forall (last : @Num), forall (a : T
 Definition ecFromThenTo : forall (first : @Num), forall (next : @Num), forall (last : @Num), forall (a : Type), forall (len : @Num), @PLiteral a -> @PLiteral a -> @PLiteral a -> @seq len a :=
   fun (first : @Num) (next : @Num) (_1 : @Num) (a : Type) => @finNumRec (fun (len : @Num) => @PLiteral a -> @PLiteral a -> @PLiteral a -> @seq len a) (fun (len : @SAWCoreScaffolding.Nat) (pa : @SAWCoreScaffolding.Nat -> a) (_2 : @SAWCoreScaffolding.Nat -> a) (_3 : @SAWCoreScaffolding.Nat -> a) => @SAWCoreVectorsAsCoqVectors.gen len a (fun (i : @SAWCoreScaffolding.Nat) => pa (@SAWCorePrelude.subNat (@SAWCorePrelude.addNat (@getFinNat first) (@SAWCorePrelude.mulNat i (@getFinNat next))) (@SAWCorePrelude.mulNat i (@getFinNat first))))).
 
-Definition ecInfFrom : forall (a : Type), @PIntegral a -> a -> @seq @TCInf a :=
+Definition ecInfFrom : forall (a : Type), @PIntegral a -> a -> @seq (@TCInf) a :=
   fun (a : Type) (pa : RecordTypeCons "div" (a -> a -> a) (RecordTypeCons "integralRing" (RecordTypeCons "add" (a -> a -> a) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> a) (RecordTypeCons "mul" (a -> a -> a) (RecordTypeCons "neg" (a -> a) (RecordTypeCons "ringZero" a (RecordTypeCons "sub" (a -> a -> a) RecordTypeNil)))))) (RecordTypeCons "mod" (a -> a -> a) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> a -> r) (RecordTypeCons "toInt" (a -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) (x : a) => @SAWCorePrelude.MkStream a (fun (i : @SAWCoreScaffolding.Nat) => RecordProj (RecordProj pa "integralRing") "add" x (RecordProj (RecordProj pa "integralRing") "int" (@SAWCoreScaffolding.natToInt i))).
 
-Definition ecInfFromThen : forall (a : Type), @PIntegral a -> a -> a -> @seq @TCInf a :=
+Definition ecInfFromThen : forall (a : Type), @PIntegral a -> a -> a -> @seq (@TCInf) a :=
   fun (a : Type) (pa : RecordTypeCons "div" (a -> a -> a) (RecordTypeCons "integralRing" (RecordTypeCons "add" (a -> a -> a) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> a) (RecordTypeCons "mul" (a -> a -> a) (RecordTypeCons "neg" (a -> a) (RecordTypeCons "ringZero" a (RecordTypeCons "sub" (a -> a -> a) RecordTypeNil)))))) (RecordTypeCons "mod" (a -> a -> a) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> a -> r) (RecordTypeCons "toInt" (a -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) (x : a) (y : a) => @SAWCorePrelude.MkStream a (fun (i : @SAWCoreScaffolding.Nat) => RecordProj (RecordProj pa "integralRing") "add" x (RecordProj (RecordProj pa "integralRing") "mul" (RecordProj (RecordProj pa "integralRing") "sub" y x) (RecordProj (RecordProj pa "integralRing") "int" (@SAWCoreScaffolding.natToInt i)))).
 
-Definition ecError : forall (a : Type), forall (len : @Num), @seq len (@SAWCoreVectorsAsCoqVectors.Vec 8 @SAWCoreScaffolding.Bool) -> a :=
-  fun (a : Type) (len : @Num) (msg : CryptolPrimitivesForSAWCore.Num_rect (fun (num : @Num) => Type) (fun (n : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreVectorsAsCoqVectors.Vec 8 @SAWCoreScaffolding.Bool)) (@SAWCorePrelude.Stream (@SAWCoreVectorsAsCoqVectors.Vec 8 @SAWCoreScaffolding.Bool)) len) => @SAWCoreScaffolding.error a "encountered call to the Cryptol 'error' function"%string.
+Definition ecError : forall (a : Type), forall (len : @Num), @seq len (@SAWCoreVectorsAsCoqVectors.Vec 8 (@SAWCoreScaffolding.Bool)) -> a :=
+  fun (a : Type) (len : @Num) (msg : CryptolPrimitivesForSAWCore.Num_rect (fun (num : @Num) => Type) (fun (n : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreVectorsAsCoqVectors.Vec 8 (@SAWCoreScaffolding.Bool))) (@SAWCorePrelude.Stream (@SAWCoreVectorsAsCoqVectors.Vec 8 (@SAWCoreScaffolding.Bool))) len) => @SAWCoreScaffolding.error a "encountered call to the Cryptol 'error' function"%string.
 
-Definition ecRandom : forall (a : Type), @SAWCoreVectorsAsCoqVectors.Vec 32 @SAWCoreScaffolding.Bool -> a :=
-  fun (a : Type) (_1 : @SAWCoreVectorsAsCoqVectors.Vec 32 @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.error a "Cryptol.random"%string.
+Definition ecRandom : forall (a : Type), @SAWCoreVectorsAsCoqVectors.Vec 32 (@SAWCoreScaffolding.Bool) -> a :=
+  fun (a : Type) (_1 : @SAWCoreVectorsAsCoqVectors.Vec 32 (@SAWCoreScaffolding.Bool)) => @SAWCoreScaffolding.error a "Cryptol.random"%string.
 
-Definition ecTrace : forall (n : @Num), forall (a : Type), forall (b : Type), @seq n (@SAWCoreVectorsAsCoqVectors.Vec 8 @SAWCoreScaffolding.Bool) -> a -> b -> b :=
-  fun (_1 : @Num) (_2 : Type) (_3 : Type) (_4 : CryptolPrimitivesForSAWCore.Num_rect (fun (num : @Num) => Type) (fun (n : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreVectorsAsCoqVectors.Vec 8 @SAWCoreScaffolding.Bool)) (@SAWCorePrelude.Stream (@SAWCoreVectorsAsCoqVectors.Vec 8 @SAWCoreScaffolding.Bool)) _1) (_5 : _2) (x : _3) => x.
+Definition ecTrace : forall (n : @Num), forall (a : Type), forall (b : Type), @seq n (@SAWCoreVectorsAsCoqVectors.Vec 8 (@SAWCoreScaffolding.Bool)) -> a -> b -> b :=
+  fun (_1 : @Num) (_2 : Type) (_3 : Type) (_4 : CryptolPrimitivesForSAWCore.Num_rect (fun (num : @Num) => Type) (fun (n : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreVectorsAsCoqVectors.Vec 8 (@SAWCoreScaffolding.Bool))) (@SAWCorePrelude.Stream (@SAWCoreVectorsAsCoqVectors.Vec 8 (@SAWCoreScaffolding.Bool))) _1) (_5 : _2) (x : _3) => x.
 
 Definition ecDeepseq : forall (a : Type), forall (b : Type), @PEq a -> a -> b -> b :=
   fun (a : Type) (b : Type) (pa : RecordTypeCons "eq" (a -> a -> @SAWCoreScaffolding.Bool) RecordTypeNil) (x : a) (y : b) => y.
 
 Definition ecParmap : forall (a : Type), forall (b : Type), forall (n : @Num), @PEq b -> (a -> b) -> @seq n a -> @seq n b :=
-  fun (a : Type) (b : Type) (n : @Num) (pb : RecordTypeCons "eq" (b -> b -> @SAWCoreScaffolding.Bool) RecordTypeNil) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => (a -> b) -> @seq n a -> @seq n b) (fun (n1 : @SAWCoreScaffolding.Nat) (f : a -> b) (xs : @SAWCoreVectorsAsCoqVectors.Vec n1 a) => @SAWCorePrelude.map a b f n xs) (fun (f : a -> b) (xs : @SAWCorePrelude.Stream a) => @SAWCoreScaffolding.error (@SAWCorePrelude.Stream b) "Unexpected infinite stream in parmap"%string) n.
+  fun (a : Type) (b : Type) (n : @Num) (pb : RecordTypeCons "eq" (b -> b -> @SAWCoreScaffolding.Bool) RecordTypeNil) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => (a -> b) -> @seq n1 a -> @seq n1 b) (fun (n1 : @SAWCoreScaffolding.Nat) (f : a -> b) (xs : @SAWCoreVectorsAsCoqVectors.Vec n1 a) => @SAWCorePrelude.map a b f n1 xs) (fun (f : a -> b) (xs : @SAWCorePrelude.Stream a) => @SAWCoreScaffolding.error (@SAWCorePrelude.Stream b) "Unexpected infinite stream in parmap"%string) n.
 
 Definition ecFoldl : forall (n : @Num), forall (a : Type), forall (b : Type), (a -> b -> a) -> a -> @seq n b -> a :=
-  fun (n : @Num) (a : Type) (b : Type) (f : a -> b -> a) (z : a) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @seq n b -> a) (fun (n1 : @SAWCoreScaffolding.Nat) (xs : @SAWCoreVectorsAsCoqVectors.Vec n1 b) => @SAWCoreVectorsAsCoqVectors.foldr b a n (fun (y : b) (x : a) => f x y) z (@SAWCorePrelude.reverse n b xs)) (fun (xs : @SAWCorePrelude.Stream b) => @SAWCoreScaffolding.error a "Unexpected infinite stream in foldl"%string) n.
+  fun (n : @Num) (a : Type) (b : Type) (f : a -> b -> a) (z : a) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => @seq n1 b -> a) (fun (n1 : @SAWCoreScaffolding.Nat) (xs : @SAWCoreVectorsAsCoqVectors.Vec n1 b) => @SAWCoreVectorsAsCoqVectors.foldr b a n1 (fun (y : b) (x : a) => f x y) z (@SAWCorePrelude.reverse n1 b xs)) (fun (xs : @SAWCorePrelude.Stream b) => @SAWCoreScaffolding.error a "Unexpected infinite stream in foldl"%string) n.
 
 Definition ecFoldlPrime : forall (n : @Num), forall (a : Type), forall (b : Type), @PEq a -> (a -> b -> a) -> a -> @seq n b -> a :=
   fun (n : @Num) (a : Type) (b : Type) (pa : RecordTypeCons "eq" (a -> a -> @SAWCoreScaffolding.Bool) RecordTypeNil) => @ecFoldl n a b.
@@ -634,10 +634,10 @@ Definition TCFloat : @Num -> @Num -> Type :=
   fun (_1 : @Num) (_2 : @Num) => unit.
 
 Definition PEqFloat : forall (e : @Num), forall (p : @Num), @PEq (@TCFloat e p) :=
-  fun (e : @Num) (p : @Num) => RecordCons "eq" (fun (x : unit) (y : unit) => @SAWCoreScaffolding.error @SAWCoreScaffolding.Bool "Unimplemented: (==) Float"%string) RecordNil.
+  fun (e : @Num) (p : @Num) => RecordCons "eq" (fun (x : unit) (y : unit) => @SAWCoreScaffolding.error (@SAWCoreScaffolding.Bool) "Unimplemented: (==) Float"%string) RecordNil.
 
 Definition PCmpFloat : forall (e : @Num), forall (p : @Num), @PCmp (@TCFloat e p) :=
-  fun (e : @Num) (p : @Num) => RecordCons "cmp" (fun (x : unit) (y : unit) (k : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.error @SAWCoreScaffolding.Bool "Unimplemented: Cmp Float"%string) (RecordCons "cmpEq" (@PEqFloat e p) RecordNil).
+  fun (e : @Num) (p : @Num) => RecordCons "cmp" (fun (x : unit) (y : unit) (k : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.error (@SAWCoreScaffolding.Bool) "Unimplemented: Cmp Float"%string) (RecordCons "cmpEq" (@PEqFloat e p) RecordNil).
 
 Definition PZeroFloat : forall (e : @Num), forall (p : @Num), @PZero (@TCFloat e p) :=
   fun (e : @Num) (p : @Num) => @SAWCoreScaffolding.error (@TCFloat e p) "Unimplemented: Zero Float"%string.
@@ -649,7 +649,7 @@ Definition PFieldFloat : forall (e : @Num), forall (p : @Num), @PField (@TCFloat
   fun (e : @Num) (p : @Num) => RecordCons "fieldDiv" (fun (x : unit) (y : unit) => @SAWCoreScaffolding.error (@TCFloat e p) "Unimplemented: (/.) Float"%string) (RecordCons "fieldRing" (@PRingFloat e p) (RecordCons "recip" (fun (x : unit) => @SAWCoreScaffolding.error (@TCFloat e p) "Unimplemented: recip Float"%string) RecordNil)).
 
 Definition PRoundFloat : forall (e : @Num), forall (p : @Num), @PRound (@TCFloat e p) :=
-  fun (e : @Num) (p : @Num) => RecordCons "ceiling" (fun (x : unit) => @SAWCoreScaffolding.error @SAWCoreScaffolding.Integer "Unimplemented: ceiling Float"%string) (RecordCons "floor" (fun (x : unit) => @SAWCoreScaffolding.error @SAWCoreScaffolding.Integer "Unimplemented: floor Float"%string) (RecordCons "roundAway" (fun (x : unit) => @SAWCoreScaffolding.error @SAWCoreScaffolding.Integer "Unimplemented: roundAway Float"%string) (RecordCons "roundCmp" (@PCmpFloat e p) (RecordCons "roundField" (@PFieldFloat e p) (RecordCons "roundToEven" (fun (x : unit) => @SAWCoreScaffolding.error @SAWCoreScaffolding.Integer "Unimplemented: roundToEven Float"%string) (RecordCons "trunc" (fun (x : unit) => @SAWCoreScaffolding.error @SAWCoreScaffolding.Integer "Unimplemented: trunc Float"%string) RecordNil)))))).
+  fun (e : @Num) (p : @Num) => RecordCons "ceiling" (fun (x : unit) => @SAWCoreScaffolding.error (@SAWCoreScaffolding.Integer) "Unimplemented: ceiling Float"%string) (RecordCons "floor" (fun (x : unit) => @SAWCoreScaffolding.error (@SAWCoreScaffolding.Integer) "Unimplemented: floor Float"%string) (RecordCons "roundAway" (fun (x : unit) => @SAWCoreScaffolding.error (@SAWCoreScaffolding.Integer) "Unimplemented: roundAway Float"%string) (RecordCons "roundCmp" (@PCmpFloat e p) (RecordCons "roundField" (@PFieldFloat e p) (RecordCons "roundToEven" (fun (x : unit) => @SAWCoreScaffolding.error (@SAWCoreScaffolding.Integer) "Unimplemented: roundToEven Float"%string) (RecordCons "trunc" (fun (x : unit) => @SAWCoreScaffolding.error (@SAWCoreScaffolding.Integer) "Unimplemented: trunc Float"%string) RecordNil)))))).
 
 Definition ecFpNaN : forall (e : @Num), forall (p : @Num), @TCFloat e p :=
   fun (e : @Num) (p : @Num) => @SAWCoreScaffolding.error (@TCFloat e p) "Unimplemented: fpNaN"%string.
@@ -657,62 +657,86 @@ Definition ecFpNaN : forall (e : @Num), forall (p : @Num), @TCFloat e p :=
 Definition ecFpPosInf : forall (e : @Num), forall (p : @Num), @TCFloat e p :=
   fun (e : @Num) (p : @Num) => @SAWCoreScaffolding.error (@TCFloat e p) "Unimplemented: fpPosInf"%string.
 
-Definition ecFpFromBits : forall (e : @Num), forall (p : @Num), @seq (@tcAdd e p) @SAWCoreScaffolding.Bool -> @TCFloat e p :=
-  fun (e : @Num) (p : @Num) (_1 : CryptolPrimitivesForSAWCore.Num_rect (fun (num : @Num) => Type) (fun (n : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) (@SAWCorePrelude.Stream @SAWCoreScaffolding.Bool) (CryptolPrimitivesForSAWCore.Num_rect (fun (num1' : @Num) => @Num) (fun (n1 : @SAWCoreScaffolding.Nat) => CryptolPrimitivesForSAWCore.Num_rect (fun (num2' : @Num) => @Num) (fun (n2 : @SAWCoreScaffolding.Nat) => @TCNum (@SAWCorePrelude.addNat n1 n2)) ((fun (x : @SAWCoreScaffolding.Nat) => @TCInf) n1) p) (CryptolPrimitivesForSAWCore.Num_rect (fun (num2' : @Num) => @Num) (fun (y : @SAWCoreScaffolding.Nat) => @TCInf) @TCInf p) e)) => @SAWCoreScaffolding.error (@TCFloat e p) "Unimplemented: fpFromBits"%string.
+Definition ecFpFromBits : forall (e : @Num), forall (p : @Num), @seq (@tcAdd e p) (@SAWCoreScaffolding.Bool) -> @TCFloat e p :=
+  fun (e : @Num) (p : @Num) (_1 : CryptolPrimitivesForSAWCore.Num_rect (fun (num : @Num) => Type) (fun (n : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) (@SAWCorePrelude.Stream (@SAWCoreScaffolding.Bool)) (CryptolPrimitivesForSAWCore.Num_rect (fun (num1' : @Num) => @Num) (fun (n1 : @SAWCoreScaffolding.Nat) => CryptolPrimitivesForSAWCore.Num_rect (fun (num2' : @Num) => @Num) (fun (n2 : @SAWCoreScaffolding.Nat) => @TCNum (@SAWCorePrelude.addNat n1 n2)) ((fun (x : @SAWCoreScaffolding.Nat) => @TCInf) n1) p) (CryptolPrimitivesForSAWCore.Num_rect (fun (num2' : @Num) => @Num) (fun (y : @SAWCoreScaffolding.Nat) => @TCInf) (@TCInf) p) e)) => @SAWCoreScaffolding.error (@TCFloat e p) "Unimplemented: fpFromBits"%string.
 
-Definition ecFpToBits : forall (e : @Num), forall (p : @Num), @TCFloat e p -> @seq (@tcAdd e p) @SAWCoreScaffolding.Bool :=
-  fun (e : @Num) (p : @Num) (_1 : unit) => @SAWCoreScaffolding.error (@seq (@tcAdd e p) @SAWCoreScaffolding.Bool) "Unimplemented: fpToBits"%string.
+Definition ecFpToBits : forall (e : @Num), forall (p : @Num), @TCFloat e p -> @seq (@tcAdd e p) (@SAWCoreScaffolding.Bool) :=
+  fun (e : @Num) (p : @Num) (_1 : unit) => @SAWCoreScaffolding.error (@seq (@tcAdd e p) (@SAWCoreScaffolding.Bool)) "Unimplemented: fpToBits"%string.
 
 Definition ecFpEq : forall (e : @Num), forall (p : @Num), @TCFloat e p -> @TCFloat e p -> @SAWCoreScaffolding.Bool :=
-  fun (e : @Num) (p : @Num) (_1 : unit) (_2 : unit) => @SAWCoreScaffolding.error @SAWCoreScaffolding.Bool "Unimplemented: =.="%string.
+  fun (e : @Num) (p : @Num) (_1 : unit) (_2 : unit) => @SAWCoreScaffolding.error (@SAWCoreScaffolding.Bool) "Unimplemented: =.="%string.
 
-Definition ecFpAdd : forall (e : @Num), forall (p : @Num), @SAWCoreVectorsAsCoqVectors.Vec 3 @SAWCoreScaffolding.Bool -> @TCFloat e p -> @TCFloat e p -> @TCFloat e p :=
-  fun (e : @Num) (p : @Num) (_1 : @SAWCoreVectorsAsCoqVectors.Vec 3 @SAWCoreScaffolding.Bool) (_2 : unit) (_3 : unit) => @SAWCoreScaffolding.error (@TCFloat e p) "Unimplemented: fpAdd"%string.
+Definition ecFpAdd : forall (e : @Num), forall (p : @Num), @SAWCoreVectorsAsCoqVectors.Vec 3 (@SAWCoreScaffolding.Bool) -> @TCFloat e p -> @TCFloat e p -> @TCFloat e p :=
+  fun (e : @Num) (p : @Num) (_1 : @SAWCoreVectorsAsCoqVectors.Vec 3 (@SAWCoreScaffolding.Bool)) (_2 : unit) (_3 : unit) => @SAWCoreScaffolding.error (@TCFloat e p) "Unimplemented: fpAdd"%string.
 
-Definition ecFpSub : forall (e : @Num), forall (p : @Num), @SAWCoreVectorsAsCoqVectors.Vec 3 @SAWCoreScaffolding.Bool -> @TCFloat e p -> @TCFloat e p -> @TCFloat e p :=
-  fun (e : @Num) (p : @Num) (_1 : @SAWCoreVectorsAsCoqVectors.Vec 3 @SAWCoreScaffolding.Bool) (_2 : unit) (_3 : unit) => @SAWCoreScaffolding.error (@TCFloat e p) "Unimplemented: fpSub"%string.
+Definition ecFpSub : forall (e : @Num), forall (p : @Num), @SAWCoreVectorsAsCoqVectors.Vec 3 (@SAWCoreScaffolding.Bool) -> @TCFloat e p -> @TCFloat e p -> @TCFloat e p :=
+  fun (e : @Num) (p : @Num) (_1 : @SAWCoreVectorsAsCoqVectors.Vec 3 (@SAWCoreScaffolding.Bool)) (_2 : unit) (_3 : unit) => @SAWCoreScaffolding.error (@TCFloat e p) "Unimplemented: fpSub"%string.
 
-Definition ecFpMul : forall (e : @Num), forall (p : @Num), @SAWCoreVectorsAsCoqVectors.Vec 3 @SAWCoreScaffolding.Bool -> @TCFloat e p -> @TCFloat e p -> @TCFloat e p :=
-  fun (e : @Num) (p : @Num) (_1 : @SAWCoreVectorsAsCoqVectors.Vec 3 @SAWCoreScaffolding.Bool) (_2 : unit) (_3 : unit) => @SAWCoreScaffolding.error (@TCFloat e p) "Unimplemented: fpMul"%string.
+Definition ecFpMul : forall (e : @Num), forall (p : @Num), @SAWCoreVectorsAsCoqVectors.Vec 3 (@SAWCoreScaffolding.Bool) -> @TCFloat e p -> @TCFloat e p -> @TCFloat e p :=
+  fun (e : @Num) (p : @Num) (_1 : @SAWCoreVectorsAsCoqVectors.Vec 3 (@SAWCoreScaffolding.Bool)) (_2 : unit) (_3 : unit) => @SAWCoreScaffolding.error (@TCFloat e p) "Unimplemented: fpMul"%string.
 
-Definition ecFpDiv : forall (e : @Num), forall (p : @Num), @SAWCoreVectorsAsCoqVectors.Vec 3 @SAWCoreScaffolding.Bool -> @TCFloat e p -> @TCFloat e p -> @TCFloat e p :=
-  fun (e : @Num) (p : @Num) (_1 : @SAWCoreVectorsAsCoqVectors.Vec 3 @SAWCoreScaffolding.Bool) (_2 : unit) (_3 : unit) => @SAWCoreScaffolding.error (@TCFloat e p) "Unimplemented: fpDiv"%string.
+Definition ecFpDiv : forall (e : @Num), forall (p : @Num), @SAWCoreVectorsAsCoqVectors.Vec 3 (@SAWCoreScaffolding.Bool) -> @TCFloat e p -> @TCFloat e p -> @TCFloat e p :=
+  fun (e : @Num) (p : @Num) (_1 : @SAWCoreVectorsAsCoqVectors.Vec 3 (@SAWCoreScaffolding.Bool)) (_2 : unit) (_3 : unit) => @SAWCoreScaffolding.error (@TCFloat e p) "Unimplemented: fpDiv"%string.
 
-Definition ecFpIsFinite : forall (e : @Num), forall (p : @Num), @TCFloat e p -> @SAWCoreScaffolding.Bool :=
-  fun (e : @Num) (p : @Num) (_1 : unit) => @SAWCoreScaffolding.error @SAWCoreScaffolding.Bool "Unimplemented: fpIsFinite"%string.
+Definition ecFpToRational : forall (e : @Num), forall (p : @Num), @TCFloat e p -> Rational :=
+  fun (e : @Num) (p : @Num) (_1 : unit) => @SAWCoreScaffolding.error Rational "Unimplemented: fpToRational"%string.
 
-Definition ecFpToRational : forall (e : @Num), forall (p : @Num), @TCFloat e p -> @Rational :=
-  fun (e : @Num) (p : @Num) (_1 : unit) => @SAWCoreScaffolding.error @Rational "Unimplemented: fpToRational"%string.
+Definition ecFpFromRational : forall (e : @Num), forall (p : @Num), @SAWCoreVectorsAsCoqVectors.Vec 3 (@SAWCoreScaffolding.Bool) -> Rational -> @TCFloat e p :=
+  fun (e : @Num) (p : @Num) (_1 : @SAWCoreVectorsAsCoqVectors.Vec 3 (@SAWCoreScaffolding.Bool)) (_2 : unit) => @SAWCoreScaffolding.error (@TCFloat e p) "Unimplemented: fpFromRational"%string.
 
-Definition ecFpFromRational : forall (e : @Num), forall (p : @Num), @SAWCoreVectorsAsCoqVectors.Vec 3 @SAWCoreScaffolding.Bool -> @Rational -> @TCFloat e p :=
-  fun (e : @Num) (p : @Num) (_1 : @SAWCoreVectorsAsCoqVectors.Vec 3 @SAWCoreScaffolding.Bool) (_2 : unit) => @SAWCoreScaffolding.error (@TCFloat e p) "Unimplemented: fpFromRational"%string.
+Definition fpIsNaN : forall (e : @Num), forall (p : @Num), @TCFloat e p -> @SAWCoreScaffolding.Bool :=
+  fun (e : @Num) (p : @Num) (x : unit) => @SAWCoreScaffolding.error (@SAWCoreScaffolding.Bool) "Unimplemented: fpIsNaN"%string.
+
+Definition fpIsInf : forall (e : @Num), forall (p : @Num), @TCFloat e p -> @SAWCoreScaffolding.Bool :=
+  fun (e : @Num) (p : @Num) (x : unit) => @SAWCoreScaffolding.error (@SAWCoreScaffolding.Bool) "Unimplemented: fpIsInf"%string.
+
+Definition fpIsZero : forall (e : @Num), forall (p : @Num), @TCFloat e p -> @SAWCoreScaffolding.Bool :=
+  fun (e : @Num) (p : @Num) (x : unit) => @SAWCoreScaffolding.error (@SAWCoreScaffolding.Bool) "Unimplemented: fpIsZero"%string.
+
+Definition fpIsNeg : forall (e : @Num), forall (p : @Num), @TCFloat e p -> @SAWCoreScaffolding.Bool :=
+  fun (e : @Num) (p : @Num) (x : unit) => @SAWCoreScaffolding.error (@SAWCoreScaffolding.Bool) "Unimplemented: fpIsNeg"%string.
+
+Definition fpIsNormal : forall (e : @Num), forall (p : @Num), @TCFloat e p -> @SAWCoreScaffolding.Bool :=
+  fun (e : @Num) (p : @Num) (x : unit) => @SAWCoreScaffolding.error (@SAWCoreScaffolding.Bool) "Unimplemented: fpIsNormal"%string.
+
+Definition fpIsSubnormal : forall (e : @Num), forall (p : @Num), @TCFloat e p -> @SAWCoreScaffolding.Bool :=
+  fun (e : @Num) (p : @Num) (x : unit) => @SAWCoreScaffolding.error (@SAWCoreScaffolding.Bool) "Unimplemented: fpIsSubnormal"%string.
+
+Definition fpFMA : forall (e : @Num), forall (p : @Num), @SAWCoreVectorsAsCoqVectors.Vec 3 (@SAWCoreScaffolding.Bool) -> @TCFloat e p -> @TCFloat e p -> @TCFloat e p -> @TCFloat e p :=
+  fun (e : @Num) (p : @Num) (r : @SAWCoreVectorsAsCoqVectors.Vec 3 (@SAWCoreScaffolding.Bool)) (x : unit) (y : unit) (z : unit) => @SAWCoreScaffolding.error (@TCFloat e p) "Unimplemented: fpFMA"%string.
+
+Definition fpAbs : forall (e : @Num), forall (p : @Num), @TCFloat e p -> @TCFloat e p :=
+  fun (e : @Num) (p : @Num) (x : unit) => @SAWCoreScaffolding.error (@TCFloat e p) "Unimplemented: fpAbs"%string.
+
+Definition fpSqrt : forall (e : @Num), forall (p : @Num), @SAWCoreVectorsAsCoqVectors.Vec 3 (@SAWCoreScaffolding.Bool) -> @TCFloat e p -> @TCFloat e p :=
+  fun (e : @Num) (p : @Num) (r : @SAWCoreVectorsAsCoqVectors.Vec 3 (@SAWCoreScaffolding.Bool)) (x : unit) => @SAWCoreScaffolding.error (@TCFloat e p) "Unimplemented: fpSqrt"%string.
 
 Definition ecUpdate : forall (n : @Num), forall (a : Type), forall (ix : Type), @PIntegral ix -> @seq n a -> ix -> a -> @seq n a :=
-  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => forall (a : Type), forall (ix : Type), @PIntegral ix -> @seq n a -> ix -> a -> @seq n a) (fun (n1 : @SAWCoreScaffolding.Nat) (a : Type) (ix : Type) (pix : RecordTypeCons "div" (ix -> ix -> ix) (RecordTypeCons "integralRing" (RecordTypeCons "add" (ix -> ix -> ix) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> ix) (RecordTypeCons "mul" (ix -> ix -> ix) (RecordTypeCons "neg" (ix -> ix) (RecordTypeCons "ringZero" ix (RecordTypeCons "sub" (ix -> ix -> ix) RecordTypeNil)))))) (RecordTypeCons "mod" (ix -> ix -> ix) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> ix -> r) (RecordTypeCons "toInt" (ix -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) (xs : @SAWCoreVectorsAsCoqVectors.Vec n1 a) => RecordProj pix "posNegCases" (a -> @SAWCoreVectorsAsCoqVectors.Vec n a) (@SAWCorePrelude.upd n a xs) (fun (_1 : @SAWCoreScaffolding.Nat) (_2 : a) => xs)) (fun (a : Type) (ix : Type) (pix : RecordTypeCons "div" (ix -> ix -> ix) (RecordTypeCons "integralRing" (RecordTypeCons "add" (ix -> ix -> ix) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> ix) (RecordTypeCons "mul" (ix -> ix -> ix) (RecordTypeCons "neg" (ix -> ix) (RecordTypeCons "ringZero" ix (RecordTypeCons "sub" (ix -> ix -> ix) RecordTypeNil)))))) (RecordTypeCons "mod" (ix -> ix -> ix) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> ix -> r) (RecordTypeCons "toInt" (ix -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) (xs : @SAWCorePrelude.Stream a) => RecordProj pix "posNegCases" (a -> @SAWCorePrelude.Stream a) (@SAWCorePrelude.streamUpd a xs) (fun (_1 : @SAWCoreScaffolding.Nat) (_2 : a) => xs)) n.
+  fun (n : @Num) => CryptolPrimitivesForSAWCore.Num_rect (fun (n1 : @Num) => forall (a : Type), forall (ix : Type), @PIntegral ix -> @seq n1 a -> ix -> a -> @seq n1 a) (fun (n1 : @SAWCoreScaffolding.Nat) (a : Type) (ix : Type) (pix : RecordTypeCons "div" (ix -> ix -> ix) (RecordTypeCons "integralRing" (RecordTypeCons "add" (ix -> ix -> ix) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> ix) (RecordTypeCons "mul" (ix -> ix -> ix) (RecordTypeCons "neg" (ix -> ix) (RecordTypeCons "ringZero" ix (RecordTypeCons "sub" (ix -> ix -> ix) RecordTypeNil)))))) (RecordTypeCons "mod" (ix -> ix -> ix) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> ix -> r) (RecordTypeCons "toInt" (ix -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) (xs : @SAWCoreVectorsAsCoqVectors.Vec n1 a) => RecordProj pix "posNegCases" (a -> @SAWCoreVectorsAsCoqVectors.Vec n1 a) (@SAWCorePrelude.upd n1 a xs) (fun (_1 : @SAWCoreScaffolding.Nat) (_2 : a) => xs)) (fun (a : Type) (ix : Type) (pix : RecordTypeCons "div" (ix -> ix -> ix) (RecordTypeCons "integralRing" (RecordTypeCons "add" (ix -> ix -> ix) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> ix) (RecordTypeCons "mul" (ix -> ix -> ix) (RecordTypeCons "neg" (ix -> ix) (RecordTypeCons "ringZero" ix (RecordTypeCons "sub" (ix -> ix -> ix) RecordTypeNil)))))) (RecordTypeCons "mod" (ix -> ix -> ix) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> ix -> r) (RecordTypeCons "toInt" (ix -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) (xs : @SAWCorePrelude.Stream a) => RecordProj pix "posNegCases" (a -> @SAWCorePrelude.Stream a) (@SAWCorePrelude.streamUpd a xs) (fun (_1 : @SAWCoreScaffolding.Nat) (_2 : a) => xs)) n.
 
 Definition ecUpdateEnd : forall (n : @Num), forall (a : Type), forall (ix : Type), @PIntegral ix -> @seq n a -> ix -> a -> @seq n a :=
   @finNumRec (fun (n : @Num) => forall (a : Type), forall (ix : Type), @PIntegral ix -> @seq n a -> ix -> a -> @seq n a) (fun (n : @SAWCoreScaffolding.Nat) (a : Type) (ix : Type) (pix : RecordTypeCons "div" (ix -> ix -> ix) (RecordTypeCons "integralRing" (RecordTypeCons "add" (ix -> ix -> ix) (RecordTypeCons "int" (@SAWCoreScaffolding.Integer -> ix) (RecordTypeCons "mul" (ix -> ix -> ix) (RecordTypeCons "neg" (ix -> ix) (RecordTypeCons "ringZero" ix (RecordTypeCons "sub" (ix -> ix -> ix) RecordTypeNil)))))) (RecordTypeCons "mod" (ix -> ix -> ix) (RecordTypeCons "posNegCases" (forall (r : Type), (@SAWCoreScaffolding.Nat -> r) -> (@SAWCoreScaffolding.Nat -> r) -> ix -> r) (RecordTypeCons "toInt" (ix -> @SAWCoreScaffolding.Integer) RecordTypeNil))))) (xs : @SAWCoreVectorsAsCoqVectors.Vec n a) => RecordProj pix "posNegCases" (a -> @SAWCoreVectorsAsCoqVectors.Vec n a) (fun (i : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.upd n a xs (@SAWCorePrelude.subNat (@SAWCorePrelude.subNat n 1) i)) (fun (_1 : @SAWCoreScaffolding.Nat) (_2 : a) => xs)).
 
-Definition ecTrunc : forall (m : @Num), forall (n : @Num), @seq (@tcAdd m n) @SAWCoreScaffolding.Bool -> @seq n @SAWCoreScaffolding.Bool :=
-  @finNumRec2 (fun (m : @Num) (n : @Num) => @seq (@tcAdd m n) @SAWCoreScaffolding.Bool -> @seq n @SAWCoreScaffolding.Bool) @SAWCorePrelude.bvTrunc.
+Definition ecTrunc : forall (m : @Num), forall (n : @Num), @seq (@tcAdd m n) (@SAWCoreScaffolding.Bool) -> @seq n (@SAWCoreScaffolding.Bool) :=
+  @finNumRec2 (fun (m : @Num) (n : @Num) => @seq (@tcAdd m n) (@SAWCoreScaffolding.Bool) -> @seq n (@SAWCoreScaffolding.Bool)) bvTrunc.
 
-Definition ecUExt : forall (m : @Num), forall (n : @Num), @seq n @SAWCoreScaffolding.Bool -> @seq (@tcAdd m n) @SAWCoreScaffolding.Bool :=
-  @finNumRec2 (fun (m : @Num) (n : @Num) => @seq n @SAWCoreScaffolding.Bool -> @seq (@tcAdd m n) @SAWCoreScaffolding.Bool) @SAWCorePrelude.bvUExt.
+Definition ecUExt : forall (m : @Num), forall (n : @Num), @seq n (@SAWCoreScaffolding.Bool) -> @seq (@tcAdd m n) (@SAWCoreScaffolding.Bool) :=
+  @finNumRec2 (fun (m : @Num) (n : @Num) => @seq n (@SAWCoreScaffolding.Bool) -> @seq (@tcAdd m n) (@SAWCoreScaffolding.Bool)) bvUExt.
 
-Definition ecSExt : forall (m : @Num), forall (n : @Num), @seq n @SAWCoreScaffolding.Bool -> @seq (@tcAdd m n) @SAWCoreScaffolding.Bool :=
-  @finNumRec2 (fun (m : @Num) (n : @Num) => @seq n @SAWCoreScaffolding.Bool -> @seq (@tcAdd m n) @SAWCoreScaffolding.Bool) (fun (m : @SAWCoreScaffolding.Nat) (n : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.natCase (fun (n' : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.Vec n' @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec (@SAWCorePrelude.addNat m n') @SAWCoreScaffolding.Bool) (fun (_1 : @SAWCoreVectorsAsCoqVectors.Vec 0 @SAWCoreScaffolding.Bool) => @SAWCoreVectorsAsCoqVectors.bvNat (@SAWCorePrelude.addNat m 0) 0) (@SAWCorePrelude.bvSExt m) n).
+Definition ecSExt : forall (m : @Num), forall (n : @Num), @seq n (@SAWCoreScaffolding.Bool) -> @seq (@tcAdd m n) (@SAWCoreScaffolding.Bool) :=
+  @finNumRec2 (fun (m : @Num) (n : @Num) => @seq n (@SAWCoreScaffolding.Bool) -> @seq (@tcAdd m n) (@SAWCoreScaffolding.Bool)) (fun (m : @SAWCoreScaffolding.Nat) (n : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.natCase (fun (n' : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.Vec n' (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec (@SAWCorePrelude.addNat m n') (@SAWCoreScaffolding.Bool)) (fun (_1 : @SAWCoreVectorsAsCoqVectors.Vec 0 (@SAWCoreScaffolding.Bool)) => @SAWCoreVectorsAsCoqVectors.bvNat (@SAWCorePrelude.addNat m 0) 0) (@SAWCorePrelude.bvSExt m) n).
 
-Definition ecSgt : forall (n : @Num), @seq n @SAWCoreScaffolding.Bool -> @seq n @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool :=
-  @finNumRec (fun (n : @Num) => @seq n @SAWCoreScaffolding.Bool -> @seq n @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) @SAWCoreVectorsAsCoqVectors.bvsgt.
+Definition ecSgt : forall (n : @Num), @seq n (@SAWCoreScaffolding.Bool) -> @seq n (@SAWCoreScaffolding.Bool) -> @SAWCoreScaffolding.Bool :=
+  @finNumRec (fun (n : @Num) => @seq n (@SAWCoreScaffolding.Bool) -> @seq n (@SAWCoreScaffolding.Bool) -> @SAWCoreScaffolding.Bool) (@SAWCoreVectorsAsCoqVectors.bvsgt).
 
-Definition ecSge : forall (n : @Num), @seq n @SAWCoreScaffolding.Bool -> @seq n @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool :=
-  @finNumRec (fun (n : @Num) => @seq n @SAWCoreScaffolding.Bool -> @seq n @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) @SAWCoreVectorsAsCoqVectors.bvsge.
+Definition ecSge : forall (n : @Num), @seq n (@SAWCoreScaffolding.Bool) -> @seq n (@SAWCoreScaffolding.Bool) -> @SAWCoreScaffolding.Bool :=
+  @finNumRec (fun (n : @Num) => @seq n (@SAWCoreScaffolding.Bool) -> @seq n (@SAWCoreScaffolding.Bool) -> @SAWCoreScaffolding.Bool) (@SAWCoreVectorsAsCoqVectors.bvsge).
 
-Definition ecSlt : forall (n : @Num), @seq n @SAWCoreScaffolding.Bool -> @seq n @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool :=
-  @finNumRec (fun (n : @Num) => @seq n @SAWCoreScaffolding.Bool -> @seq n @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) @SAWCoreVectorsAsCoqVectors.bvslt.
+Definition ecSlt : forall (n : @Num), @seq n (@SAWCoreScaffolding.Bool) -> @seq n (@SAWCoreScaffolding.Bool) -> @SAWCoreScaffolding.Bool :=
+  @finNumRec (fun (n : @Num) => @seq n (@SAWCoreScaffolding.Bool) -> @seq n (@SAWCoreScaffolding.Bool) -> @SAWCoreScaffolding.Bool) (@SAWCoreVectorsAsCoqVectors.bvslt).
 
-Definition ecSle : forall (n : @Num), @seq n @SAWCoreScaffolding.Bool -> @seq n @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool :=
-  @finNumRec (fun (n : @Num) => @seq n @SAWCoreScaffolding.Bool -> @seq n @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) @SAWCoreVectorsAsCoqVectors.bvsle.
+Definition ecSle : forall (n : @Num), @seq n (@SAWCoreScaffolding.Bool) -> @seq n (@SAWCoreScaffolding.Bool) -> @SAWCoreScaffolding.Bool :=
+  @finNumRec (fun (n : @Num) => @seq n (@SAWCoreScaffolding.Bool) -> @seq n (@SAWCoreScaffolding.Bool) -> @SAWCoreScaffolding.Bool) (@SAWCoreVectorsAsCoqVectors.bvsle).
 
 Definition ecArrayConstant : forall (a : Type), forall (b : Type), b -> @SAWCorePrelude.Array a b :=
   @SAWCorePrelude.arrayConstant.
@@ -723,8 +747,8 @@ Definition ecArrayLookup : forall (a : Type), forall (b : Type), @SAWCorePrelude
 Definition ecArrayUpdate : forall (a : Type), forall (b : Type), @SAWCorePrelude.Array a b -> a -> b -> @SAWCorePrelude.Array a b :=
   @SAWCorePrelude.arrayUpdate.
 
-Axiom replicate_False : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreScaffolding.Eq (@SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) (@SAWCorePrelude.replicate n @SAWCoreScaffolding.Bool @SAWCoreScaffolding.false) (@SAWCoreVectorsAsCoqVectors.bvNat n 0) .
+Axiom replicate_False : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreScaffolding.Eq (@SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) (@SAWCorePrelude.replicate n (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.false)) (@SAWCoreVectorsAsCoqVectors.bvNat n 0) .
 
-Axiom subNat_0 : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Nat (@SAWCorePrelude.subNat n 0) n .
+Axiom subNat_0 : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Nat) (@SAWCorePrelude.subNat n 0) n .
 
 End CryptolPrimitivesForSAWCore.

--- a/saw-core-coq/coq/generated/CryptolToCoq/SAWCorePrelude.v
+++ b/saw-core-coq/coq/generated/CryptolToCoq/SAWCorePrelude.v
@@ -98,8 +98,8 @@ Inductive Bit : Type :=
 | Bit0 : @Bit
 .
 
-Definition Bit__rec : forall (p : @Bit -> Type), p @Bit1 -> p @Bit0 -> forall (b : @Bit), p b :=
-  fun (p : @Bit -> Type) (f1 : p @Bit1) (f2 : p @Bit0) (b : @Bit) => SAWCorePrelude.Bit_rect p f1 f2 b.
+Definition Bit__rec : forall (p : @Bit -> Type), p (@Bit1) -> p (@Bit0) -> forall (b : @Bit), p b :=
+  fun (p : @Bit -> Type) (f1 : p (@Bit1)) (f2 : p (@Bit0)) (b : @Bit) => SAWCorePrelude.Bit_rect p f1 f2 b.
 
 (* Prelude.Bool was skipped *)
 
@@ -118,28 +118,28 @@ Definition Bit__rec : forall (p : @Bit -> Type), p @Bit1 -> p @Bit0 -> forall (b
 (* Prelude.ite_eq_iteDep was skipped *)
 
 Definition ite_true : forall (a : Type), forall (x : a), forall (y : a), @SAWCoreScaffolding.Eq a (if @SAWCoreScaffolding.true then x else y) x :=
-  fun (a : Type) (x : a) (y : a) => @trans a (if @SAWCoreScaffolding.true then x else y) (@SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => a) @SAWCoreScaffolding.true x y) x (@SAWCoreScaffolding.ite_eq_iteDep a @SAWCoreScaffolding.true x y) (@SAWCoreScaffolding.iteDep_True (fun (_1 : @SAWCoreScaffolding.Bool) => a) x y).
+  fun (a : Type) (x : a) (y : a) => @trans a (if @SAWCoreScaffolding.true then x else y) (@SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => a) (@SAWCoreScaffolding.true) x y) x (@SAWCoreScaffolding.ite_eq_iteDep a (@SAWCoreScaffolding.true) x y) (@SAWCoreScaffolding.iteDep_True (fun (_1 : @SAWCoreScaffolding.Bool) => a) x y).
 
 Definition ite_false : forall (a : Type), forall (x : a), forall (y : a), @SAWCoreScaffolding.Eq a (if @SAWCoreScaffolding.false then x else y) y :=
-  fun (a : Type) (x : a) (y : a) => @trans a (if @SAWCoreScaffolding.false then x else y) (@SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => a) @SAWCoreScaffolding.false x y) y (@SAWCoreScaffolding.ite_eq_iteDep a @SAWCoreScaffolding.false x y) (@SAWCoreScaffolding.iteDep_False (fun (_1 : @SAWCoreScaffolding.Bool) => a) x y).
+  fun (a : Type) (x : a) (y : a) => @trans a (if @SAWCoreScaffolding.false then x else y) (@SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => a) (@SAWCoreScaffolding.false) x y) y (@SAWCoreScaffolding.ite_eq_iteDep a (@SAWCoreScaffolding.false) x y) (@SAWCoreScaffolding.iteDep_False (fun (_1 : @SAWCoreScaffolding.Bool) => a) x y).
 
 Definition bool2bit : @SAWCoreScaffolding.Bool -> @Bit :=
-  fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (_1 : @SAWCoreScaffolding.Bool) => @Bit) b @Bit1 @Bit0.
+  fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (_1 : @SAWCoreScaffolding.Bool) => @Bit) b (@Bit1) (@Bit0).
 
-Definition bool2bit_True : @SAWCoreScaffolding.Eq @Bit (@bool2bit @SAWCoreScaffolding.true) @Bit1 :=
-  @SAWCoreScaffolding.iteDep_True (fun (_1 : @SAWCoreScaffolding.Bool) => @Bit) @Bit1 @Bit0.
+Definition bool2bit_True : @SAWCoreScaffolding.Eq (@Bit) (@bool2bit (@SAWCoreScaffolding.true)) (@Bit1) :=
+  @SAWCoreScaffolding.iteDep_True (fun (_1 : @SAWCoreScaffolding.Bool) => @Bit) (@Bit1) (@Bit0).
 
-Definition bool2bit_False : @SAWCoreScaffolding.Eq @Bit (@bool2bit @SAWCoreScaffolding.false) @Bit0 :=
-  @SAWCoreScaffolding.iteDep_False (fun (_1 : @SAWCoreScaffolding.Bool) => @Bit) @Bit1 @Bit0.
+Definition bool2bit_False : @SAWCoreScaffolding.Eq (@Bit) (@bool2bit (@SAWCoreScaffolding.false)) (@Bit0) :=
+  @SAWCoreScaffolding.iteDep_False (fun (_1 : @SAWCoreScaffolding.Bool) => @Bit) (@Bit1) (@Bit0).
 
 Definition bit2bool : @Bit -> @SAWCoreScaffolding.Bool :=
-  @Bit__rec (fun (_1 : @Bit) => @SAWCoreScaffolding.Bool) @SAWCoreScaffolding.true @SAWCoreScaffolding.false.
+  @Bit__rec (fun (_1 : @Bit) => @SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.true) (@SAWCoreScaffolding.false).
 
-Definition bit2bool_Bit1 : @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@bit2bool @Bit1) @SAWCoreScaffolding.true :=
-  @SAWCoreScaffolding.Refl @SAWCoreScaffolding.Bool @SAWCoreScaffolding.true.
+Definition bit2bool_Bit1 : @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@bit2bool (@Bit1)) (@SAWCoreScaffolding.true) :=
+  @SAWCoreScaffolding.Refl (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.true).
 
-Definition bit2bool_Bit0 : @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@bit2bool @Bit0) @SAWCoreScaffolding.false :=
-  @SAWCoreScaffolding.Refl @SAWCoreScaffolding.Bool @SAWCoreScaffolding.false.
+Definition bit2bool_Bit0 : @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@bit2bool (@Bit0)) (@SAWCoreScaffolding.false) :=
+  @SAWCoreScaffolding.Refl (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.false).
 
 (* Prelude.not was skipped *)
 
@@ -164,155 +164,161 @@ Definition bit2bool_Bit0 : @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@bit
 Definition implies : @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool :=
   fun (a : @SAWCoreScaffolding.Bool) (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.or (@SAWCoreScaffolding.not a) b.
 
-Definition implies__eq : forall (a : @SAWCoreScaffolding.Bool), forall (b : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@implies a b) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.not a) b) :=
-  fun (a : @SAWCoreScaffolding.Bool) (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Refl @SAWCoreScaffolding.Bool (@implies a b).
+Definition implies__eq : forall (a : @SAWCoreScaffolding.Bool), forall (b : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@implies a b) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.not a) b) :=
+  fun (a : @SAWCoreScaffolding.Bool) (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Refl (@SAWCoreScaffolding.Bool) (@implies a b).
 
-Definition not_True : @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) @SAWCoreScaffolding.false :=
-  @trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) (if @SAWCoreScaffolding.true then @SAWCoreScaffolding.false else @SAWCoreScaffolding.true) @SAWCoreScaffolding.false (@SAWCoreScaffolding.not__eq @SAWCoreScaffolding.true) (@ite_true @SAWCoreScaffolding.Bool @SAWCoreScaffolding.false @SAWCoreScaffolding.true).
+Definition unitEq : @SAWCoreScaffolding.UnitType -> @SAWCoreScaffolding.UnitType -> @SAWCoreScaffolding.Bool :=
+  fun (_1 : @SAWCoreScaffolding.UnitType) (_2 : @SAWCoreScaffolding.UnitType) => @SAWCoreScaffolding.true.
 
-Definition not_False : @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) @SAWCoreScaffolding.true :=
-  @trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) (if @SAWCoreScaffolding.false then @SAWCoreScaffolding.false else @SAWCoreScaffolding.true) @SAWCoreScaffolding.true (@SAWCoreScaffolding.not__eq @SAWCoreScaffolding.false) (@ite_false @SAWCoreScaffolding.Bool @SAWCoreScaffolding.false @SAWCoreScaffolding.true).
+Definition pairEq : forall (a : Type), forall (b : Type), (a -> a -> @SAWCoreScaffolding.Bool) -> (b -> b -> @SAWCoreScaffolding.Bool) -> prod a b -> prod a b -> @SAWCoreScaffolding.Bool :=
+  fun (a : Type) (b : Type) (f : a -> a -> @SAWCoreScaffolding.Bool) (g : b -> b -> @SAWCoreScaffolding.Bool) (x : prod a b) (y : prod a b) => @SAWCoreScaffolding.and (f (SAWCoreScaffolding.fst x) (SAWCoreScaffolding.fst y)) (g (SAWCoreScaffolding.snd x) (SAWCoreScaffolding.snd y)).
 
-Definition not_not : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not (@SAWCoreScaffolding.not x)) x :=
-  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not (@SAWCoreScaffolding.not b)) b) x (@trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not (@SAWCoreScaffolding.not @SAWCoreScaffolding.true)) (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) @SAWCoreScaffolding.true (@eq_cong @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) @SAWCoreScaffolding.false @not_True @SAWCoreScaffolding.Bool @SAWCoreScaffolding.not) @not_False) (@trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not (@SAWCoreScaffolding.not @SAWCoreScaffolding.false)) (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) @SAWCoreScaffolding.false (@eq_cong @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) @SAWCoreScaffolding.true @not_False @SAWCoreScaffolding.Bool @SAWCoreScaffolding.not) @not_True).
+Definition not_True : @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.false) :=
+  @trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) (if @SAWCoreScaffolding.true then @SAWCoreScaffolding.false else @SAWCoreScaffolding.true) (@SAWCoreScaffolding.false) (@SAWCoreScaffolding.not__eq (@SAWCoreScaffolding.true)) (@ite_true (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.false) (@SAWCoreScaffolding.true)).
 
-Definition and_True1 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and @SAWCoreScaffolding.true x) x :=
-  fun (x : @SAWCoreScaffolding.Bool) => @trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and @SAWCoreScaffolding.true x) (if @SAWCoreScaffolding.true then x else @SAWCoreScaffolding.false) x (@SAWCoreScaffolding.and__eq @SAWCoreScaffolding.true x) (@ite_true @SAWCoreScaffolding.Bool x @SAWCoreScaffolding.false).
+Definition not_False : @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.true) :=
+  @trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) (if @SAWCoreScaffolding.false then @SAWCoreScaffolding.false else @SAWCoreScaffolding.true) (@SAWCoreScaffolding.true) (@SAWCoreScaffolding.not__eq (@SAWCoreScaffolding.false)) (@ite_false (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.false) (@SAWCoreScaffolding.true)).
 
-Definition and_False1 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and @SAWCoreScaffolding.false x) @SAWCoreScaffolding.false :=
-  fun (x : @SAWCoreScaffolding.Bool) => @trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and @SAWCoreScaffolding.false x) (if @SAWCoreScaffolding.false then x else @SAWCoreScaffolding.false) @SAWCoreScaffolding.false (@SAWCoreScaffolding.and__eq @SAWCoreScaffolding.false x) (@ite_false @SAWCoreScaffolding.Bool x @SAWCoreScaffolding.false).
+Definition not_not : forall (x : @SAWCoreScaffolding.Bool), let var__0   := @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool in
+  @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.not x)) x :=
+  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.not b)) b) x (@trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true))) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.true) (@eq_cong (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.false) not_True (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not)) not_False) (@trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false))) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.false) (@eq_cong (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.true) not_False (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not)) not_True).
 
-Definition and_True2 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and x @SAWCoreScaffolding.true) x :=
-  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and b @SAWCoreScaffolding.true) b) x (@and_True1 @SAWCoreScaffolding.true) (@and_False1 @SAWCoreScaffolding.true).
+Definition and_True1 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.true) x) x :=
+  fun (x : @SAWCoreScaffolding.Bool) => @trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.true) x) (if @SAWCoreScaffolding.true then x else @SAWCoreScaffolding.false) x (@SAWCoreScaffolding.and__eq (@SAWCoreScaffolding.true) x) (@ite_true (@SAWCoreScaffolding.Bool) x (@SAWCoreScaffolding.false)).
 
-Definition and_False2 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and x @SAWCoreScaffolding.false) @SAWCoreScaffolding.false :=
-  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and b @SAWCoreScaffolding.false) @SAWCoreScaffolding.false) x (@and_True1 @SAWCoreScaffolding.false) (@and_False1 @SAWCoreScaffolding.false).
+Definition and_False1 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.false) x) (@SAWCoreScaffolding.false) :=
+  fun (x : @SAWCoreScaffolding.Bool) => @trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.false) x) (if @SAWCoreScaffolding.false then x else @SAWCoreScaffolding.false) (@SAWCoreScaffolding.false) (@SAWCoreScaffolding.and__eq (@SAWCoreScaffolding.false) x) (@ite_false (@SAWCoreScaffolding.Bool) x (@SAWCoreScaffolding.false)).
 
-Definition and_assoc : forall (x : @SAWCoreScaffolding.Bool), forall (y : @SAWCoreScaffolding.Bool), forall (z : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and x (@SAWCoreScaffolding.and y z)) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.and x y) z) :=
-  fun (x : @SAWCoreScaffolding.Bool) (y : @SAWCoreScaffolding.Bool) (z : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and x (@SAWCoreScaffolding.and y b)) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.and x y) b)) z (@trans2 @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and x (@SAWCoreScaffolding.and y @SAWCoreScaffolding.true)) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.and x y) @SAWCoreScaffolding.true) (@SAWCoreScaffolding.and x y) (@eq_cong @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and y @SAWCoreScaffolding.true) y (@and_True2 y) @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and x)) (@and_True2 (@SAWCoreScaffolding.and x y))) (@trans2 @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and x (@SAWCoreScaffolding.and y @SAWCoreScaffolding.false)) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.and x y) @SAWCoreScaffolding.false) @SAWCoreScaffolding.false (@trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and x (@SAWCoreScaffolding.and y @SAWCoreScaffolding.false)) (@SAWCoreScaffolding.and x @SAWCoreScaffolding.false) @SAWCoreScaffolding.false (@eq_cong @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and y @SAWCoreScaffolding.false) @SAWCoreScaffolding.false (@and_False2 y) @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and x)) (@and_False2 x)) (@and_False2 (@SAWCoreScaffolding.and x y))).
+Definition and_True2 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and x (@SAWCoreScaffolding.true)) x :=
+  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and b (@SAWCoreScaffolding.true)) b) x (@and_True1 (@SAWCoreScaffolding.true)) (@and_False1 (@SAWCoreScaffolding.true)).
 
-Definition and_idem : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and x x) x :=
-  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and b b) b) x (@and_True1 @SAWCoreScaffolding.true) (@and_False1 @SAWCoreScaffolding.false).
+Definition and_False2 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and x (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.false) :=
+  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and b (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.false)) x (@and_True1 (@SAWCoreScaffolding.false)) (@and_False1 (@SAWCoreScaffolding.false)).
 
-Definition or_True1 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or @SAWCoreScaffolding.true x) @SAWCoreScaffolding.true :=
-  fun (x : @SAWCoreScaffolding.Bool) => @trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or @SAWCoreScaffolding.true x) (if @SAWCoreScaffolding.true then @SAWCoreScaffolding.true else x) @SAWCoreScaffolding.true (@SAWCoreScaffolding.or__eq @SAWCoreScaffolding.true x) (@ite_true @SAWCoreScaffolding.Bool @SAWCoreScaffolding.true x).
+Definition and_assoc : forall (x : @SAWCoreScaffolding.Bool), forall (y : @SAWCoreScaffolding.Bool), forall (z : @SAWCoreScaffolding.Bool), let var__0   := @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool in
+  @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and x (@SAWCoreScaffolding.and y z)) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.and x y) z) :=
+  fun (x : @SAWCoreScaffolding.Bool) (y : @SAWCoreScaffolding.Bool) (z : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and x (@SAWCoreScaffolding.and y b)) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.and x y) b)) z (@trans2 (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and x (@SAWCoreScaffolding.and y (@SAWCoreScaffolding.true))) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.and x y) (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.and x y) (@eq_cong (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and y (@SAWCoreScaffolding.true)) y (@and_True2 y) (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and x)) (@and_True2 (@SAWCoreScaffolding.and x y))) (@trans2 (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and x (@SAWCoreScaffolding.and y (@SAWCoreScaffolding.false))) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.and x y) (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.false) (@trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and x (@SAWCoreScaffolding.and y (@SAWCoreScaffolding.false))) (@SAWCoreScaffolding.and x (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.false) (@eq_cong (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and y (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.false) (@and_False2 y) (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and x)) (@and_False2 x)) (@and_False2 (@SAWCoreScaffolding.and x y))).
 
-Definition or_False1 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or @SAWCoreScaffolding.false x) x :=
-  fun (x : @SAWCoreScaffolding.Bool) => @trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or @SAWCoreScaffolding.false x) (if @SAWCoreScaffolding.false then @SAWCoreScaffolding.true else x) x (@SAWCoreScaffolding.or__eq @SAWCoreScaffolding.false x) (@ite_false @SAWCoreScaffolding.Bool @SAWCoreScaffolding.true x).
+Definition and_idem : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and x x) x :=
+  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and b b) b) x (@and_True1 (@SAWCoreScaffolding.true)) (@and_False1 (@SAWCoreScaffolding.false)).
 
-Definition or_True2 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or x @SAWCoreScaffolding.true) @SAWCoreScaffolding.true :=
-  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or b @SAWCoreScaffolding.true) @SAWCoreScaffolding.true) x (@or_True1 @SAWCoreScaffolding.true) (@or_False1 @SAWCoreScaffolding.true).
+Definition or_True1 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.true) x) (@SAWCoreScaffolding.true) :=
+  fun (x : @SAWCoreScaffolding.Bool) => @trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.true) x) (if @SAWCoreScaffolding.true then @SAWCoreScaffolding.true else x) (@SAWCoreScaffolding.true) (@SAWCoreScaffolding.or__eq (@SAWCoreScaffolding.true) x) (@ite_true (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.true) x).
 
-Definition or_False2 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or x @SAWCoreScaffolding.false) x :=
-  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or b @SAWCoreScaffolding.false) b) x (@or_True1 @SAWCoreScaffolding.false) (@or_False1 @SAWCoreScaffolding.false).
+Definition or_False1 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.false) x) x :=
+  fun (x : @SAWCoreScaffolding.Bool) => @trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.false) x) (if @SAWCoreScaffolding.false then @SAWCoreScaffolding.true else x) x (@SAWCoreScaffolding.or__eq (@SAWCoreScaffolding.false) x) (@ite_false (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.true) x).
 
-Definition or_assoc : forall (x : @SAWCoreScaffolding.Bool), forall (y : @SAWCoreScaffolding.Bool), forall (z : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or x (@SAWCoreScaffolding.or y z)) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.or x y) z) :=
-  fun (x : @SAWCoreScaffolding.Bool) (y : @SAWCoreScaffolding.Bool) (z : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or x (@SAWCoreScaffolding.or y b)) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.or x y) b)) z (@trans2 @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or x (@SAWCoreScaffolding.or y @SAWCoreScaffolding.true)) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.or x y) @SAWCoreScaffolding.true) @SAWCoreScaffolding.true (@trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or x (@SAWCoreScaffolding.or y @SAWCoreScaffolding.true)) (@SAWCoreScaffolding.or x @SAWCoreScaffolding.true) @SAWCoreScaffolding.true (@eq_cong @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or y @SAWCoreScaffolding.true) @SAWCoreScaffolding.true (@or_True2 y) @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or x)) (@or_True2 x)) (@or_True2 (@SAWCoreScaffolding.or x y))) (@trans2 @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or x (@SAWCoreScaffolding.or y @SAWCoreScaffolding.false)) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.or x y) @SAWCoreScaffolding.false) (@SAWCoreScaffolding.or x y) (@eq_cong @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or y @SAWCoreScaffolding.false) y (@or_False2 y) @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or x)) (@or_False2 (@SAWCoreScaffolding.or x y))).
+Definition or_True2 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or x (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.true) :=
+  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or b (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.true)) x (@or_True1 (@SAWCoreScaffolding.true)) (@or_False1 (@SAWCoreScaffolding.true)).
 
-Definition or_idem : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or x x) x :=
-  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or b b) b) x (@or_True1 @SAWCoreScaffolding.true) (@or_False1 @SAWCoreScaffolding.false).
+Definition or_False2 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or x (@SAWCoreScaffolding.false)) x :=
+  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or b (@SAWCoreScaffolding.false)) b) x (@or_True1 (@SAWCoreScaffolding.false)) (@or_False1 (@SAWCoreScaffolding.false)).
 
-Definition implies_True1 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@implies @SAWCoreScaffolding.true x) x :=
-  fun (x : @SAWCoreScaffolding.Bool) => @trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) x) (@SAWCoreScaffolding.or @SAWCoreScaffolding.false x) x (@eq_cong @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) @SAWCoreScaffolding.false @not_True @SAWCoreScaffolding.Bool (fun (y : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.or y x)) (@or_False1 x).
+Definition or_assoc : forall (x : @SAWCoreScaffolding.Bool), forall (y : @SAWCoreScaffolding.Bool), forall (z : @SAWCoreScaffolding.Bool), let var__0   := @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool in
+  @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or x (@SAWCoreScaffolding.or y z)) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.or x y) z) :=
+  fun (x : @SAWCoreScaffolding.Bool) (y : @SAWCoreScaffolding.Bool) (z : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or x (@SAWCoreScaffolding.or y b)) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.or x y) b)) z (@trans2 (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or x (@SAWCoreScaffolding.or y (@SAWCoreScaffolding.true))) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.or x y) (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.true) (@trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or x (@SAWCoreScaffolding.or y (@SAWCoreScaffolding.true))) (@SAWCoreScaffolding.or x (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.true) (@eq_cong (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or y (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.true) (@or_True2 y) (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or x)) (@or_True2 x)) (@or_True2 (@SAWCoreScaffolding.or x y))) (@trans2 (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or x (@SAWCoreScaffolding.or y (@SAWCoreScaffolding.false))) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.or x y) (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.or x y) (@eq_cong (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or y (@SAWCoreScaffolding.false)) y (@or_False2 y) (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or x)) (@or_False2 (@SAWCoreScaffolding.or x y))).
 
-Definition implies_False1 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@implies @SAWCoreScaffolding.false x) @SAWCoreScaffolding.true :=
-  fun (x : @SAWCoreScaffolding.Bool) => @trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) x) (@SAWCoreScaffolding.or @SAWCoreScaffolding.true x) @SAWCoreScaffolding.true (@eq_cong @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) @SAWCoreScaffolding.true @not_False @SAWCoreScaffolding.Bool (fun (y : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.or y x)) (@or_True1 x).
+Definition or_idem : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or x x) x :=
+  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or b b) b) x (@or_True1 (@SAWCoreScaffolding.true)) (@or_False1 (@SAWCoreScaffolding.false)).
 
-Definition true_implies : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@implies @SAWCoreScaffolding.true x) x :=
+Definition implies_True1 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@implies (@SAWCoreScaffolding.true) x) x :=
+  fun (x : @SAWCoreScaffolding.Bool) => @trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) x) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.false) x) x (@eq_cong (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.false) not_True (@SAWCoreScaffolding.Bool) (fun (y : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.or y x)) (@or_False1 x).
+
+Definition implies_False1 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@implies (@SAWCoreScaffolding.false) x) (@SAWCoreScaffolding.true) :=
+  fun (x : @SAWCoreScaffolding.Bool) => @trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) x) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.true) x) (@SAWCoreScaffolding.true) (@eq_cong (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.true) not_False (@SAWCoreScaffolding.Bool) (fun (y : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.or y x)) (@or_True1 x).
+
+Definition true_implies : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@implies (@SAWCoreScaffolding.true) x) x :=
   fun (x : @SAWCoreScaffolding.Bool) => @implies_True1 x.
 
-Definition xor_True1 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.xor @SAWCoreScaffolding.true x) (@SAWCoreScaffolding.not x) :=
-  fun (x : @SAWCoreScaffolding.Bool) => @trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.xor @SAWCoreScaffolding.true x) (if @SAWCoreScaffolding.true then @SAWCoreScaffolding.not x else x) (@SAWCoreScaffolding.not x) (@SAWCoreScaffolding.xor__eq @SAWCoreScaffolding.true x) (@ite_true @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not x) x).
+Definition xor_True1 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.xor (@SAWCoreScaffolding.true) x) (@SAWCoreScaffolding.not x) :=
+  fun (x : @SAWCoreScaffolding.Bool) => @trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.xor (@SAWCoreScaffolding.true) x) (if @SAWCoreScaffolding.true then @SAWCoreScaffolding.not x else x) (@SAWCoreScaffolding.not x) (@SAWCoreScaffolding.xor__eq (@SAWCoreScaffolding.true) x) (@ite_true (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not x) x).
 
-Definition xor_False1 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.xor @SAWCoreScaffolding.false x) x :=
-  fun (x : @SAWCoreScaffolding.Bool) => @trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.xor @SAWCoreScaffolding.false x) (if @SAWCoreScaffolding.false then @SAWCoreScaffolding.not x else x) x (@SAWCoreScaffolding.xor__eq @SAWCoreScaffolding.false x) (@ite_false @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not x) x).
+Definition xor_False1 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.xor (@SAWCoreScaffolding.false) x) x :=
+  fun (x : @SAWCoreScaffolding.Bool) => @trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.xor (@SAWCoreScaffolding.false) x) (if @SAWCoreScaffolding.false then @SAWCoreScaffolding.not x else x) x (@SAWCoreScaffolding.xor__eq (@SAWCoreScaffolding.false) x) (@ite_false (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not x) x).
 
-Definition xor_False2 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.xor x @SAWCoreScaffolding.false) x :=
-  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.xor b @SAWCoreScaffolding.false) b) x (@trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.xor @SAWCoreScaffolding.true @SAWCoreScaffolding.false) (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) @SAWCoreScaffolding.true (@xor_True1 @SAWCoreScaffolding.false) @not_False) (@xor_False1 @SAWCoreScaffolding.false).
+Definition xor_False2 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.xor x (@SAWCoreScaffolding.false)) x :=
+  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.xor b (@SAWCoreScaffolding.false)) b) x (@trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.xor (@SAWCoreScaffolding.true) (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.true) (@xor_True1 (@SAWCoreScaffolding.false)) not_False) (@xor_False1 (@SAWCoreScaffolding.false)).
 
-Definition xor_True2 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.xor x @SAWCoreScaffolding.true) (@SAWCoreScaffolding.not x) :=
-  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.xor b @SAWCoreScaffolding.true) (@SAWCoreScaffolding.not b)) x (@xor_True1 @SAWCoreScaffolding.true) (@trans2 @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.xor @SAWCoreScaffolding.false @SAWCoreScaffolding.true) (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) @SAWCoreScaffolding.true (@xor_False1 @SAWCoreScaffolding.true) @not_False).
+Definition xor_True2 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.xor x (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.not x) :=
+  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.xor b (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.not b)) x (@xor_True1 (@SAWCoreScaffolding.true)) (@trans2 (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.xor (@SAWCoreScaffolding.false) (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.true) (@xor_False1 (@SAWCoreScaffolding.true)) not_False).
 
-Definition xor_same : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.xor x x) @SAWCoreScaffolding.false :=
-  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.xor b b) @SAWCoreScaffolding.false) x (@trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.xor @SAWCoreScaffolding.true @SAWCoreScaffolding.true) (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) @SAWCoreScaffolding.false (@xor_True1 @SAWCoreScaffolding.true) @not_True) (@xor_False1 @SAWCoreScaffolding.false).
+Definition xor_same : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.xor x x) (@SAWCoreScaffolding.false) :=
+  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.xor b b) (@SAWCoreScaffolding.false)) x (@trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.xor (@SAWCoreScaffolding.true) (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.false) (@xor_True1 (@SAWCoreScaffolding.true)) not_True) (@xor_False1 (@SAWCoreScaffolding.false)).
 
-Definition boolEq_True1 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.boolEq @SAWCoreScaffolding.true x) x :=
-  fun (x : @SAWCoreScaffolding.Bool) => @trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.boolEq @SAWCoreScaffolding.true x) (if @SAWCoreScaffolding.true then x else @SAWCoreScaffolding.not x) x (@SAWCoreScaffolding.boolEq__eq @SAWCoreScaffolding.true x) (@ite_true @SAWCoreScaffolding.Bool x (@SAWCoreScaffolding.not x)).
+Definition boolEq_True1 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.boolEq (@SAWCoreScaffolding.true) x) x :=
+  fun (x : @SAWCoreScaffolding.Bool) => @trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.boolEq (@SAWCoreScaffolding.true) x) (if @SAWCoreScaffolding.true then x else @SAWCoreScaffolding.not x) x (@SAWCoreScaffolding.boolEq__eq (@SAWCoreScaffolding.true) x) (@ite_true (@SAWCoreScaffolding.Bool) x (@SAWCoreScaffolding.not x)).
 
-Definition boolEq_False1 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.boolEq @SAWCoreScaffolding.false x) (@SAWCoreScaffolding.not x) :=
-  fun (x : @SAWCoreScaffolding.Bool) => @trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.boolEq @SAWCoreScaffolding.false x) (if @SAWCoreScaffolding.false then x else @SAWCoreScaffolding.not x) (@SAWCoreScaffolding.not x) (@SAWCoreScaffolding.boolEq__eq @SAWCoreScaffolding.false x) (@ite_false @SAWCoreScaffolding.Bool x (@SAWCoreScaffolding.not x)).
+Definition boolEq_False1 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.boolEq (@SAWCoreScaffolding.false) x) (@SAWCoreScaffolding.not x) :=
+  fun (x : @SAWCoreScaffolding.Bool) => @trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.boolEq (@SAWCoreScaffolding.false) x) (if @SAWCoreScaffolding.false then x else @SAWCoreScaffolding.not x) (@SAWCoreScaffolding.not x) (@SAWCoreScaffolding.boolEq__eq (@SAWCoreScaffolding.false) x) (@ite_false (@SAWCoreScaffolding.Bool) x (@SAWCoreScaffolding.not x)).
 
-Definition boolEq_True2 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.boolEq x @SAWCoreScaffolding.true) x :=
-  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.boolEq b @SAWCoreScaffolding.true) b) x (@boolEq_True1 @SAWCoreScaffolding.true) (@trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.boolEq @SAWCoreScaffolding.false @SAWCoreScaffolding.true) (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) @SAWCoreScaffolding.false (@boolEq_False1 @SAWCoreScaffolding.true) @not_True).
+Definition boolEq_True2 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.boolEq x (@SAWCoreScaffolding.true)) x :=
+  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.boolEq b (@SAWCoreScaffolding.true)) b) x (@boolEq_True1 (@SAWCoreScaffolding.true)) (@trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.boolEq (@SAWCoreScaffolding.false) (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.false) (@boolEq_False1 (@SAWCoreScaffolding.true)) not_True).
 
-Definition boolEq_False2 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.boolEq x @SAWCoreScaffolding.false) (@SAWCoreScaffolding.not x) :=
-  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.boolEq b @SAWCoreScaffolding.false) (@SAWCoreScaffolding.not b)) x (@trans2 @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.boolEq @SAWCoreScaffolding.true @SAWCoreScaffolding.false) (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) @SAWCoreScaffolding.false (@boolEq_True1 @SAWCoreScaffolding.false) @not_True) (@boolEq_False1 @SAWCoreScaffolding.false).
+Definition boolEq_False2 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.boolEq x (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.not x) :=
+  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.boolEq b (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.not b)) x (@trans2 (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.boolEq (@SAWCoreScaffolding.true) (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.false) (@boolEq_True1 (@SAWCoreScaffolding.false)) not_True) (@boolEq_False1 (@SAWCoreScaffolding.false)).
 
-Definition boolEq_same : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.boolEq x x) @SAWCoreScaffolding.true :=
-  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.boolEq b b) @SAWCoreScaffolding.true) x (@boolEq_True1 @SAWCoreScaffolding.true) (@trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.boolEq @SAWCoreScaffolding.false @SAWCoreScaffolding.false) (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) @SAWCoreScaffolding.true (@boolEq_False1 @SAWCoreScaffolding.false) @not_False).
+Definition boolEq_same : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.boolEq x x) (@SAWCoreScaffolding.true) :=
+  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.boolEq b b) (@SAWCoreScaffolding.true)) x (@boolEq_True1 (@SAWCoreScaffolding.true)) (@trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.boolEq (@SAWCoreScaffolding.false) (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.true) (@boolEq_False1 (@SAWCoreScaffolding.false)) not_False).
 
-Definition not_or : forall (x : @SAWCoreScaffolding.Bool), forall (y : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not (@SAWCoreScaffolding.or x y)) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not x) (@SAWCoreScaffolding.not y)) :=
-  fun (x : @SAWCoreScaffolding.Bool) (y : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not (@SAWCoreScaffolding.or b y)) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not b) (@SAWCoreScaffolding.not y))) x (@trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not (@SAWCoreScaffolding.or @SAWCoreScaffolding.true y)) @SAWCoreScaffolding.false (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) (@SAWCoreScaffolding.not y)) (@trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not (@SAWCoreScaffolding.or @SAWCoreScaffolding.true y)) (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) @SAWCoreScaffolding.false (@eq_cong @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or @SAWCoreScaffolding.true y) @SAWCoreScaffolding.true (@or_True1 y) @SAWCoreScaffolding.Bool @SAWCoreScaffolding.not) @not_True) (@trans @SAWCoreScaffolding.Bool @SAWCoreScaffolding.false (@SAWCoreScaffolding.and @SAWCoreScaffolding.false (@SAWCoreScaffolding.not y)) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) (@SAWCoreScaffolding.not y)) (@sym @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and @SAWCoreScaffolding.false (@SAWCoreScaffolding.not y)) @SAWCoreScaffolding.false (@and_False1 (@SAWCoreScaffolding.not y))) (@eq_cong @SAWCoreScaffolding.Bool @SAWCoreScaffolding.false (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) (@sym @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) @SAWCoreScaffolding.false @not_True) @SAWCoreScaffolding.Bool (fun (z : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.and z (@SAWCoreScaffolding.not y))))) (@trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not (@SAWCoreScaffolding.or @SAWCoreScaffolding.false y)) (@SAWCoreScaffolding.not y) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) (@SAWCoreScaffolding.not y)) (@eq_cong @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or @SAWCoreScaffolding.false y) y (@or_False1 y) @SAWCoreScaffolding.Bool @SAWCoreScaffolding.not) (@sym @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) (@SAWCoreScaffolding.not y)) (@SAWCoreScaffolding.not y) (@trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) (@SAWCoreScaffolding.not y)) (@SAWCoreScaffolding.and @SAWCoreScaffolding.true (@SAWCoreScaffolding.not y)) (@SAWCoreScaffolding.not y) (@eq_cong @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) @SAWCoreScaffolding.true @not_False @SAWCoreScaffolding.Bool (fun (z : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.and z (@SAWCoreScaffolding.not y))) (@and_True1 (@SAWCoreScaffolding.not y))))).
+Definition not_or : forall (x : @SAWCoreScaffolding.Bool), forall (y : @SAWCoreScaffolding.Bool), let var__0   := @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool in
+  let var__1   := @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool in
+  @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.or x y)) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not x) (@SAWCoreScaffolding.not y)) :=
+  fun (x : @SAWCoreScaffolding.Bool) (y : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.or b y)) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not b) (@SAWCoreScaffolding.not y))) x (@trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.or (@SAWCoreScaffolding.true) y)) (@SAWCoreScaffolding.false) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.not y)) (@trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.or (@SAWCoreScaffolding.true) y)) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.false) (@eq_cong (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.true) y) (@SAWCoreScaffolding.true) (@or_True1 y) (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not)) not_True) (@trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.false) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.false) (@SAWCoreScaffolding.not y)) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.not y)) (@sym (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.false) (@SAWCoreScaffolding.not y)) (@SAWCoreScaffolding.false) (@and_False1 (@SAWCoreScaffolding.not y))) (@eq_cong (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.false) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) (@sym (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.false) not_True) (@SAWCoreScaffolding.Bool) (fun (z : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.and z (@SAWCoreScaffolding.not y))))) (@trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.or (@SAWCoreScaffolding.false) y)) (@SAWCoreScaffolding.not y) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.not y)) (@eq_cong (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.false) y) y (@or_False1 y) (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not)) (@sym (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.not y)) (@SAWCoreScaffolding.not y) (@trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.not y)) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.true) (@SAWCoreScaffolding.not y)) (@SAWCoreScaffolding.not y) (@eq_cong (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.true) not_False (@SAWCoreScaffolding.Bool) (fun (z : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.and z (@SAWCoreScaffolding.not y))) (@and_True1 (@SAWCoreScaffolding.not y))))).
 
-Definition not_and : forall (x : @SAWCoreScaffolding.Bool), forall (y : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not (@SAWCoreScaffolding.and x y)) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.not x) (@SAWCoreScaffolding.not y)) :=
-  fun (x : @SAWCoreScaffolding.Bool) (y : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not (@SAWCoreScaffolding.and b y)) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.not b) (@SAWCoreScaffolding.not y))) x (@trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not (@SAWCoreScaffolding.and @SAWCoreScaffolding.true y)) (@SAWCoreScaffolding.not y) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) (@SAWCoreScaffolding.not y)) (@eq_cong @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and @SAWCoreScaffolding.true y) y (@and_True1 y) @SAWCoreScaffolding.Bool @SAWCoreScaffolding.not) (@sym @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) (@SAWCoreScaffolding.not y)) (@SAWCoreScaffolding.not y) (@trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) (@SAWCoreScaffolding.not y)) (@SAWCoreScaffolding.or @SAWCoreScaffolding.false (@SAWCoreScaffolding.not y)) (@SAWCoreScaffolding.not y) (@eq_cong @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) @SAWCoreScaffolding.false @not_True @SAWCoreScaffolding.Bool (fun (z : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.or z (@SAWCoreScaffolding.not y))) (@or_False1 (@SAWCoreScaffolding.not y))))) (@trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not (@SAWCoreScaffolding.and @SAWCoreScaffolding.false y)) @SAWCoreScaffolding.true (@SAWCoreScaffolding.or (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) (@SAWCoreScaffolding.not y)) (@trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not (@SAWCoreScaffolding.and @SAWCoreScaffolding.false y)) (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) @SAWCoreScaffolding.true (@eq_cong @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and @SAWCoreScaffolding.false y) @SAWCoreScaffolding.false (@and_False1 y) @SAWCoreScaffolding.Bool @SAWCoreScaffolding.not) @not_False) (@trans @SAWCoreScaffolding.Bool @SAWCoreScaffolding.true (@SAWCoreScaffolding.or @SAWCoreScaffolding.true (@SAWCoreScaffolding.not y)) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) (@SAWCoreScaffolding.not y)) (@sym @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or @SAWCoreScaffolding.true (@SAWCoreScaffolding.not y)) @SAWCoreScaffolding.true (@or_True1 (@SAWCoreScaffolding.not y))) (@eq_cong @SAWCoreScaffolding.Bool @SAWCoreScaffolding.true (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) (@sym @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) @SAWCoreScaffolding.true @not_False) @SAWCoreScaffolding.Bool (fun (z : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.or z (@SAWCoreScaffolding.not y))))).
+Definition not_and : forall (x : @SAWCoreScaffolding.Bool), forall (y : @SAWCoreScaffolding.Bool), let var__0   := @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool in
+  let var__1   := @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool in
+  @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.and x y)) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.not x) (@SAWCoreScaffolding.not y)) :=
+  fun (x : @SAWCoreScaffolding.Bool) (y : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.and b y)) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.not b) (@SAWCoreScaffolding.not y))) x (@trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.and (@SAWCoreScaffolding.true) y)) (@SAWCoreScaffolding.not y) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.not y)) (@eq_cong (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.true) y) y (@and_True1 y) (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not)) (@sym (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.not y)) (@SAWCoreScaffolding.not y) (@trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.not y)) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.false) (@SAWCoreScaffolding.not y)) (@SAWCoreScaffolding.not y) (@eq_cong (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.false) not_True (@SAWCoreScaffolding.Bool) (fun (z : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.or z (@SAWCoreScaffolding.not y))) (@or_False1 (@SAWCoreScaffolding.not y))))) (@trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.and (@SAWCoreScaffolding.false) y)) (@SAWCoreScaffolding.true) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.not y)) (@trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.and (@SAWCoreScaffolding.false) y)) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.true) (@eq_cong (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.false) y) (@SAWCoreScaffolding.false) (@and_False1 y) (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not)) not_False) (@trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.true) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.true) (@SAWCoreScaffolding.not y)) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.not y)) (@sym (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.true) (@SAWCoreScaffolding.not y)) (@SAWCoreScaffolding.true) (@or_True1 (@SAWCoreScaffolding.not y))) (@eq_cong (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.true) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) (@sym (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.true) not_False) (@SAWCoreScaffolding.Bool) (fun (z : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.or z (@SAWCoreScaffolding.not y))))).
 
-Definition ite_not : forall (a : Type), forall (b : @SAWCoreScaffolding.Bool), forall (x : a), forall (y : a), @SAWCoreScaffolding.Eq a (if @SAWCoreScaffolding.not b then x else y) (if b then y else x) :=
-  fun (a : Type) (b : @SAWCoreScaffolding.Bool) (x : a) (y : a) => @SAWCoreScaffolding.iteDep (fun (b' : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq a (if @SAWCoreScaffolding.not b' then x else y) (if b' then y else x)) b (@trans a (if @SAWCoreScaffolding.not @SAWCoreScaffolding.true then x else y) y (if @SAWCoreScaffolding.true then y else x) (@trans a (if @SAWCoreScaffolding.not @SAWCoreScaffolding.true then x else y) (if @SAWCoreScaffolding.false then x else y) y (@eq_cong @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) @SAWCoreScaffolding.false @not_True a (fun (z : @SAWCoreScaffolding.Bool) => if z then x else y)) (@ite_false a x y)) (@sym a (if @SAWCoreScaffolding.true then y else x) y (@ite_true a y x))) (@trans a (if @SAWCoreScaffolding.not @SAWCoreScaffolding.false then x else y) x (if @SAWCoreScaffolding.false then y else x) (@trans a (if @SAWCoreScaffolding.not @SAWCoreScaffolding.false then x else y) (if @SAWCoreScaffolding.true then x else y) x (@eq_cong @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) @SAWCoreScaffolding.true @not_False a (fun (z : @SAWCoreScaffolding.Bool) => if z then x else y)) (@ite_true a x y)) (@sym a (if @SAWCoreScaffolding.false then y else x) x (@ite_false a y x))).
+Definition ite_not : forall (a : Type), forall (b : @SAWCoreScaffolding.Bool), forall (x : a), forall (y : a), let var__0   := forall (a1 : Type), @SAWCoreScaffolding.Bool -> a1 -> a1 -> a1 in
+  @SAWCoreScaffolding.Eq a (if @SAWCoreScaffolding.not b then x else y) (if b then y else x) :=
+  fun (a : Type) (b : @SAWCoreScaffolding.Bool) (x : a) (y : a) => @SAWCoreScaffolding.iteDep (fun (b' : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq a (if @SAWCoreScaffolding.not b' then x else y) (if b' then y else x)) b (@trans a (if @SAWCoreScaffolding.not (@SAWCoreScaffolding.true) then x else y) y (if @SAWCoreScaffolding.true then y else x) (@trans a (if @SAWCoreScaffolding.not (@SAWCoreScaffolding.true) then x else y) (if @SAWCoreScaffolding.false then x else y) y (@eq_cong (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.false) not_True a (fun (z : @SAWCoreScaffolding.Bool) => if z then x else y)) (@ite_false a x y)) (@sym a (if @SAWCoreScaffolding.true then y else x) y (@ite_true a y x))) (@trans a (if @SAWCoreScaffolding.not (@SAWCoreScaffolding.false) then x else y) x (if @SAWCoreScaffolding.false then y else x) (@trans a (if @SAWCoreScaffolding.not (@SAWCoreScaffolding.false) then x else y) (if @SAWCoreScaffolding.true then x else y) x (@eq_cong (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.true) not_False a (fun (z : @SAWCoreScaffolding.Bool) => if z then x else y)) (@ite_true a x y)) (@sym a (if @SAWCoreScaffolding.false then y else x) x (@ite_false a y x))).
 
-Definition ite_nest1 : forall (a : Type), forall (b : @SAWCoreScaffolding.Bool), forall (x : a), forall (y : a), forall (z : a), @SAWCoreScaffolding.Eq a (if b then if b then x else y else z) (if b then x else z) :=
+Definition ite_nest1 : forall (a : Type), forall (b : @SAWCoreScaffolding.Bool), forall (x : a), forall (y : a), forall (z : a), let var__0   := forall (a1 : Type), @SAWCoreScaffolding.Bool -> a1 -> a1 -> a1 in
+  @SAWCoreScaffolding.Eq a (if b then if b then x else y else z) (if b then x else z) :=
   fun (a : Type) (b : @SAWCoreScaffolding.Bool) (x : a) (y : a) (z : a) => @SAWCoreScaffolding.iteDep (fun (b' : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq a (if b' then if b' then x else y else z) (if b' then x else z)) b (@trans a (if @SAWCoreScaffolding.true then if @SAWCoreScaffolding.true then x else y else z) x (if @SAWCoreScaffolding.true then x else z) (@trans a (if @SAWCoreScaffolding.true then if @SAWCoreScaffolding.true then x else y else z) (if @SAWCoreScaffolding.true then x else y) x (@ite_true a (if @SAWCoreScaffolding.true then x else y) z) (@ite_true a x y)) (@sym a (if @SAWCoreScaffolding.true then x else z) x (@ite_true a x z))) (@trans a (if @SAWCoreScaffolding.false then if @SAWCoreScaffolding.false then x else y else z) z (if @SAWCoreScaffolding.false then x else z) (@ite_false a (if @SAWCoreScaffolding.false then x else y) z) (@sym a (if @SAWCoreScaffolding.false then x else z) z (@ite_false a x z))).
 
-Definition ite_nest2 : forall (a : Type), forall (b : @SAWCoreScaffolding.Bool), forall (x : a), forall (y : a), forall (z : a), @SAWCoreScaffolding.Eq a (if b then x else if b then y else z) (if b then x else z) :=
+Definition ite_nest2 : forall (a : Type), forall (b : @SAWCoreScaffolding.Bool), forall (x : a), forall (y : a), forall (z : a), let var__0   := forall (a1 : Type), @SAWCoreScaffolding.Bool -> a1 -> a1 -> a1 in
+  @SAWCoreScaffolding.Eq a (if b then x else if b then y else z) (if b then x else z) :=
   fun (a : Type) (b : @SAWCoreScaffolding.Bool) (x : a) (y : a) (z : a) => @SAWCoreScaffolding.iteDep (fun (b' : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq a (if b' then x else if b' then y else z) (if b' then x else z)) b (@trans a (if @SAWCoreScaffolding.true then x else if @SAWCoreScaffolding.true then y else z) x (if @SAWCoreScaffolding.true then x else z) (@ite_true a x (if @SAWCoreScaffolding.true then y else z)) (@sym a (if @SAWCoreScaffolding.true then x else z) x (@ite_true a x z))) (@trans a (if @SAWCoreScaffolding.false then x else if @SAWCoreScaffolding.false then y else z) z (if @SAWCoreScaffolding.false then x else z) (@trans a (if @SAWCoreScaffolding.false then x else if @SAWCoreScaffolding.false then y else z) (if @SAWCoreScaffolding.false then y else z) z (@ite_false a x (if @SAWCoreScaffolding.false then y else z)) (@ite_false a y z)) (@sym a (if @SAWCoreScaffolding.false then x else z) z (@ite_false a x z))).
 
 (* Prelude.ite_bit was skipped *)
 
-Definition ite_bit_false_1 : forall (b : @SAWCoreScaffolding.Bool), forall (c : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (if b then @SAWCoreScaffolding.false else c) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not b) c) :=
-  fun (b : @SAWCoreScaffolding.Bool) (c : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b' : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (if b' then @SAWCoreScaffolding.false else c) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not b') c)) b (@trans @SAWCoreScaffolding.Bool (if @SAWCoreScaffolding.true then @SAWCoreScaffolding.false else c) @SAWCoreScaffolding.false (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) c) (@ite_true @SAWCoreScaffolding.Bool @SAWCoreScaffolding.false c) (@sym @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) c) @SAWCoreScaffolding.false (@trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) c) (@SAWCoreScaffolding.and @SAWCoreScaffolding.false c) @SAWCoreScaffolding.false (@eq_cong @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) @SAWCoreScaffolding.false @not_True @SAWCoreScaffolding.Bool (fun (z : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.and z c)) (@and_False1 c)))) (@trans @SAWCoreScaffolding.Bool (if @SAWCoreScaffolding.false then @SAWCoreScaffolding.false else c) c (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) c) (@ite_false @SAWCoreScaffolding.Bool @SAWCoreScaffolding.false c) (@sym @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) c) c (@trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) c) (@SAWCoreScaffolding.and @SAWCoreScaffolding.true c) c (@eq_cong @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) @SAWCoreScaffolding.true @not_False @SAWCoreScaffolding.Bool (fun (z : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.and z c)) (@and_True1 c)))).
+Definition ite_bit_false_1 : forall (b : @SAWCoreScaffolding.Bool), forall (c : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (if b then @SAWCoreScaffolding.false else c) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not b) c) :=
+  fun (b : @SAWCoreScaffolding.Bool) (c : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b' : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (if b' then @SAWCoreScaffolding.false else c) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not b') c)) b (@trans (@SAWCoreScaffolding.Bool) (if @SAWCoreScaffolding.true then @SAWCoreScaffolding.false else c) (@SAWCoreScaffolding.false) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) c) (@ite_true (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.false) c) (@sym (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) c) (@SAWCoreScaffolding.false) (@trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) c) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.false) c) (@SAWCoreScaffolding.false) (@eq_cong (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.false) not_True (@SAWCoreScaffolding.Bool) (fun (z : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.and z c)) (@and_False1 c)))) (@trans (@SAWCoreScaffolding.Bool) (if @SAWCoreScaffolding.false then @SAWCoreScaffolding.false else c) c (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) c) (@ite_false (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.false) c) (@sym (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) c) c (@trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) c) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.true) c) c (@eq_cong (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.true) not_False (@SAWCoreScaffolding.Bool) (fun (z : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.and z c)) (@and_True1 c)))).
 
-Definition ite_bit_true_1 : forall (b : @SAWCoreScaffolding.Bool), forall (c : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (if b then @SAWCoreScaffolding.true else c) (@SAWCoreScaffolding.or b c) :=
-  fun (b : @SAWCoreScaffolding.Bool) (c : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b' : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (if b' then @SAWCoreScaffolding.true else c) (@SAWCoreScaffolding.or b' c)) b (@trans @SAWCoreScaffolding.Bool (if @SAWCoreScaffolding.true then @SAWCoreScaffolding.true else c) @SAWCoreScaffolding.true (@SAWCoreScaffolding.or @SAWCoreScaffolding.true c) (@ite_true @SAWCoreScaffolding.Bool @SAWCoreScaffolding.true c) (@sym @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or @SAWCoreScaffolding.true c) @SAWCoreScaffolding.true (@or_True1 c))) (@trans @SAWCoreScaffolding.Bool (if @SAWCoreScaffolding.false then @SAWCoreScaffolding.true else c) c (@SAWCoreScaffolding.or @SAWCoreScaffolding.false c) (@ite_false @SAWCoreScaffolding.Bool @SAWCoreScaffolding.true c) (@sym @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or @SAWCoreScaffolding.false c) c (@or_False1 c))).
+Definition ite_bit_true_1 : forall (b : @SAWCoreScaffolding.Bool), forall (c : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (if b then @SAWCoreScaffolding.true else c) (@SAWCoreScaffolding.or b c) :=
+  fun (b : @SAWCoreScaffolding.Bool) (c : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b' : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (if b' then @SAWCoreScaffolding.true else c) (@SAWCoreScaffolding.or b' c)) b (@trans (@SAWCoreScaffolding.Bool) (if @SAWCoreScaffolding.true then @SAWCoreScaffolding.true else c) (@SAWCoreScaffolding.true) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.true) c) (@ite_true (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.true) c) (@sym (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.true) c) (@SAWCoreScaffolding.true) (@or_True1 c))) (@trans (@SAWCoreScaffolding.Bool) (if @SAWCoreScaffolding.false then @SAWCoreScaffolding.true else c) c (@SAWCoreScaffolding.or (@SAWCoreScaffolding.false) c) (@ite_false (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.true) c) (@sym (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.false) c) c (@or_False1 c))).
 
-Definition ite_fold_not : forall (b : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (if b then @SAWCoreScaffolding.false else @SAWCoreScaffolding.true) (@SAWCoreScaffolding.not b) :=
-  fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b' : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (if b' then @SAWCoreScaffolding.false else @SAWCoreScaffolding.true) (@SAWCoreScaffolding.not b')) b (@trans @SAWCoreScaffolding.Bool (if @SAWCoreScaffolding.true then @SAWCoreScaffolding.false else @SAWCoreScaffolding.true) @SAWCoreScaffolding.false (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) (@ite_true @SAWCoreScaffolding.Bool @SAWCoreScaffolding.false @SAWCoreScaffolding.true) (@sym @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) @SAWCoreScaffolding.false @not_True)) (@trans @SAWCoreScaffolding.Bool (if @SAWCoreScaffolding.false then @SAWCoreScaffolding.false else @SAWCoreScaffolding.true) @SAWCoreScaffolding.true (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) (@ite_false @SAWCoreScaffolding.Bool @SAWCoreScaffolding.false @SAWCoreScaffolding.true) (@sym @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) @SAWCoreScaffolding.true @not_False)).
+Definition ite_fold_not : forall (b : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (if b then @SAWCoreScaffolding.false else @SAWCoreScaffolding.true) (@SAWCoreScaffolding.not b) :=
+  fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b' : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (if b' then @SAWCoreScaffolding.false else @SAWCoreScaffolding.true) (@SAWCoreScaffolding.not b')) b (@trans (@SAWCoreScaffolding.Bool) (if @SAWCoreScaffolding.true then @SAWCoreScaffolding.false else @SAWCoreScaffolding.true) (@SAWCoreScaffolding.false) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) (@ite_true (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.false) (@SAWCoreScaffolding.true)) (@sym (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.false) not_True)) (@trans (@SAWCoreScaffolding.Bool) (if @SAWCoreScaffolding.false then @SAWCoreScaffolding.false else @SAWCoreScaffolding.true) (@SAWCoreScaffolding.true) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) (@ite_false (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.false) (@SAWCoreScaffolding.true)) (@sym (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.true) not_False)).
 
 Definition ite_eq : forall (a : Type), forall (b : @SAWCoreScaffolding.Bool), forall (x : a), @SAWCoreScaffolding.Eq a (if b then x else x) x :=
   fun (a : Type) (b : @SAWCoreScaffolding.Bool) (x : a) => @SAWCoreScaffolding.iteDep (fun (b' : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq a (if b' then x else x) x) b (@ite_true a x x) (@ite_false a x x).
 
-Definition or_triv1 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or x (@SAWCoreScaffolding.not x)) @SAWCoreScaffolding.true :=
-  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or b (@SAWCoreScaffolding.not b)) @SAWCoreScaffolding.true) x (@or_True1 (@SAWCoreScaffolding.not @SAWCoreScaffolding.true)) (@trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or @SAWCoreScaffolding.false (@SAWCoreScaffolding.not @SAWCoreScaffolding.false)) (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) @SAWCoreScaffolding.true (@or_False1 (@SAWCoreScaffolding.not @SAWCoreScaffolding.false)) @not_False).
+Definition or_triv1 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or x (@SAWCoreScaffolding.not x)) (@SAWCoreScaffolding.true) :=
+  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or b (@SAWCoreScaffolding.not b)) (@SAWCoreScaffolding.true)) x (@or_True1 (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true))) (@trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.false) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false))) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.true) (@or_False1 (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false))) not_False).
 
-Definition or_triv2 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or (@SAWCoreScaffolding.not x) x) @SAWCoreScaffolding.true :=
-  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or (@SAWCoreScaffolding.not b) b) @SAWCoreScaffolding.true) x (@or_True2 (@SAWCoreScaffolding.not @SAWCoreScaffolding.true)) (@trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.or (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) @SAWCoreScaffolding.false) (@SAWCoreScaffolding.not @SAWCoreScaffolding.false) @SAWCoreScaffolding.true (@or_False2 (@SAWCoreScaffolding.not @SAWCoreScaffolding.false)) @not_False).
+Definition or_triv2 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.not x) x) (@SAWCoreScaffolding.true) :=
+  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.not b) b) (@SAWCoreScaffolding.true)) x (@or_True2 (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true))) (@trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.or (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false)) (@SAWCoreScaffolding.true) (@or_False2 (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false))) not_False).
 
-Definition and_triv1 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and x (@SAWCoreScaffolding.not x)) @SAWCoreScaffolding.false :=
-  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and b (@SAWCoreScaffolding.not b)) @SAWCoreScaffolding.false) x (@trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and @SAWCoreScaffolding.true (@SAWCoreScaffolding.not @SAWCoreScaffolding.true)) (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) @SAWCoreScaffolding.false (@and_True1 (@SAWCoreScaffolding.not @SAWCoreScaffolding.true)) @not_True) (@and_False1 (@SAWCoreScaffolding.not @SAWCoreScaffolding.false)).
+Definition and_triv1 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and x (@SAWCoreScaffolding.not x)) (@SAWCoreScaffolding.false) :=
+  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and b (@SAWCoreScaffolding.not b)) (@SAWCoreScaffolding.false)) x (@trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.true) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true))) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.false) (@and_True1 (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true))) not_True) (@and_False1 (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false))).
 
-Definition and_triv2 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not x) x) @SAWCoreScaffolding.false :=
-  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not b) b) @SAWCoreScaffolding.false) x (@trans @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) @SAWCoreScaffolding.true) (@SAWCoreScaffolding.not @SAWCoreScaffolding.true) @SAWCoreScaffolding.false (@and_True2 (@SAWCoreScaffolding.not @SAWCoreScaffolding.true)) @not_True) (@and_False2 (@SAWCoreScaffolding.not @SAWCoreScaffolding.false)).
+Definition and_triv2 : forall (x : @SAWCoreScaffolding.Bool), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not x) x) (@SAWCoreScaffolding.false) :=
+  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not b) b) (@SAWCoreScaffolding.false)) x (@trans (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.false) (@and_True2 (@SAWCoreScaffolding.not (@SAWCoreScaffolding.true))) not_True) (@and_False2 (@SAWCoreScaffolding.not (@SAWCoreScaffolding.false))).
 
 Definition EqTrue : @SAWCoreScaffolding.Bool -> Type :=
-  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool x @SAWCoreScaffolding.true.
+  fun (x : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) x (@SAWCoreScaffolding.true).
 
-Definition TrueI : @EqTrue @SAWCoreScaffolding.true :=
-  @SAWCoreScaffolding.Refl @SAWCoreScaffolding.Bool @SAWCoreScaffolding.true.
+Definition TrueI : @EqTrue (@SAWCoreScaffolding.true) :=
+  @SAWCoreScaffolding.Refl (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.true).
 
 Definition andI : forall (x : @SAWCoreScaffolding.Bool), forall (y : @SAWCoreScaffolding.Bool), @EqTrue x -> @EqTrue y -> @EqTrue (@SAWCoreScaffolding.and x y) :=
-  fun (x : @SAWCoreScaffolding.Bool) (y : @SAWCoreScaffolding.Bool) (p : @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool x @SAWCoreScaffolding.true) (q : @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool y @SAWCoreScaffolding.true) => @trans4 @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and x y) (@SAWCoreScaffolding.and x @SAWCoreScaffolding.true) x @SAWCoreScaffolding.true (@eq_cong @SAWCoreScaffolding.Bool y @SAWCoreScaffolding.true q @SAWCoreScaffolding.Bool (@SAWCoreScaffolding.and x)) (@and_True2 x) p.
+  fun (x : @SAWCoreScaffolding.Bool) (y : @SAWCoreScaffolding.Bool) (p : @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) x (@SAWCoreScaffolding.true)) (q : @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) y (@SAWCoreScaffolding.true)) => @trans4 (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and x y) (@SAWCoreScaffolding.and x (@SAWCoreScaffolding.true)) x (@SAWCoreScaffolding.true) (@eq_cong (@SAWCoreScaffolding.Bool) y (@SAWCoreScaffolding.true) q (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.and x)) (@and_True2 x) p.
 
 Definition impliesI : forall (x : @SAWCoreScaffolding.Bool), forall (y : @SAWCoreScaffolding.Bool), (@EqTrue x -> @EqTrue y) -> @EqTrue (@implies x y) :=
-  fun (x : @SAWCoreScaffolding.Bool) (y : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (x1 : @SAWCoreScaffolding.Bool) => (@EqTrue x -> @EqTrue y) -> @EqTrue (@implies x y)) x (fun (H : @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool @SAWCoreScaffolding.true @SAWCoreScaffolding.true -> @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool y @SAWCoreScaffolding.true) => @trans @SAWCoreScaffolding.Bool (@implies @SAWCoreScaffolding.true y) y @SAWCoreScaffolding.true (@implies_True1 y) (H @TrueI)) (fun (_1 : @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool @SAWCoreScaffolding.false @SAWCoreScaffolding.true -> @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Bool y @SAWCoreScaffolding.true) => @implies_False1 y).
-
-(* Prelude.eq was skipped *)
-
-(* Prelude.eq_refl was skipped *)
-
-(* Prelude.eq_Bool was skipped *)
-
-(* Prelude.ite_eq_cong_1 was skipped *)
-
-(* Prelude.ite_eq_cong_2 was skipped *)
+  fun (x : @SAWCoreScaffolding.Bool) (y : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.iteDep (fun (x1 : @SAWCoreScaffolding.Bool) => (@EqTrue x1 -> @EqTrue y) -> @EqTrue (@implies x1 y)) x (fun (H : @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.true) (@SAWCoreScaffolding.true) -> @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) y (@SAWCoreScaffolding.true)) => @trans (@SAWCoreScaffolding.Bool) (@implies (@SAWCoreScaffolding.true) y) y (@SAWCoreScaffolding.true) (@implies_True1 y) (H TrueI)) (fun (_1 : @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.false) (@SAWCoreScaffolding.true) -> @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) y (@SAWCoreScaffolding.true)) => @implies_False1 y).
 
 Inductive Either (s : Type) (t : Type) : Type :=
 | Left : s -> @Either s t
@@ -344,71 +350,86 @@ Definition maybe : forall (a : Type), forall (b : Type), b -> (a -> b) -> @Maybe
 
 (* Prelude.Nat was skipped *)
 
-Definition Nat__rec : forall (p : @SAWCoreScaffolding.Nat -> Type), p @SAWCoreScaffolding.Zero -> (forall (n : @SAWCoreScaffolding.Nat), p n -> p (@SAWCoreScaffolding.Succ n)) -> forall (n : @SAWCoreScaffolding.Nat), p n :=
+Definition Nat__rec : forall (p : @SAWCoreScaffolding.Nat -> Type), p (@SAWCoreScaffolding.Zero) -> (forall (n : @SAWCoreScaffolding.Nat), p n -> p (@SAWCoreScaffolding.Succ n)) -> forall (n : @SAWCoreScaffolding.Nat), p n :=
   fun (p : @SAWCoreScaffolding.Nat -> Type) (f1 : p 0) (f2 : forall (n : @SAWCoreScaffolding.Nat), p n -> p (@SAWCoreScaffolding.Succ n)) (n : @SAWCoreScaffolding.Nat) => SAWCoreScaffolding.Nat_rect p f1 f2 n.
 
 Definition Nat_cases : forall (a : Type), a -> (@SAWCoreScaffolding.Nat -> a -> a) -> @SAWCoreScaffolding.Nat -> a :=
   fun (a : Type) (f1 : a) (f2 : @SAWCoreScaffolding.Nat -> a -> a) (n : @SAWCoreScaffolding.Nat) => @Nat__rec (fun (n1 : @SAWCoreScaffolding.Nat) => a) f1 f2 n.
 
 Definition Nat_cases2 : forall (a : Type), (@SAWCoreScaffolding.Nat -> a) -> (@SAWCoreScaffolding.Nat -> a) -> (@SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat -> a -> a) -> @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat -> a :=
-  fun (a : Type) (f1 : @SAWCoreScaffolding.Nat -> a) (f2 : @SAWCoreScaffolding.Nat -> a) (f3 : @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat -> a -> a) (n : @SAWCoreScaffolding.Nat) (m : @SAWCoreScaffolding.Nat) => @Nat__rec (fun (n1 : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Nat -> a) f1 (fun (n1 : @SAWCoreScaffolding.Nat) (f_rec : @SAWCoreScaffolding.Nat -> a) (m1 : @SAWCoreScaffolding.Nat) => @Nat__rec (fun (m' : @SAWCoreScaffolding.Nat) => a) (f2 n) (fun (m' : @SAWCoreScaffolding.Nat) (frec' : a) => f3 n m' (f_rec m')) m) n m.
+  fun (a : Type) (f1 : @SAWCoreScaffolding.Nat -> a) (f2 : @SAWCoreScaffolding.Nat -> a) (f3 : @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat -> a -> a) (n : @SAWCoreScaffolding.Nat) (m : @SAWCoreScaffolding.Nat) => @Nat__rec (fun (n1 : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Nat -> a) f1 (fun (n1 : @SAWCoreScaffolding.Nat) (f_rec : @SAWCoreScaffolding.Nat -> a) (m1 : @SAWCoreScaffolding.Nat) => @Nat__rec (fun (m' : @SAWCoreScaffolding.Nat) => a) (f2 n1) (fun (m' : @SAWCoreScaffolding.Nat) (frec' : a) => f3 n1 m' (f_rec m')) m1) n m.
 
 Definition eqNat : @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat -> Type :=
-  fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Nat x y.
+  fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Nat) x y.
 
 Definition eqNatSucc : forall (x : @SAWCoreScaffolding.Nat), forall (y : @SAWCoreScaffolding.Nat), @eqNat x y -> @eqNat (@SAWCoreScaffolding.Succ x) (@SAWCoreScaffolding.Succ y) :=
-  fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) (eq : @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Nat x y) => @eq_cong @SAWCoreScaffolding.Nat x y eq @SAWCoreScaffolding.Nat (fun (n : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Succ n).
+  fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) (eq : @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Nat) x y) => @eq_cong (@SAWCoreScaffolding.Nat) x y eq (@SAWCoreScaffolding.Nat) (fun (n : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Succ n).
 
 Definition pred : @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat :=
-  fun (x : @SAWCoreScaffolding.Nat) => @Nat_cases @SAWCoreScaffolding.Nat @SAWCoreScaffolding.Zero (fun (n : @SAWCoreScaffolding.Nat) (m : @SAWCoreScaffolding.Nat) => n) x.
+  fun (x : @SAWCoreScaffolding.Nat) => @Nat_cases (@SAWCoreScaffolding.Nat) (@SAWCoreScaffolding.Zero) (fun (n : @SAWCoreScaffolding.Nat) (m : @SAWCoreScaffolding.Nat) => n) x.
 
 Definition eqNatPrec : forall (x : @SAWCoreScaffolding.Nat), forall (y : @SAWCoreScaffolding.Nat), @eqNat (@SAWCoreScaffolding.Succ x) (@SAWCoreScaffolding.Succ y) -> @eqNat x y :=
-  fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) (eq' : @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Nat (@SAWCoreScaffolding.Succ x) (@SAWCoreScaffolding.Succ y)) => @eq_cong @SAWCoreScaffolding.Nat (@SAWCoreScaffolding.Succ x) (@SAWCoreScaffolding.Succ y) eq' @SAWCoreScaffolding.Nat @pred.
+  fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) (eq' : @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Nat) (@SAWCoreScaffolding.Succ x) (@SAWCoreScaffolding.Succ y)) => @eq_cong (@SAWCoreScaffolding.Nat) (@SAWCoreScaffolding.Succ x) (@SAWCoreScaffolding.Succ y) eq' (@SAWCoreScaffolding.Nat) pred.
+
+Inductive IsLeNat (n : @SAWCoreScaffolding.Nat) : forall (_1 : @SAWCoreScaffolding.Nat), Prop :=
+| IsLeNat_base :  @IsLeNat n n
+| IsLeNat_succ : forall (m : @SAWCoreScaffolding.Nat), @IsLeNat n m -> @IsLeNat n (@SAWCoreScaffolding.Succ m)
+.
+
+Definition IsLtNat : @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat -> Prop :=
+  fun (m : @SAWCoreScaffolding.Nat) (n : @SAWCoreScaffolding.Nat) => @IsLeNat (@SAWCoreScaffolding.Succ m) n.
+
+Axiom natCompareLe : forall (m : @SAWCoreScaffolding.Nat), forall (n : @SAWCoreScaffolding.Nat), @Either (@IsLtNat m n) (@IsLeNat n m) .
+
+Axiom proveEqNat : forall (m : @SAWCoreScaffolding.Nat), forall (n : @SAWCoreScaffolding.Nat), @Maybe (@SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Nat) m n) .
+
+Axiom proveLeNat : forall (x : @SAWCoreScaffolding.Nat), forall (y : @SAWCoreScaffolding.Nat), @Maybe (@IsLeNat x y) .
+
+Definition proveLtNat : forall (x : @SAWCoreScaffolding.Nat), forall (y : @SAWCoreScaffolding.Nat), @Maybe (@IsLtNat x y) :=
+  fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) => @proveLeNat (@SAWCoreScaffolding.Succ x) y.
 
 Definition addNat : @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat :=
-  fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) => @Nat_cases @SAWCoreScaffolding.Nat y (fun (_1 : @SAWCoreScaffolding.Nat) (prev_sum : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Succ prev_sum) x.
+  fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) => @Nat_cases (@SAWCoreScaffolding.Nat) y (fun (_1 : @SAWCoreScaffolding.Nat) (prev_sum : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Succ prev_sum) x.
 
 Definition eqNatAdd0 : forall (x : @SAWCoreScaffolding.Nat), @eqNat (@addNat x 0) x :=
-  fun (x : @SAWCoreScaffolding.Nat) => @Nat__rec (fun (n : @SAWCoreScaffolding.Nat) => @eqNat (@addNat n 0) n) (@SAWCoreScaffolding.Refl @SAWCoreScaffolding.Nat 0) (fun (n : @SAWCoreScaffolding.Nat) => @eqNatSucc (@addNat n 0) n) x.
+  fun (x : @SAWCoreScaffolding.Nat) => @Nat__rec (fun (n : @SAWCoreScaffolding.Nat) => @eqNat (@addNat n 0) n) (@SAWCoreScaffolding.Refl (@SAWCoreScaffolding.Nat) 0) (fun (n : @SAWCoreScaffolding.Nat) => @eqNatSucc (@addNat n 0) n) x.
 
 Definition eqNatAddS : forall (x : @SAWCoreScaffolding.Nat), forall (y : @SAWCoreScaffolding.Nat), @eqNat (@addNat x (@SAWCoreScaffolding.Succ y)) (@SAWCoreScaffolding.Succ (@addNat x y)) :=
-  fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) => @Nat__rec (fun (x' : @SAWCoreScaffolding.Nat) => forall (y' : @SAWCoreScaffolding.Nat), @eqNat (@addNat x' (@SAWCoreScaffolding.Succ y')) (@SAWCoreScaffolding.Succ (@addNat x' y'))) (fun (y' : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Refl @SAWCoreScaffolding.Nat (@SAWCoreScaffolding.Succ y')) (fun (x' : @SAWCoreScaffolding.Nat) (eqF : forall (y' : @SAWCoreScaffolding.Nat), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Nat (SAWCoreScaffolding.Nat_rect (fun (n : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Nat) (@SAWCoreScaffolding.Succ y') (fun (_1 : @SAWCoreScaffolding.Nat) (prev_sum : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Succ prev_sum) x') (@SAWCoreScaffolding.Succ (@addNat x' y'))) (y' : @SAWCoreScaffolding.Nat) => @eqNatSucc (@addNat x' (@SAWCoreScaffolding.Succ y')) (@SAWCoreScaffolding.Succ (@addNat x' y')) (eqF y')) x y.
+  fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) => @Nat__rec (fun (x' : @SAWCoreScaffolding.Nat) => forall (y' : @SAWCoreScaffolding.Nat), @eqNat (@addNat x' (@SAWCoreScaffolding.Succ y')) (@SAWCoreScaffolding.Succ (@addNat x' y'))) (fun (y' : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Refl (@SAWCoreScaffolding.Nat) (@SAWCoreScaffolding.Succ y')) (fun (x' : @SAWCoreScaffolding.Nat) (eqF : forall (y' : @SAWCoreScaffolding.Nat), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Nat) (SAWCoreScaffolding.Nat_rect (fun (n : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Nat) (@SAWCoreScaffolding.Succ y') (fun (_1 : @SAWCoreScaffolding.Nat) (prev_sum : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Succ prev_sum) x') (@SAWCoreScaffolding.Succ (@addNat x' y'))) (y' : @SAWCoreScaffolding.Nat) => @eqNatSucc (@addNat x' (@SAWCoreScaffolding.Succ y')) (@SAWCoreScaffolding.Succ (@addNat x' y')) (eqF y')) x y.
 
 Definition eqNatAddComm : forall (x : @SAWCoreScaffolding.Nat), forall (y : @SAWCoreScaffolding.Nat), @eqNat (@addNat x y) (@addNat y x) :=
   fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) => @Nat__rec (fun (y' : @SAWCoreScaffolding.Nat) => forall (x' : @SAWCoreScaffolding.Nat), @eqNat (@addNat x' y') (@addNat y' x')) (fun (x' : @SAWCoreScaffolding.Nat) => @eqNatAdd0 x') (fun (y' : @SAWCoreScaffolding.Nat) (eqF : forall (x' : @SAWCoreScaffolding.Nat), let var__0   := fun (n : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Nat in
   let var__1   := fun (_1 : @SAWCoreScaffolding.Nat) (prev_sum : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Succ prev_sum in
-  @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Nat (SAWCoreScaffolding.Nat_rect var__0 y' var__1 x') (SAWCoreScaffolding.Nat_rect var__0 x' var__1 y')) (x' : @SAWCoreScaffolding.Nat) => @trans @SAWCoreScaffolding.Nat (@addNat x' (@SAWCoreScaffolding.Succ y')) (@SAWCoreScaffolding.Succ (@addNat x' y')) (@SAWCoreScaffolding.Succ (@addNat y' x')) (@eqNatAddS x' y') (@eqNatSucc (@addNat x' y') (@addNat y' x') (eqF x'))) y x.
+  @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Nat) (SAWCoreScaffolding.Nat_rect var__0 y' var__1 x') (SAWCoreScaffolding.Nat_rect var__0 x' var__1 y')) (x' : @SAWCoreScaffolding.Nat) => @trans (@SAWCoreScaffolding.Nat) (@addNat x' (@SAWCoreScaffolding.Succ y')) (@SAWCoreScaffolding.Succ (@addNat x' y')) (@SAWCoreScaffolding.Succ (@addNat y' x')) (@eqNatAddS x' y') (@eqNatSucc (@addNat x' y') (@addNat y' x') (eqF x'))) y x.
 
 Definition addNat_assoc : forall (x : @SAWCoreScaffolding.Nat), forall (y : @SAWCoreScaffolding.Nat), forall (z : @SAWCoreScaffolding.Nat), @eqNat (@addNat x (@addNat y z)) (@addNat (@addNat x y) z) :=
-  fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) (z : @SAWCoreScaffolding.Nat) => @Nat__rec (fun (x' : @SAWCoreScaffolding.Nat) => @eqNat (@addNat x' (@addNat y z)) (@addNat (@addNat x' y) z)) (@SAWCoreScaffolding.Refl @SAWCoreScaffolding.Nat (@addNat y z)) (fun (x' : @SAWCoreScaffolding.Nat) (eq : @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Nat (SAWCoreScaffolding.Nat_rect (fun (n : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Nat) (@addNat y z) (fun (_1 : @SAWCoreScaffolding.Nat) (prev_sum : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Succ prev_sum) x') (SAWCoreScaffolding.Nat_rect (fun (n : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Nat) z (fun (_1 : @SAWCoreScaffolding.Nat) (prev_sum : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Succ prev_sum) (SAWCoreScaffolding.Nat_rect (fun (n : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Nat) y (fun (_1 : @SAWCoreScaffolding.Nat) (prev_sum : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Succ prev_sum) x'))) => @eqNatSucc (@addNat x' (@addNat y z)) (@addNat (@addNat x' y) z) eq) x.
+  fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) (z : @SAWCoreScaffolding.Nat) => @Nat__rec (fun (x' : @SAWCoreScaffolding.Nat) => @eqNat (@addNat x' (@addNat y z)) (@addNat (@addNat x' y) z)) (@SAWCoreScaffolding.Refl (@SAWCoreScaffolding.Nat) (@addNat y z)) (fun (x' : @SAWCoreScaffolding.Nat) (eq : @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Nat) (SAWCoreScaffolding.Nat_rect (fun (n : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Nat) (@addNat y z) (fun (_1 : @SAWCoreScaffolding.Nat) (prev_sum : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Succ prev_sum) x') (SAWCoreScaffolding.Nat_rect (fun (n : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Nat) z (fun (_1 : @SAWCoreScaffolding.Nat) (prev_sum : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Succ prev_sum) (SAWCoreScaffolding.Nat_rect (fun (n : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Nat) y (fun (_1 : @SAWCoreScaffolding.Nat) (prev_sum : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Succ prev_sum) x'))) => @eqNatSucc (@addNat x' (@addNat y z)) (@addNat (@addNat x' y) z) eq) x.
 
 Definition mulNat : @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat :=
   fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) => @Nat__rec (fun (x' : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Nat) 0 (fun (x' : @SAWCoreScaffolding.Nat) (prod : @SAWCoreScaffolding.Nat) => @addNat y prod) x.
 
 Definition equal0Nat : @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Bool :=
-  fun (n : @SAWCoreScaffolding.Nat) => @Nat_cases @SAWCoreScaffolding.Bool @SAWCoreScaffolding.true (fun (n1 : @SAWCoreScaffolding.Nat) (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.false) n.
+  fun (n : @SAWCoreScaffolding.Nat) => @Nat_cases (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.true) (fun (n1 : @SAWCoreScaffolding.Nat) (b : @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.false) n.
 
 Definition equalNat : @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Bool :=
-  fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) => @Nat_cases (@SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Bool) @equal0Nat (fun (n' : @SAWCoreScaffolding.Nat) (eqN : @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Bool) (m : @SAWCoreScaffolding.Nat) => @Nat_cases @SAWCoreScaffolding.Bool @SAWCoreScaffolding.false (fun (m' : @SAWCoreScaffolding.Nat) (b : @SAWCoreScaffolding.Bool) => eqN m') m) x y.
+  fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) => @Nat_cases (@SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Bool) equal0Nat (fun (n' : @SAWCoreScaffolding.Nat) (eqN : @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Bool) (m : @SAWCoreScaffolding.Nat) => @Nat_cases (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.false) (fun (m' : @SAWCoreScaffolding.Nat) (b : @SAWCoreScaffolding.Bool) => eqN m') m) x y.
 
 Definition ltNat : @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Bool :=
-  fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) => @Nat_cases2 @SAWCoreScaffolding.Bool (fun (x' : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.false) (fun (y' : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.true) (fun (y' : @SAWCoreScaffolding.Nat) (x' : @SAWCoreScaffolding.Nat) (lt_mn : @SAWCoreScaffolding.Bool) => lt_mn) y x.
+  fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) => @Nat_cases2 (@SAWCoreScaffolding.Bool) (fun (x' : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.false) (fun (y' : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.true) (fun (y' : @SAWCoreScaffolding.Nat) (x' : @SAWCoreScaffolding.Nat) (lt_mn : @SAWCoreScaffolding.Bool) => lt_mn) y x.
 
 Definition subNat : @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat :=
-  fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) => @Nat_cases2 @SAWCoreScaffolding.Nat (fun (x' : @SAWCoreScaffolding.Nat) => x') (fun (y' : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Zero) (fun (y' : @SAWCoreScaffolding.Nat) (x' : @SAWCoreScaffolding.Nat) (sub_xy : @SAWCoreScaffolding.Nat) => sub_xy) y x.
+  fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) => @Nat_cases2 (@SAWCoreScaffolding.Nat) (fun (x' : @SAWCoreScaffolding.Nat) => x') (fun (y' : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Zero) (fun (y' : @SAWCoreScaffolding.Nat) (x' : @SAWCoreScaffolding.Nat) (sub_xy : @SAWCoreScaffolding.Nat) => sub_xy) y x.
 
 Definition minNat : @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat :=
-  fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) => @Nat_cases2 @SAWCoreScaffolding.Nat (fun (y' : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Zero) (fun (x' : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Zero) (fun (x' : @SAWCoreScaffolding.Nat) (y' : @SAWCoreScaffolding.Nat) (min_xy : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Succ min_xy) x y.
+  fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) => @Nat_cases2 (@SAWCoreScaffolding.Nat) (fun (y' : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Zero) (fun (x' : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Zero) (fun (x' : @SAWCoreScaffolding.Nat) (y' : @SAWCoreScaffolding.Nat) (min_xy : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Succ min_xy) x y.
 
 Definition maxNat : @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat :=
-  fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) => @Nat_cases2 @SAWCoreScaffolding.Nat (fun (x' : @SAWCoreScaffolding.Nat) => x') (fun (y' : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Succ y') (fun (y' : @SAWCoreScaffolding.Nat) (x' : @SAWCoreScaffolding.Nat) (sub_xy : @SAWCoreScaffolding.Nat) => sub_xy) y x.
+  fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) => @Nat_cases2 (@SAWCoreScaffolding.Nat) (fun (x' : @SAWCoreScaffolding.Nat) => x') (fun (y' : @SAWCoreScaffolding.Nat) => @SAWCoreScaffolding.Succ y') (fun (y' : @SAWCoreScaffolding.Nat) (x' : @SAWCoreScaffolding.Nat) (sub_xy : @SAWCoreScaffolding.Nat) => sub_xy) y x.
 
 (* Prelude.widthNat was skipped *)
 
-(* Prelude.eq_Nat was skipped *)
-
 Definition expNat : @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat :=
-  fun (b : @SAWCoreScaffolding.Nat) (e : @SAWCoreScaffolding.Nat) => @Nat_cases @SAWCoreScaffolding.Nat 1 (fun (e' : @SAWCoreScaffolding.Nat) (exp_b_e : @SAWCoreScaffolding.Nat) => @mulNat b exp_b_e) e.
+  fun (b : @SAWCoreScaffolding.Nat) (e : @SAWCoreScaffolding.Nat) => @Nat_cases (@SAWCoreScaffolding.Nat) 1 (fun (e' : @SAWCoreScaffolding.Nat) (exp_b_e : @SAWCoreScaffolding.Nat) => @mulNat b exp_b_e) e.
 
 (* Prelude.divModNat was skipped *)
 
@@ -418,7 +439,7 @@ Definition divNat : @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat -> @SAWCo
 Definition modNat : @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat -> @SAWCoreScaffolding.Nat :=
   fun (x : @SAWCoreScaffolding.Nat) (y : @SAWCoreScaffolding.Nat) => SAWCoreScaffolding.snd (@SAWCoreScaffolding.divModNat x y).
 
-Definition natCase : forall (p : @SAWCoreScaffolding.Nat -> Type), p @SAWCoreScaffolding.Zero -> (forall (n : @SAWCoreScaffolding.Nat), p (@SAWCoreScaffolding.Succ n)) -> forall (n : @SAWCoreScaffolding.Nat), p n :=
+Definition natCase : forall (p : @SAWCoreScaffolding.Nat -> Type), p (@SAWCoreScaffolding.Zero) -> (forall (n : @SAWCoreScaffolding.Nat), p (@SAWCoreScaffolding.Succ n)) -> forall (n : @SAWCoreScaffolding.Nat), p n :=
   fun (p : @SAWCoreScaffolding.Nat -> Type) (z : p 0) (s : forall (n : @SAWCoreScaffolding.Nat), p (@SAWCoreScaffolding.Succ n)) => @Nat__rec p z (fun (n : @SAWCoreScaffolding.Nat) (r : p n) => s n).
 
 Definition if0Nat : forall (a : Type), @SAWCoreScaffolding.Nat -> a -> a -> a :=
@@ -481,19 +502,19 @@ Fixpoint zip (a b : sort 0) (m n : Nat) (xs : Vec m a) (ys : Vec n b)
 Definition reverse : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), @SAWCoreVectorsAsCoqVectors.Vec n a -> @SAWCoreVectorsAsCoqVectors.Vec n a :=
   fun (n : @SAWCoreScaffolding.Nat) (a : Type) (xs : @SAWCoreVectorsAsCoqVectors.Vec n a) => @SAWCoreVectorsAsCoqVectors.gen n a (fun (i : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.sawAt n a xs (@subNat (@subNat n 1) i)).
 
-Definition transpose : forall (m : @SAWCoreScaffolding.Nat), forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), @SAWCoreVectorsAsCoqVectors.Vec m (@SAWCoreVectorsAsCoqVectors.Vec n a) -> @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreVectorsAsCoqVectors.Vec m a) :=
+Definition transpose : forall (m : @SAWCoreScaffolding.Nat), forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), @SAWCoreVectorsAsCoqVectors.Vec m (@SAWCoreVectorsAsCoqVectors.Vec n a) -> let var__0   := @SAWCoreScaffolding.Nat -> Type -> Type in
+  @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreVectorsAsCoqVectors.Vec m a) :=
   fun (m : @SAWCoreScaffolding.Nat) (n : @SAWCoreScaffolding.Nat) (a : Type) (xss : @SAWCoreVectorsAsCoqVectors.Vec m (@SAWCoreVectorsAsCoqVectors.Vec n a)) => @SAWCoreVectorsAsCoqVectors.gen n (@SAWCoreVectorsAsCoqVectors.Vec m a) (fun (j : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.gen m a (fun (i : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.sawAt n a (@SAWCorePrelude.sawAt m (@SAWCoreVectorsAsCoqVectors.Vec n a) xss i) j)).
 
 Definition vecEq : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), (a -> a -> @SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n a -> @SAWCoreVectorsAsCoqVectors.Vec n a -> @SAWCoreScaffolding.Bool :=
-  fun (n : @SAWCoreScaffolding.Nat) (a : Type) (eqFn : a -> a -> @SAWCoreScaffolding.Bool) (x : @SAWCoreVectorsAsCoqVectors.Vec n a) (y : @SAWCoreVectorsAsCoqVectors.Vec n a) => @SAWCoreVectorsAsCoqVectors.foldr @SAWCoreScaffolding.Bool @SAWCoreScaffolding.Bool n @SAWCoreScaffolding.and @SAWCoreScaffolding.true (@zipWith a a @SAWCoreScaffolding.Bool eqFn n x y).
-
-(* Prelude.eq_Vec was skipped *)
+  fun (n : @SAWCoreScaffolding.Nat) (a : Type) (eqFn : a -> a -> @SAWCoreScaffolding.Bool) (x : @SAWCoreVectorsAsCoqVectors.Vec n a) (y : @SAWCoreVectorsAsCoqVectors.Vec n a) => @SAWCoreVectorsAsCoqVectors.foldr (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.Bool) n (@SAWCoreScaffolding.and) (@SAWCoreScaffolding.true) (@zipWith a a (@SAWCoreScaffolding.Bool) eqFn n x y).
 
 Definition take : forall (a : Type), forall (m : @SAWCoreScaffolding.Nat), forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec (@addNat m n) a -> @SAWCoreVectorsAsCoqVectors.Vec m a :=
   fun (a : Type) (m : @SAWCoreScaffolding.Nat) (n : @SAWCoreScaffolding.Nat) (v : @SAWCoreVectorsAsCoqVectors.Vec (@addNat m n) a) => @SAWCoreVectorsAsCoqVectors.gen m a (fun (i : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.sawAt (@addNat m n) a v i).
 
-Definition vecCong : forall (a : Type), forall (m : @SAWCoreScaffolding.Nat), forall (n : @SAWCoreScaffolding.Nat), @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Nat m n -> @SAWCoreScaffolding.Eq Type (@SAWCoreVectorsAsCoqVectors.Vec m a) (@SAWCoreVectorsAsCoqVectors.Vec n a) :=
-  fun (a : Type) (m : @SAWCoreScaffolding.Nat) (n : @SAWCoreScaffolding.Nat) (eq : @SAWCoreScaffolding.Eq @SAWCoreScaffolding.Nat m n) => @eq_cong @SAWCoreScaffolding.Nat m n eq Type (fun (i : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.Vec i a).
+Definition vecCong : forall (a : Type), forall (m : @SAWCoreScaffolding.Nat), forall (n : @SAWCoreScaffolding.Nat), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Nat) m n -> let var__0   := @SAWCoreScaffolding.Nat -> Type -> Type in
+  @SAWCoreScaffolding.Eq Type (@SAWCoreVectorsAsCoqVectors.Vec m a) (@SAWCoreVectorsAsCoqVectors.Vec n a) :=
+  fun (a : Type) (m : @SAWCoreScaffolding.Nat) (n : @SAWCoreScaffolding.Nat) (eq : @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Nat) m n) => @eq_cong (@SAWCoreScaffolding.Nat) m n eq Type (fun (i : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.Vec i a).
 
 (* Prelude.coerceVec was skipped *)
 
@@ -510,7 +531,8 @@ Definition slice : forall (a : Type), forall (m : @SAWCoreScaffolding.Nat), fora
 Definition join : forall (m : @SAWCoreScaffolding.Nat), forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), @SAWCoreVectorsAsCoqVectors.Vec m (@SAWCoreVectorsAsCoqVectors.Vec n a) -> @SAWCoreVectorsAsCoqVectors.Vec (@mulNat m n) a :=
   fun (m : @SAWCoreScaffolding.Nat) (n : @SAWCoreScaffolding.Nat) (a : Type) (v : @SAWCoreVectorsAsCoqVectors.Vec m (@SAWCoreVectorsAsCoqVectors.Vec n a)) => @SAWCoreVectorsAsCoqVectors.gen (@mulNat m n) a (fun (i : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.sawAt n a (@SAWCorePrelude.sawAt m (@SAWCoreVectorsAsCoqVectors.Vec n a) v (@divNat i n)) (@modNat i n)).
 
-Definition split : forall (m : @SAWCoreScaffolding.Nat), forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), @SAWCoreVectorsAsCoqVectors.Vec (@mulNat m n) a -> @SAWCoreVectorsAsCoqVectors.Vec m (@SAWCoreVectorsAsCoqVectors.Vec n a) :=
+Definition split : forall (m : @SAWCoreScaffolding.Nat), forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), @SAWCoreVectorsAsCoqVectors.Vec (@mulNat m n) a -> let var__0   := @SAWCoreScaffolding.Nat -> Type -> Type in
+  @SAWCoreVectorsAsCoqVectors.Vec m (@SAWCoreVectorsAsCoqVectors.Vec n a) :=
   fun (m : @SAWCoreScaffolding.Nat) (n : @SAWCoreScaffolding.Nat) (a : Type) (v : @SAWCoreVectorsAsCoqVectors.Vec (@mulNat m n) a) => @SAWCoreVectorsAsCoqVectors.gen m (@SAWCoreVectorsAsCoqVectors.Vec n a) (fun (i : @SAWCoreScaffolding.Nat) => @SAWCoreVectorsAsCoqVectors.gen n a (fun (j : @SAWCoreScaffolding.Nat) => @SAWCorePrelude.sawAt (@mulNat m n) a v (@addNat (@mulNat i n) j))).
 
 Definition append : forall (m : @SAWCoreScaffolding.Nat), forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), @SAWCoreVectorsAsCoqVectors.Vec m a -> @SAWCoreVectorsAsCoqVectors.Vec n a -> @SAWCoreVectorsAsCoqVectors.Vec (@addNat m n) a :=
@@ -527,36 +549,37 @@ Definition append : forall (m : @SAWCoreScaffolding.Nat), forall (n : @SAWCoreSc
 Definition joinLittleEndian : forall (m : @SAWCoreScaffolding.Nat), forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), @SAWCoreVectorsAsCoqVectors.Vec m (@SAWCoreVectorsAsCoqVectors.Vec n a) -> @SAWCoreVectorsAsCoqVectors.Vec (@mulNat m n) a :=
   fun (m : @SAWCoreScaffolding.Nat) (n : @SAWCoreScaffolding.Nat) (a : Type) (v : @SAWCoreVectorsAsCoqVectors.Vec m (@SAWCoreVectorsAsCoqVectors.Vec n a)) => @join m n a (@reverse m (@SAWCoreVectorsAsCoqVectors.Vec n a) v).
 
-Definition splitLittleEndian : forall (m : @SAWCoreScaffolding.Nat), forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), @SAWCoreVectorsAsCoqVectors.Vec (@mulNat m n) a -> @SAWCoreVectorsAsCoqVectors.Vec m (@SAWCoreVectorsAsCoqVectors.Vec n a) :=
+Definition splitLittleEndian : forall (m : @SAWCoreScaffolding.Nat), forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), @SAWCoreVectorsAsCoqVectors.Vec (@mulNat m n) a -> let var__0   := @SAWCoreScaffolding.Nat -> Type -> Type in
+  @SAWCoreVectorsAsCoqVectors.Vec m (@SAWCoreVectorsAsCoqVectors.Vec n a) :=
   fun (m : @SAWCoreScaffolding.Nat) (n : @SAWCoreScaffolding.Nat) (a : Type) (v : @SAWCoreVectorsAsCoqVectors.Vec (@mulNat m n) a) => @reverse m (@SAWCoreVectorsAsCoqVectors.Vec n a) (@split m n a v).
 
-Definition msb : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n) @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool :=
-  fun (n : @SAWCoreScaffolding.Nat) (v : @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n) @SAWCoreScaffolding.Bool) => @SAWCorePrelude.sawAt (@SAWCoreScaffolding.Succ n) @SAWCoreScaffolding.Bool v 0.
+Definition msb : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n) (@SAWCoreScaffolding.Bool) -> @SAWCoreScaffolding.Bool :=
+  fun (n : @SAWCoreScaffolding.Nat) (v : @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n) (@SAWCoreScaffolding.Bool)) => @SAWCorePrelude.sawAt (@SAWCoreScaffolding.Succ n) (@SAWCoreScaffolding.Bool) v 0.
 
-Definition lsb : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n) @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool :=
-  fun (n : @SAWCoreScaffolding.Nat) (v : @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n) @SAWCoreScaffolding.Bool) => @SAWCorePrelude.sawAt (@SAWCoreScaffolding.Succ n) @SAWCoreScaffolding.Bool v n.
+Definition lsb : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n) (@SAWCoreScaffolding.Bool) -> @SAWCoreScaffolding.Bool :=
+  fun (n : @SAWCoreScaffolding.Nat) (v : @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n) (@SAWCoreScaffolding.Bool)) => @SAWCorePrelude.sawAt (@SAWCoreScaffolding.Succ n) (@SAWCoreScaffolding.Bool) v n.
 
 (* Prelude.bvNat was skipped *)
 
 (* Prelude.bvToNat was skipped *)
 
-Definition bvAt : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), forall (w : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n a -> @SAWCoreVectorsAsCoqVectors.Vec w @SAWCoreScaffolding.Bool -> a :=
-  fun (n : @SAWCoreScaffolding.Nat) (a : Type) (w : @SAWCoreScaffolding.Nat) (xs : @SAWCoreVectorsAsCoqVectors.Vec n a) (i : @SAWCoreVectorsAsCoqVectors.Vec w @SAWCoreScaffolding.Bool) => @SAWCorePrelude.sawAt n a xs (@SAWCoreVectorsAsCoqVectors.bvToNat w i).
+Definition bvAt : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), forall (w : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n a -> @SAWCoreVectorsAsCoqVectors.Vec w (@SAWCoreScaffolding.Bool) -> a :=
+  fun (n : @SAWCoreScaffolding.Nat) (a : Type) (w : @SAWCoreScaffolding.Nat) (xs : @SAWCoreVectorsAsCoqVectors.Vec n a) (i : @SAWCoreVectorsAsCoqVectors.Vec w (@SAWCoreScaffolding.Bool)) => @SAWCorePrelude.sawAt n a xs (@SAWCoreVectorsAsCoqVectors.bvToNat w i).
 
-Definition bvUpd : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), forall (w : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n a -> @SAWCoreVectorsAsCoqVectors.Vec w @SAWCoreScaffolding.Bool -> a -> @SAWCoreVectorsAsCoqVectors.Vec n a :=
-  fun (n : @SAWCoreScaffolding.Nat) (a : Type) (w : @SAWCoreScaffolding.Nat) (xs : @SAWCoreVectorsAsCoqVectors.Vec n a) (i : @SAWCoreVectorsAsCoqVectors.Vec w @SAWCoreScaffolding.Bool) (y : a) => @upd n a xs (@SAWCoreVectorsAsCoqVectors.bvToNat w i) y.
+Definition bvUpd : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), forall (w : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n a -> @SAWCoreVectorsAsCoqVectors.Vec w (@SAWCoreScaffolding.Bool) -> a -> @SAWCoreVectorsAsCoqVectors.Vec n a :=
+  fun (n : @SAWCoreScaffolding.Nat) (a : Type) (w : @SAWCoreScaffolding.Nat) (xs : @SAWCoreVectorsAsCoqVectors.Vec n a) (i : @SAWCoreVectorsAsCoqVectors.Vec w (@SAWCoreScaffolding.Bool)) (y : a) => @upd n a xs (@SAWCoreVectorsAsCoqVectors.bvToNat w i) y.
 
-Definition bvRotateL : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), forall (w : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n a -> @SAWCoreVectorsAsCoqVectors.Vec w @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n a :=
-  fun (n : @SAWCoreScaffolding.Nat) (a : Type) (w : @SAWCoreScaffolding.Nat) (xs : @SAWCoreVectorsAsCoqVectors.Vec n a) (i : @SAWCoreVectorsAsCoqVectors.Vec w @SAWCoreScaffolding.Bool) => @SAWCoreVectorsAsCoqVectors.rotateL n a xs (@SAWCoreVectorsAsCoqVectors.bvToNat w i).
+Definition bvRotateL : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), forall (w : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n a -> @SAWCoreVectorsAsCoqVectors.Vec w (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n a :=
+  fun (n : @SAWCoreScaffolding.Nat) (a : Type) (w : @SAWCoreScaffolding.Nat) (xs : @SAWCoreVectorsAsCoqVectors.Vec n a) (i : @SAWCoreVectorsAsCoqVectors.Vec w (@SAWCoreScaffolding.Bool)) => @SAWCoreVectorsAsCoqVectors.rotateL n a xs (@SAWCoreVectorsAsCoqVectors.bvToNat w i).
 
-Definition bvRotateR : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), forall (w : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n a -> @SAWCoreVectorsAsCoqVectors.Vec w @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n a :=
-  fun (n : @SAWCoreScaffolding.Nat) (a : Type) (w : @SAWCoreScaffolding.Nat) (xs : @SAWCoreVectorsAsCoqVectors.Vec n a) (i : @SAWCoreVectorsAsCoqVectors.Vec w @SAWCoreScaffolding.Bool) => @SAWCoreVectorsAsCoqVectors.rotateR n a xs (@SAWCoreVectorsAsCoqVectors.bvToNat w i).
+Definition bvRotateR : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), forall (w : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n a -> @SAWCoreVectorsAsCoqVectors.Vec w (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n a :=
+  fun (n : @SAWCoreScaffolding.Nat) (a : Type) (w : @SAWCoreScaffolding.Nat) (xs : @SAWCoreVectorsAsCoqVectors.Vec n a) (i : @SAWCoreVectorsAsCoqVectors.Vec w (@SAWCoreScaffolding.Bool)) => @SAWCoreVectorsAsCoqVectors.rotateR n a xs (@SAWCoreVectorsAsCoqVectors.bvToNat w i).
 
-Definition bvShiftL : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), forall (w : @SAWCoreScaffolding.Nat), a -> @SAWCoreVectorsAsCoqVectors.Vec n a -> @SAWCoreVectorsAsCoqVectors.Vec w @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n a :=
-  fun (n : @SAWCoreScaffolding.Nat) (a : Type) (w : @SAWCoreScaffolding.Nat) (z : a) (xs : @SAWCoreVectorsAsCoqVectors.Vec n a) (i : @SAWCoreVectorsAsCoqVectors.Vec w @SAWCoreScaffolding.Bool) => @SAWCoreVectorsAsCoqVectors.shiftL n a z xs (@SAWCoreVectorsAsCoqVectors.bvToNat w i).
+Definition bvShiftL : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), forall (w : @SAWCoreScaffolding.Nat), a -> @SAWCoreVectorsAsCoqVectors.Vec n a -> @SAWCoreVectorsAsCoqVectors.Vec w (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n a :=
+  fun (n : @SAWCoreScaffolding.Nat) (a : Type) (w : @SAWCoreScaffolding.Nat) (z : a) (xs : @SAWCoreVectorsAsCoqVectors.Vec n a) (i : @SAWCoreVectorsAsCoqVectors.Vec w (@SAWCoreScaffolding.Bool)) => @SAWCoreVectorsAsCoqVectors.shiftL n a z xs (@SAWCoreVectorsAsCoqVectors.bvToNat w i).
 
-Definition bvShiftR : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), forall (w : @SAWCoreScaffolding.Nat), a -> @SAWCoreVectorsAsCoqVectors.Vec n a -> @SAWCoreVectorsAsCoqVectors.Vec w @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n a :=
-  fun (n : @SAWCoreScaffolding.Nat) (a : Type) (w : @SAWCoreScaffolding.Nat) (z : a) (xs : @SAWCoreVectorsAsCoqVectors.Vec n a) (i : @SAWCoreVectorsAsCoqVectors.Vec w @SAWCoreScaffolding.Bool) => @SAWCoreVectorsAsCoqVectors.shiftR n a z xs (@SAWCoreVectorsAsCoqVectors.bvToNat w i).
+Definition bvShiftR : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), forall (w : @SAWCoreScaffolding.Nat), a -> @SAWCoreVectorsAsCoqVectors.Vec n a -> @SAWCoreVectorsAsCoqVectors.Vec w (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n a :=
+  fun (n : @SAWCoreScaffolding.Nat) (a : Type) (w : @SAWCoreScaffolding.Nat) (z : a) (xs : @SAWCoreVectorsAsCoqVectors.Vec n a) (i : @SAWCoreVectorsAsCoqVectors.Vec w (@SAWCoreScaffolding.Bool)) => @SAWCoreVectorsAsCoqVectors.shiftR n a z xs (@SAWCoreVectorsAsCoqVectors.bvToNat w i).
 
 (* Prelude.bvAdd was skipped *)
 
@@ -584,14 +607,14 @@ Definition bvShiftR : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), f
 
 (* Prelude.bvForall was skipped *)
 
-Definition bvCarry : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool :=
-  fun (n : @SAWCoreScaffolding.Nat) (x : @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) (y : @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) => @SAWCoreVectorsAsCoqVectors.bvult n (@SAWCoreVectorsAsCoqVectors.bvAdd n x y) x.
+Definition bvCarry : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> @SAWCoreScaffolding.Bool :=
+  fun (n : @SAWCoreScaffolding.Nat) (x : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) (y : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) => @SAWCoreVectorsAsCoqVectors.bvult n (@SAWCoreVectorsAsCoqVectors.bvAdd n x y) x.
 
-Definition bvSCarry : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n) @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n) @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool :=
-  fun (n : @SAWCoreScaffolding.Nat) (x : @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n) @SAWCoreScaffolding.Bool) (y : @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n) @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.and (@SAWCoreScaffolding.boolEq (@msb n x) (@msb n y)) (@SAWCoreScaffolding.xor (@msb n x) (@msb n (@SAWCoreVectorsAsCoqVectors.bvAdd (@SAWCoreScaffolding.Succ n) x y))).
+Definition bvSCarry : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n) (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n) (@SAWCoreScaffolding.Bool) -> @SAWCoreScaffolding.Bool :=
+  fun (n : @SAWCoreScaffolding.Nat) (x : @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n) (@SAWCoreScaffolding.Bool)) (y : @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n) (@SAWCoreScaffolding.Bool)) => @SAWCoreScaffolding.and (@SAWCoreScaffolding.boolEq (@msb n x) (@msb n y)) (@SAWCoreScaffolding.xor (@msb n x) (@msb n (@SAWCoreVectorsAsCoqVectors.bvAdd (@SAWCoreScaffolding.Succ n) x y))).
 
-Definition bvAddWithCarry : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> prod @SAWCoreScaffolding.Bool (@SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) :=
-  fun (n : @SAWCoreScaffolding.Nat) (x : @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) (y : @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) => pair (@bvCarry n x y) (@SAWCoreVectorsAsCoqVectors.bvAdd n x y).
+Definition bvAddWithCarry : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> prod (@SAWCoreScaffolding.Bool) (@SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) :=
+  fun (n : @SAWCoreScaffolding.Nat) (x : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) (y : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) => pair (@bvCarry n x y) (@SAWCoreVectorsAsCoqVectors.bvAdd n x y).
 
 (* Prelude.bvAddZeroL was skipped *)
 
@@ -600,6 +623,9 @@ Definition bvAddWithCarry : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVector
 (* Prelude.bvNeg was skipped *)
 
 (* Prelude.bvSub was skipped *)
+
+Definition bvSBorrow : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n) (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n) (@SAWCoreScaffolding.Bool) -> @SAWCoreScaffolding.Bool :=
+  fun (n : @SAWCoreScaffolding.Nat) (x : @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n) (@SAWCoreScaffolding.Bool)) (y : @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n) (@SAWCoreScaffolding.Bool)) => @SAWCoreScaffolding.and (@SAWCoreScaffolding.xor (@msb n x) (@msb n y)) (@SAWCoreScaffolding.xor (@msb n x) (@msb n (@SAWCoreVectorsAsCoqVectors.bvSub (@SAWCoreScaffolding.Succ n) x y))).
 
 (* Prelude.bvMul was skipped *)
 
@@ -623,54 +649,48 @@ Definition bvAddWithCarry : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVector
 
 (* Prelude.bvShiftR_bvShr was skipped *)
 
-Definition bvZipWith : (@SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) -> forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool :=
-  @zipWith @SAWCoreScaffolding.Bool @SAWCoreScaffolding.Bool @SAWCoreScaffolding.Bool.
+Definition bvZipWith : (@SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool) -> forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) :=
+  @zipWith (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.Bool).
 
-Definition bvNot : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool :=
-  @map @SAWCoreScaffolding.Bool @SAWCoreScaffolding.Bool @SAWCoreScaffolding.not.
+Definition bvNot : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) :=
+  @map (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.not).
 
-Definition bvAnd : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool :=
-  @bvZipWith @SAWCoreScaffolding.and.
+Definition bvAnd : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) :=
+  @bvZipWith (@SAWCoreScaffolding.and).
 
-Definition bvOr : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool :=
-  @bvZipWith @SAWCoreScaffolding.or.
+Definition bvOr : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) :=
+  @bvZipWith (@SAWCoreScaffolding.or).
 
-Definition bvXor : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool :=
-  @bvZipWith @SAWCoreScaffolding.xor.
+Definition bvXor : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) :=
+  @bvZipWith (@SAWCoreScaffolding.xor).
 
-Definition bvEq : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool :=
-  fun (n : @SAWCoreScaffolding.Nat) (x : @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) (y : @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) => @vecEq n @SAWCoreScaffolding.Bool @SAWCoreScaffolding.boolEq x y.
+Definition bvEq : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> @SAWCoreScaffolding.Bool :=
+  fun (n : @SAWCoreScaffolding.Nat) (x : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) (y : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) => @vecEq n (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.boolEq) x y.
 
 (* Prelude.bvEq_refl was skipped *)
 
-(* Prelude.eq_bitvector was skipped *)
-
-(* Prelude.eq_VecBool was skipped *)
-
-(* Prelude.eq_VecVec was skipped *)
-
 (* Prelude.equalNat_bv was skipped *)
 
-Definition bvBool : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool :=
+Definition bvBool : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) :=
   fun (n : @SAWCoreScaffolding.Nat) (b : @SAWCoreScaffolding.Bool) => if b then @SAWCoreVectorsAsCoqVectors.bvNat n 1 else @SAWCoreVectorsAsCoqVectors.bvNat n 0.
 
-Definition bvNe : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool :=
-  fun (n : @SAWCoreScaffolding.Nat) (x : @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) (y : @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) => @SAWCoreScaffolding.not (@bvEq n x y).
+Definition bvNe : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> @SAWCoreScaffolding.Bool :=
+  fun (n : @SAWCoreScaffolding.Nat) (x : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) (y : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) => @SAWCoreScaffolding.not (@bvEq n x y).
 
-Definition bvNonzero : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Bool :=
-  fun (n : @SAWCoreScaffolding.Nat) (x : @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) => @bvNe n x (@SAWCoreVectorsAsCoqVectors.bvNat n 0).
+Definition bvNonzero : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> @SAWCoreScaffolding.Bool :=
+  fun (n : @SAWCoreScaffolding.Nat) (x : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) => @bvNe n x (@SAWCoreVectorsAsCoqVectors.bvNat n 0).
 
-Definition bvTrunc : forall (m : @SAWCoreScaffolding.Nat), forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec (@addNat m n) @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool :=
-  @drop @SAWCoreScaffolding.Bool.
+Definition bvTrunc : forall (m : @SAWCoreScaffolding.Nat), forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec (@addNat m n) (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) :=
+  @drop (@SAWCoreScaffolding.Bool).
 
-Definition bvUExt : forall (m : @SAWCoreScaffolding.Nat), forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec (@addNat m n) @SAWCoreScaffolding.Bool :=
-  fun (m : @SAWCoreScaffolding.Nat) (n : @SAWCoreScaffolding.Nat) (x : @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) => @append m n @SAWCoreScaffolding.Bool (@SAWCoreVectorsAsCoqVectors.bvNat m 0) x.
+Definition bvUExt : forall (m : @SAWCoreScaffolding.Nat), forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec (@addNat m n) (@SAWCoreScaffolding.Bool) :=
+  fun (m : @SAWCoreScaffolding.Nat) (n : @SAWCoreScaffolding.Nat) (x : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) => @append m n (@SAWCoreScaffolding.Bool) (@SAWCoreVectorsAsCoqVectors.bvNat m 0) x.
 
-Definition replicateBool : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool :=
+Definition replicateBool : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) :=
   fun (n : @SAWCoreScaffolding.Nat) (b : @SAWCoreScaffolding.Bool) => if b then @bvNot n (@SAWCoreVectorsAsCoqVectors.bvNat n 0) else @SAWCoreVectorsAsCoqVectors.bvNat n 0.
 
-Definition bvSExt : forall (m : @SAWCoreScaffolding.Nat), forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n) @SAWCoreScaffolding.Bool -> @SAWCoreVectorsAsCoqVectors.Vec (@addNat m (@SAWCoreScaffolding.Succ n)) @SAWCoreScaffolding.Bool :=
-  fun (m : @SAWCoreScaffolding.Nat) (n : @SAWCoreScaffolding.Nat) (x : @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n) @SAWCoreScaffolding.Bool) => @append m (@SAWCoreScaffolding.Succ n) @SAWCoreScaffolding.Bool (@replicateBool m (@msb n x)) x.
+Definition bvSExt : forall (m : @SAWCoreScaffolding.Nat), forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n) (@SAWCoreScaffolding.Bool) -> @SAWCoreVectorsAsCoqVectors.Vec (@addNat m (@SAWCoreScaffolding.Succ n)) (@SAWCoreScaffolding.Bool) :=
+  fun (m : @SAWCoreScaffolding.Nat) (n : @SAWCoreScaffolding.Nat) (x : @SAWCoreVectorsAsCoqVectors.Vec (@SAWCoreScaffolding.Succ n) (@SAWCoreScaffolding.Bool)) => @append m (@SAWCoreScaffolding.Succ n) (@SAWCoreScaffolding.Bool) (@replicateBool m (@msb n x)) x.
 
 Inductive Stream (a : Type) : Type :=
 | MkStream : (@SAWCoreScaffolding.Nat -> a) -> @Stream a
@@ -682,8 +702,8 @@ Definition Stream__rec : forall (a : Type), forall (p : @Stream a -> Type), (for
 Definition streamUpd : forall (a : Type), @Stream a -> @SAWCoreScaffolding.Nat -> a -> @Stream a :=
   fun (a : Type) (strm : @Stream a) (i : @SAWCoreScaffolding.Nat) (y : a) => @Stream__rec a (fun (strm' : @Stream a) => @Stream a) (fun (s : @SAWCoreScaffolding.Nat -> a) => @MkStream a (fun (j : @SAWCoreScaffolding.Nat) => if @equalNat i j then y else s j)) strm.
 
-Definition bvStreamUpd : forall (a : Type), forall (w : @SAWCoreScaffolding.Nat), @Stream a -> @SAWCoreVectorsAsCoqVectors.Vec w @SAWCoreScaffolding.Bool -> a -> @Stream a :=
-  fun (a : Type) (w : @SAWCoreScaffolding.Nat) (xs : @Stream a) (i : @SAWCoreVectorsAsCoqVectors.Vec w @SAWCoreScaffolding.Bool) (y : a) => @streamUpd a xs (@SAWCoreVectorsAsCoqVectors.bvToNat w i) y.
+Definition bvStreamUpd : forall (a : Type), forall (w : @SAWCoreScaffolding.Nat), @Stream a -> @SAWCoreVectorsAsCoqVectors.Vec w (@SAWCoreScaffolding.Bool) -> a -> @Stream a :=
+  fun (a : Type) (w : @SAWCoreScaffolding.Nat) (xs : @Stream a) (i : @SAWCoreVectorsAsCoqVectors.Vec w (@SAWCoreScaffolding.Bool)) (y : a) => @streamUpd a xs (@SAWCoreVectorsAsCoqVectors.bvToNat w i) y.
 
 Definition streamGet : forall (a : Type), @Stream a -> @SAWCoreScaffolding.Nat -> a :=
   fun (a : Type) (strm : @Stream a) (i : @SAWCoreScaffolding.Nat) => @Stream__rec a (fun (strm' : @Stream a) => a) (fun (s : @SAWCoreScaffolding.Nat -> a) => s i) strm.
@@ -748,9 +768,9 @@ Definition streamShiftR : forall (a : Type), a -> @Stream a -> @SAWCoreScaffoldi
 
 (* Prelude.natToInt was skipped *)
 
-Axiom intToBv : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreScaffolding.Integer -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool .
+(* Prelude.intToBv was skipped *)
 
-Axiom bvToInt : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> @SAWCoreScaffolding.Integer .
+(* Prelude.bvToInt was skipped *)
 
 (* Prelude.sbvToInt was skipped *)
 
@@ -773,8 +793,8 @@ Axiom bvToInt : forall (n : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVector
 Definition updNatFun : forall (a : Type), (@SAWCoreScaffolding.Nat -> a) -> @SAWCoreScaffolding.Nat -> a -> @SAWCoreScaffolding.Nat -> a :=
   fun (a : Type) (f : @SAWCoreScaffolding.Nat -> a) (i : @SAWCoreScaffolding.Nat) (v : a) (x : @SAWCoreScaffolding.Nat) => if @equalNat i x then v else f x.
 
-Definition updBvFun : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), (@SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> a) -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> a -> @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> a :=
-  fun (n : @SAWCoreScaffolding.Nat) (a : Type) (f : @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool -> a) (i : @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) (v : a) (x : @SAWCoreVectorsAsCoqVectors.Vec n @SAWCoreScaffolding.Bool) => if @bvEq n i x then v else f x.
+Definition updBvFun : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), (@SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> a) -> @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> a -> @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> a :=
+  fun (n : @SAWCoreScaffolding.Nat) (a : Type) (f : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool) -> a) (i : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) (v : a) (x : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) => if @bvEq n i x then v else f x.
 
 (* Prelude.Float was skipped *)
 
@@ -783,6 +803,60 @@ Definition updBvFun : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), (
 (* Prelude.Double was skipped *)
 
 (* Prelude.mkDouble was skipped *)
+
+(* Prelude.Sigma was skipped *)
+
+(* Prelude.Sigma__rec was skipped *)
+
+(* Prelude.Sigma_proj1 was skipped *)
+
+(* Prelude.Sigma_proj2 was skipped *)
+
+(* Prelude.List was skipped *)
+
+(* Prelude.List__rec was skipped *)
+
+Definition unfoldList : forall (a : Type), @Datatypes.list a -> @Either unit (prod a (prod (@Datatypes.list a) unit)) :=
+  fun (a : Type) (l : @Datatypes.list a) => @Datatypes.list_rect a (fun (_1 : @Datatypes.list a) => @Either unit (prod a (prod (@Datatypes.list a) unit))) (@Left unit (prod a (prod (@Datatypes.list a) unit)) tt) (fun (x : a) (l1 : @Datatypes.list a) (_1 : @Either unit (prod a (prod (@Datatypes.list a) unit))) => @Right unit (prod a (prod (@Datatypes.list a) unit)) (pair x (pair l1 tt))) l.
+
+Definition foldList : forall (a : Type), @Either unit (prod a (prod (@Datatypes.list a) unit)) -> @Datatypes.list a :=
+  fun (a : Type) => @either unit (prod a (prod (@Datatypes.list a) unit)) (@Datatypes.list a) (fun (_1 : unit) => @Datatypes.nil a) (fun (tup : prod a (prod (@Datatypes.list a) unit)) => @Datatypes.cons a (SAWCoreScaffolding.fst tup) (SAWCoreScaffolding.fst (SAWCoreScaffolding.snd tup))).
+
+Inductive W64List : Type :=
+| W64Nil : @W64List
+| W64Cons : @SAWCoreVectorsAsCoqVectors.Vec 64 (@SAWCoreScaffolding.Bool) -> @W64List -> @W64List
+.
+
+Definition unfoldedW64List : Type :=
+  @Either unit (prod (@sigT (@SAWCoreVectorsAsCoqVectors.Vec 64 (@SAWCoreScaffolding.Bool)) (fun (_1 : @SAWCoreVectorsAsCoqVectors.Vec 64 (@SAWCoreScaffolding.Bool)) => unit)) (prod (@W64List) unit)).
+
+Definition unfoldW64List : @W64List -> unfoldedW64List :=
+  fun (l : @W64List) => SAWCorePrelude.W64List_rect (fun (_1 : @W64List) => unfoldedW64List) (@Left unit (prod (@sigT (@SAWCoreVectorsAsCoqVectors.Vec 64 (@SAWCoreScaffolding.Bool)) (fun (_1 : @SAWCoreVectorsAsCoqVectors.Vec 64 (@SAWCoreScaffolding.Bool)) => unit)) (prod (@W64List) unit)) tt) (fun (bv : @SAWCoreVectorsAsCoqVectors.Vec 64 (@SAWCoreScaffolding.Bool)) (l' : @W64List) (_1 : @Either unit (prod (@sigT (@SAWCoreVectorsAsCoqVectors.Vec 64 (@SAWCoreScaffolding.Bool)) (fun (_1 : @SAWCoreVectorsAsCoqVectors.Vec 64 (@SAWCoreScaffolding.Bool)) => unit)) (prod (@W64List) unit))) => @Right unit (prod (@sigT (@SAWCoreVectorsAsCoqVectors.Vec 64 (@SAWCoreScaffolding.Bool)) (fun (_2 : @SAWCoreVectorsAsCoqVectors.Vec 64 (@SAWCoreScaffolding.Bool)) => unit)) (prod (@W64List) unit)) (pair (@existT (@SAWCoreVectorsAsCoqVectors.Vec 64 (@SAWCoreScaffolding.Bool)) (fun (_2 : @SAWCoreVectorsAsCoqVectors.Vec 64 (@SAWCoreScaffolding.Bool)) => unit) bv tt) (pair l' tt))) l.
+
+Definition foldW64List : unfoldedW64List -> @W64List :=
+  @either unit (prod (@sigT (@SAWCoreVectorsAsCoqVectors.Vec 64 (@SAWCoreScaffolding.Bool)) (fun (_1 : @SAWCoreVectorsAsCoqVectors.Vec 64 (@SAWCoreScaffolding.Bool)) => unit)) (prod (@W64List) unit)) (@W64List) (fun (_1 : unit) => @W64Nil) (fun (bv_l : prod (@sigT (@SAWCoreVectorsAsCoqVectors.Vec 64 (@SAWCoreScaffolding.Bool)) (fun (_1 : @SAWCoreVectorsAsCoqVectors.Vec 64 (@SAWCoreScaffolding.Bool)) => unit)) (prod (@W64List) unit)) => @W64Cons (@projT1 (@SAWCoreVectorsAsCoqVectors.Vec 64 (@SAWCoreScaffolding.Bool)) (fun (_1 : @SAWCoreVectorsAsCoqVectors.Vec 64 (@SAWCoreScaffolding.Bool)) => unit) (SAWCoreScaffolding.fst bv_l)) (SAWCoreScaffolding.fst (SAWCoreScaffolding.snd bv_l))).
+
+Axiom bvEqWithProof : forall (n : @SAWCoreScaffolding.Nat), forall (v1 : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)), forall (v2 : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)), @Maybe (@SAWCoreScaffolding.Eq (@SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) v1 v2) .
+
+Definition bvultWithProof : forall (n : @SAWCoreScaffolding.Nat), forall (v1 : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)), forall (v2 : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)), @Maybe (@SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreVectorsAsCoqVectors.bvult n v1 v2) (@SAWCoreScaffolding.true)) :=
+  fun (n : @SAWCoreScaffolding.Nat) (v1 : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) (v2 : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @Maybe (@SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) b (@SAWCoreScaffolding.true))) (@SAWCoreVectorsAsCoqVectors.bvult n v1 v2) (@Just (@SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.true) (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.Refl (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.true))) (@Nothing (@SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.false) (@SAWCoreScaffolding.true))).
+
+Definition bvuleWithProof : forall (n : @SAWCoreScaffolding.Nat), forall (v1 : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)), forall (v2 : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)), @Maybe (@SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreVectorsAsCoqVectors.bvule n v1 v2) (@SAWCoreScaffolding.true)) :=
+  fun (n : @SAWCoreScaffolding.Nat) (v1 : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) (v2 : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) => @SAWCoreScaffolding.iteDep (fun (b : @SAWCoreScaffolding.Bool) => @Maybe (@SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) b (@SAWCoreScaffolding.true))) (@SAWCoreVectorsAsCoqVectors.bvule n v1 v2) (@Just (@SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.true) (@SAWCoreScaffolding.true)) (@SAWCoreScaffolding.Refl (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.true))) (@Nothing (@SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreScaffolding.false) (@SAWCoreScaffolding.true))).
+
+Axiom bvEqToEqNat : forall (n : @SAWCoreScaffolding.Nat), forall (v1 : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)), forall (v2 : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)), @SAWCoreScaffolding.Eq (@SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)) v1 v2 -> let var__0   := forall (n1 : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n1 (@SAWCoreScaffolding.Bool) -> @SAWCoreScaffolding.Nat in
+  @eqNat (@SAWCoreVectorsAsCoqVectors.bvToNat n v1) (@SAWCoreVectorsAsCoqVectors.bvToNat n v2) .
+
+Axiom bvultToIsLtNat : forall (n : @SAWCoreScaffolding.Nat), forall (v1 : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)), forall (v2 : @SAWCoreVectorsAsCoqVectors.Vec n (@SAWCoreScaffolding.Bool)), @SAWCoreScaffolding.Eq (@SAWCoreScaffolding.Bool) (@SAWCoreVectorsAsCoqVectors.bvult n v1 v2) (@SAWCoreScaffolding.true) -> let var__0   := forall (n1 : @SAWCoreScaffolding.Nat), @SAWCoreVectorsAsCoqVectors.Vec n1 (@SAWCoreScaffolding.Bool) -> @SAWCoreScaffolding.Nat in
+  @IsLtNat (@SAWCoreVectorsAsCoqVectors.bvToNat n v1) (@SAWCoreVectorsAsCoqVectors.bvToNat n v2) .
+
+Axiom atWithProof : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), a -> @SAWCoreVectorsAsCoqVectors.Vec n a -> forall (i : @SAWCoreScaffolding.Nat), @IsLtNat i n -> a .
+
+Axiom updWithProof : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), @SAWCoreVectorsAsCoqVectors.Vec n a -> forall (i : @SAWCoreScaffolding.Nat), a -> @IsLtNat i n -> @SAWCoreVectorsAsCoqVectors.Vec n a .
+
+Axiom sliceWithProof : forall (a : Type), forall (n : @SAWCoreScaffolding.Nat), forall (off : @SAWCoreScaffolding.Nat), forall (len : @SAWCoreScaffolding.Nat), @IsLeNat (@addNat off len) n -> @SAWCoreVectorsAsCoqVectors.Vec n a -> @SAWCoreVectorsAsCoqVectors.Vec len a .
+
+Axiom updSliceWithProof : forall (a : Type), forall (n : @SAWCoreScaffolding.Nat), forall (off : @SAWCoreScaffolding.Nat), forall (len : @SAWCoreScaffolding.Nat), @IsLeNat (@addNat off len) n -> @SAWCoreVectorsAsCoqVectors.Vec n a -> @SAWCoreVectorsAsCoqVectors.Vec len a -> @SAWCoreVectorsAsCoqVectors.Vec n a .
 
 (* Prelude.CompM was skipped *)
 
@@ -796,19 +870,24 @@ Definition updBvFun : forall (n : @SAWCoreScaffolding.Nat), forall (a : Type), (
 
 (* Prelude.catchM was skipped *)
 
-Inductive InputOutputTypes : Type :=
-| TypesNil : @InputOutputTypes
-| TypesCons : Type -> Type -> @InputOutputTypes -> @InputOutputTypes
-.
+(* Prelude.fixM was skipped *)
 
-(* Prelude.letRecFuns was skipped *)
+(* Prelude.LetRecType was skipped *)
+
+(* Prelude.lrtToType was skipped *)
+
+(* Prelude.LetRecTypes was skipped *)
+
+(* Prelude.lrtPi was skipped *)
+
+(* Prelude.lrtTupleType was skipped *)
+
+(* Prelude.multiFixM was skipped *)
 
 (* Prelude.letRecM was skipped *)
 
 Definition letRecM1 : forall (a : Type), forall (b : Type), forall (c : Type), ((a -> CompM b) -> a -> CompM b) -> ((a -> CompM b) -> CompM c) -> CompM c :=
-  fun (a : Type) (b : Type) (c : Type) (fn : (a -> CompM b) -> a -> CompM b) (body : (a -> CompM b) -> CompM c) => @CompM.letRecM (@TypesCons a b @TypesNil) c (fun (funs : prod (a -> CompM b) unit) => pair (fn (SAWCoreScaffolding.fst funs)) tt) (fun (funs : prod (a -> CompM b) unit) => body (SAWCoreScaffolding.fst funs)).
-
-(* Prelude.fixM was skipped *)
+  fun (a : Type) (b : Type) (c : Type) (fn : (a -> CompM b) -> a -> CompM b) (body : (a -> CompM b) -> CompM c) => @CompM.letRecM (@CompM.LRT_Cons (@CompM.LRT_Fun a (fun (_1 : a) => @CompM.LRT_Ret b)) (@CompM.LRT_Nil)) c (fun (f : a -> CompM b) => pair (fn f) tt) (fun (f : a -> CompM b) => body f).
 
 (* Prelude.test_fun0 was skipped *)
 
@@ -831,6 +910,8 @@ Axiom arrayConstant : forall (a : Type), forall (b : Type), b -> @Array a b .
 Axiom arrayLookup : forall (a : Type), forall (b : Type), @Array a b -> a -> b .
 
 Axiom arrayUpdate : forall (a : Type), forall (b : Type), @Array a b -> a -> b -> @Array a b .
+
+Axiom arrayEq : forall (a : Type), forall (b : Type), @Array a b -> @Array a b -> @SAWCoreScaffolding.Bool .
 
 (* Prelude.bveq_sameL was skipped *)
 

--- a/saw-core/prelude/Prelude.sawcore
+++ b/saw-core/prelude/Prelude.sawcore
@@ -1114,7 +1114,12 @@ axiom bvAddZeroL : (n : Nat) -> (x : Vec n Bool) -> Eq (Vec n Bool) (bvAdd n (bv
 axiom bvAddZeroR : (n : Nat) -> (x : Vec n Bool) -> Eq (Vec n Bool) (bvAdd n x (bvNat n 0)) x;
 
 primitive bvNeg : (n : Nat) -> Vec n Bool -> Vec n Bool;
+
 primitive bvSub : (n : Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool;
+
+bvSBorrow : (n : Nat) -> Vec (Succ n) Bool -> Vec (Succ n) Bool -> Bool;
+bvSBorrow n x y = and (xor (msb n x) (msb n y)) (xor (msb n x) (msb n (bvSub (Succ n) x y)));
+
 primitive bvMul : (n : Nat) -> Vec n Bool -> Vec n Bool -> Vec n Bool;
 primitive bvLg2 : (n : Nat) -> Vec n Bool -> Vec n Bool;
 

--- a/saw-core/prelude/Prelude.sawcore
+++ b/saw-core/prelude/Prelude.sawcore
@@ -1426,6 +1426,56 @@ List__rec :
   (l : List a) -> P l;
 List__rec a P f1 f2 l = List#rec a P f1 f2 l;
 
+unfoldList : (a:sort 0) -> List a -> Either #() (a * List a * #());
+unfoldList a l =
+  List__rec a (\ (_:List a) -> Either #() (a * List a * #()))
+  (Left #() (a * List a * #()) ())
+  (\ (x:a) (l:List a) (_:Either #() (a * List a * #())) ->
+     Right #() (a * List a * #()) (x, l, ()))
+  l;
+
+foldList : (a:sort 0) -> Either #() (a * List a * #()) -> List a;
+foldList a =
+  either #() (a * List a * #()) (List a)
+         (\ (_ : #()) -> Nil a)
+         (\ (tup : (a * List a * #())) ->
+            Cons a tup.(1) tup.(2).(1));
+
+
+--------------------------------------------------------------------------------
+-- Lists of 64-bit words (for testing Heapster)
+
+data W64List : sort 0 where {
+  W64Nil : W64List;
+  W64Cons : Vec 64 Bool -> W64List -> W64List;
+}
+
+unfoldedW64List : sort 0;
+unfoldedW64List =
+  Either #()
+  (Sigma (Vec 64 Bool) (\ (_:Vec 64 Bool) -> #()) * W64List * #());
+
+unfoldW64List : W64List -> unfoldedW64List;
+unfoldW64List l =
+  W64List#rec (\ (_:W64List) -> unfoldedW64List)
+  (Left #() (Sigma (Vec 64 Bool) (\ (_:Vec 64 Bool) -> #()) * W64List * #()) ())
+  (\ (bv:Vec 64 Bool) (l':W64List) (_:unfoldedW64List) ->
+     Right #() (Sigma (Vec 64 Bool) (\ (_:Vec 64 Bool) -> #()) * W64List * #())
+               (exists (Vec 64 Bool) (\ (_:Vec 64 Bool) -> #()) bv (),
+                l', ()))
+  l;
+
+foldW64List : unfoldedW64List -> W64List;
+foldW64List =
+  either #() (Sigma (Vec 64 Bool) (\ (_:Vec 64 Bool) -> #()) * W64List * #())
+         W64List
+         (\ (_:#()) -> W64Nil)
+         (\ (bv_l:(Sigma (Vec 64 Bool) (\ (_:Vec 64 Bool) -> #())
+                   * W64List * #())) ->
+            W64Cons (Sigma_proj1 (Vec 64 Bool)
+                                 (\ (_:Vec 64 Bool) -> #()) bv_l.(1))
+                    bv_l.(2).(1));
+
 
 --------------------------------------------------------------------------------
 -- Vector operations with built-in casts of their resulting lengths

--- a/saw-core/prelude/Prelude.sawcore
+++ b/saw-core/prelude/Prelude.sawcore
@@ -1413,47 +1413,204 @@ primitive errorM : (a:sort 0) -> CompM a;
 -- run the second computation
 primitive catchM : (a:sort 0) -> CompM a -> CompM a -> CompM a;
 
--- Lists of input and output types for letRecM
-data InputOutputTypes : sort 1 where {
-  TypesNil : InputOutputTypes;
-  TypesCons : sort 0 -> sort 0 -> InputOutputTypes -> InputOutputTypes;
+-- We can define fixM as let rec f x = ... in f
+primitive fixM : (a:sort 0) -> (b:a -> sort 0) ->
+                 (((x:a) -> CompM (b x)) -> ((x:a) -> CompM (b x))) ->
+                 (x:a) -> CompM (b x);
+-- fixM a b fn x = letRecM1 a b b fn (\ (f:a -> CompM b) -> f x);
+
+-- A representation of the type (x1:A1) -> ... -> (xn:An) -> CompM (B x1 ... xn)
+data LetRecType : sort 1 where {
+  LRT_Ret : sort 0 -> LetRecType;
+  LRT_Fun : (a:sort 0) -> (a -> LetRecType) -> LetRecType;
 }
 
--- Compute the type of a nested tuple of monadic functions, by converting list
--- [(a1,b1),(a2,b2),...] into ((a1 -> CompM b1), ((a2 -> CompM b2), ...))
-letRecFuns : InputOutputTypes -> sort 0;
-letRecFuns tps =
-  InputOutputTypes#rec
-    (\ (tps:InputOutputTypes) -> sort 0)
-    #()
-    (\ (a b:sort 0) (_:InputOutputTypes) (fun_tp:sort 0) ->
-       #((a -> CompM b), fun_tp))
-    tps;
+-- Convert a LetRecType to the type it represents
+lrtToType : LetRecType -> sort 0;
+lrtToType lrt =
+  LetRecType#rec
+  (\ (lrt:LetRecType) -> sort 0)
+  (\ (b:sort 0) -> CompM b)
+  (\ (a:sort 0) (_: a -> LetRecType) (b: a -> sort 0) -> (x:a) -> b x)
+  lrt;
+
+-- NOTE: the following are needed to define multiFixM instead of making it a
+-- primitive, which we are keeping commented here in case that is needed
+{-
+-- Convert the argument types of a LetRecType to their "flat" version of the
+-- form { x1:A1 & { x2:A2 & ... { xn:An & unit } ... }}
+lrtToFlatArgs : LetRecType -> sort 0;
+lrtToFlatArgs lrt =
+  LetRecType#rec
+  (\ (lrt:LetRecType) -> sort 0)
+  (\ (_:sort 0) -> #())
+  (\ (a:sort 0) (_: a -> LetRecType) (b: a -> sort 0) -> Sigma a b)
+  lrt;
+
+-- Get the dependent return type fun (args:lrtToFlatArgs) => B x.1 ... of a
+-- LetRecType in terms of the flat arguments
+lrtToFlatRet : (lrt:LetRecType) -> lrtToFlatArgs lrt -> sort 0;
+lrtToFlatRet lrt =
+  LetRecType#rec
+  (\ (lrt:LetRecType) -> lrtToFlatArgs lrt -> sort 0)
+  (\ (a:sort 0) (_:#()) -> a)
+  (\ (a:sort 0) (lrtF: a -> LetRecType)
+      (retF: (x:a) -> lrtToFlatArgs (lrtF x) -> sort 0)
+      (args: Sigma a (\ (x:a) -> lrtToFlatArgs (lrtF x))) ->
+      retF (Sigma_proj1 a (\ (x:a) -> lrtToFlatArgs (lrtF x)) args)
+           (Sigma_proj2 a (\ (x:a) -> lrtToFlatArgs (lrtF x)) args))
+  lrt;
+
+-- Extract out the "flat" version of a LetRecType
+lrtToFlatType : LetRecType -> sort 0;
+lrtToFlatType lrt = (args:lrtToFlatArgs lrt) -> CompM (lrtToFlatRet lrt args);
+
+
+-- "Flatten" a function described by a LetRecType
+flattenLRTFun : (lrt:LetRecType) -> lrtToType lrt -> lrtToFlatType lrt;
+flattenLRTFun lrt =
+  LetRecType#rec
+  (\ (lrt:LetRecType) -> lrtToType lrt -> lrtToFlatType lrt)
+  (\ (b:sort 0) (f:CompM b) (_:#()) -> f)
+  (\ (a:sort 0) (lrtF: a -> LetRecType)
+     (restF: (x:a) -> lrtToType (lrtF x) -> lrtToFlatType (lrtF x))
+     (f: lrtToType (LRT_Fun a lrtF)) (args:lrtToFlatArgs (LRT_Fun a lrtF)) ->
+     restF (Sigma_proj1 a (\ (x:a) -> lrtToFlatArgs (lrtF x)) args)
+           (f (Sigma_proj1 a (\ (x:a) -> lrtToFlatArgs (lrtF x)) args))
+           (Sigma_proj2 a (\ (x:a) -> lrtToFlatArgs (lrtF x)) args))
+  lrt;
+
+-- "Unflatten" a function described by a LetRecType
+unflattenLRTFun : (lrt:LetRecType) -> lrtToFlatType lrt -> lrtToType lrt;
+unflattenLRTFun lrt =
+  LetRecType#rec
+  (\ (lrt:LetRecType) -> lrtToFlatType lrt -> lrtToType lrt)
+  (\ (b:sort 0) (f:#() -> CompM b) -> f ())
+  (\ (a:sort 0) (lrtF: a -> LetRecType)
+     (restF: (x:a) -> lrtToFlatType (lrtF x) -> lrtToType (lrtF x))
+     (f: lrtToFlatType (LRT_Fun a lrtF)) (x:a) ->
+     restF x (\ (args:lrtToFlatArgs (lrtF x)) ->
+                f (exists a (\ (y:a) -> lrtToFlatArgs (lrtF y)) x args)))
+  lrt;
+-}
+
+-- A list of 0 or more LetRecTypes
+data LetRecTypes : sort 1 where {
+  LRT_Nil : LetRecTypes;
+  LRT_Cons : LetRecType -> LetRecTypes -> LetRecTypes;
+}
+
+-- Build the function type lrtToType lrt1 -> ... -> lrtToType lrtn -> b from the
+-- LetRecTypes list [lrt1, ..., lrtn]
+lrtPi : LetRecTypes -> sort 0 -> sort 0;
+lrtPi lrts b =
+  LetRecTypes#rec
+  (\ (lrts:LetRecTypes) -> sort 0)
+  b
+  (\ (lrt:LetRecType) (_:LetRecTypes) (rest:sort 0) -> lrtToType lrt -> rest)
+  lrts;
+
+-- Build the product type (lrtToType lrt1, ..., lrtToType lrtn) from the
+-- LetRecTypes list [lrt1, ..., lrtn]
+lrtTupleType : LetRecTypes -> sort 0;
+lrtTupleType lrts =
+  LetRecTypes#rec
+  (\ (lrts:LetRecTypes) -> sort 0)
+  #()
+  (\ (lrt:LetRecType) (_:LetRecTypes) (rest:sort 0) -> #(lrtToType lrt, rest))
+  lrts;
+
+-- NOTE: the following are needed to define multiFixM instead of making it a
+-- primitive, which we are keeping commented here in case that is needed
+{-
+-- Construct a multi-arity function of type lrtPi lrts B from one of type
+-- lrtTupleType lrts -> B
+lrtLambda : (lrts:LetRecTypes) -> (B:sort 0) -> (lrtTupleType lrts -> B) -> lrtPi lrts B;
+lrtLambda top_lrts B =
+  LetRecTypes#rec
+  (\ (lrts:LetRecTypes) -> (lrtTupleType lrts -> B) -> lrtPi lrts B)
+  (\ (F:#() -> B) -> F ())
+  (\ (lrt:LetRecType) (lrts:LetRecTypes)
+     (rest:(lrtTupleType lrts -> B) -> lrtPi lrts B)
+     (F:lrtTupleType (LRT_Cons lrt lrts) -> B) (f:lrtToType lrt) ->
+    rest (\ (fs:lrtTupleType lrts) -> F (f, fs)))
+  top_lrts;
+
+-- Apply a multi-arity function of type lrtPi lrts B to an lrtTupleType lrts
+lrtApply : (lrts:LetRecTypes) -> (B:sort 0) -> lrtPi lrts B -> lrtTupleType lrts -> B;
+lrtApply top_lrts B =
+  LetRecTypes#rec
+  (\ (lrts:LetRecTypes) -> lrtPi lrts B -> lrtTupleType lrts -> B)
+  (\ (F:B) (_:#()) -> F)
+  (\ (lrt:LetRecType) (lrts:LetRecTypes) (rest:lrtPi lrts B -> lrtTupleType lrts -> B)
+      (F:lrtPi (LRT_Cons lrt lrts) B) (fs:lrtTupleType (LRT_Cons lrt lrts)) ->
+    rest (F fs.(1)) fs.(2))
+  top_lrts;
+
+-- Build a multi-argument fixed-point of type A1 -> ... -> An -> CompM B
+multiArgFixM : (lrt:LetRecType) -> (lrtToType lrt -> lrtToType lrt) ->
+               lrtToType lrt;
+multiArgFixM lrt F =
+  unflattenLRTFun
+    lrt
+    (fixM (lrtToFlatArgs lrt) (lrtToFlatRet lrt)
+          (\ (f:lrtToFlatType lrt) ->
+             flattenLRTFun lrt (F (unflattenLRTFun lrt f))));
+
+-- Construct a mutual fixed-point over tuples of LRT functions
+multiTupleFixM : (lrts:LetRecTypes) -> (lrtTupleType lrts -> lrtTupleType lrts) ->
+                 lrtTupleType lrts;
+multiTupleFixM top_lrts =
+  LetRecTypes#rec
+  (\ (lrts:LetRecTypes) -> (lrtTupleType lrts -> lrtTupleType lrts) -> lrtTupleType lrts)
+  (\ (_:#() -> #()) -> ())
+  (\ (lrt:LetRecType) (lrts:LetRecTypes)
+     (restF: (lrtTupleType lrts -> lrtTupleType lrts) -> lrtTupleType lrts)
+     (F:lrtTupleType (LRT_Cons lrt lrts) -> lrtTupleType (LRT_Cons lrt lrts)) ->
+     (multiArgFixM lrt (\ (f:lrtToType lrt) ->
+                          (F (f, restF (\ (fs:lrtTupleType lrts) ->
+                                          (F (f, fs)).(2)))).(1)),
+      restF (\ (fs:lrtTupleType lrts) ->
+               (F (multiArgFixM lrt
+                     (\ (f:lrtToType lrt) ->
+                        (F (f, restF (\ (fs:lrtTupleType lrts) ->
+                                        (F (f, fs)).(2)))).(1)),
+                   fs)).(2))))
+  top_lrts;
+
+-- A nicer version of multiTupleFixM that abstracts the functions one at a time
+multiFixM : (lrts:LetRecTypes) -> lrtPi lrts (lrtTupleType lrts) ->
+            lrtTupleType lrts;
+multiFixM lrts F =
+  multiTupleFixM lrts (\ (fs:lrtTupleType lrts) -> lrtApply lrts (lrtTupleType lrts) F fs);
+
+-- A letrec construct for binding 0 or more mutually recursive functions
+letRecM : (lrts : LetRecTypes) -> (B:sort 0) -> lrtPi lrts (lrtTupleType lrts) ->
+          lrtPi lrts (CompM B) -> CompM B;
+letRecM lrts B F body = lrtApply lrts (CompM B) body (multiFixM lrts F);
+-}
+
+-- Construct a fixed-point for a tuple of mutually-recursive functions
+primitive multiFixM : (lrts:LetRecTypes) -> lrtPi lrts (lrtTupleType lrts) ->
+                      lrtTupleType lrts;
 
 -- This is like let rec in ML: letRecM defs body defines N recursive functions
 -- in terms of themselves using defs, and then passes them to body. We use this
 -- instead of the more standard fixM because it offers a more compact
 -- representation, and because fixM messes with functional extensionality by
 -- introducing an irreducible term at function type.
-primitive letRecM : (tps : InputOutputTypes) -> (b : sort 0) ->
-                    (letRecFuns tps -> letRecFuns tps) ->
-                    (letRecFuns tps -> CompM b) -> CompM b;
+primitive letRecM : (lrts : LetRecTypes) -> (b : sort 0) ->
+                    (lrtPi lrts (lrtTupleType lrts)) ->
+                    (lrtPi lrts (CompM b)) -> CompM b;
 
 -- This is let rec with exactly one binding
 letRecM1 : (a b c : sort 0) -> ((a -> CompM b) -> (a -> CompM b)) ->
            ((a -> CompM b) -> CompM c) -> CompM c;
 letRecM1 a b c fn body =
   letRecM
-    (TypesCons a b TypesNil) c
-    (\ (funs:#((a -> CompM b), #())) -> (fn funs.1, ()))
-    (\ (funs:#((a -> CompM b), #())) -> body funs.1);
-
--- We can define fixM as let rec f x = ... in f
-fixM : (a b:sort 0) -> ((a -> CompM b) -> (a -> CompM b)) -> a -> CompM b;
-fixM a b f x =
-  letRecM (TypesCons a b TypesNil) b
-          (\ (funs:#((a -> CompM b), #())) -> (f funs.1, ()))
-          (\ (funs:#((a -> CompM b), #())) -> funs.1 x);
+    (LRT_Cons (LRT_Fun a (\ (_:a) -> LRT_Ret b)) LRT_Nil) c
+    (\ (f:a -> CompM b) -> (fn f, ()))
+    (\ (f:a -> CompM b) -> body f);
 
 
 -- Test computations
@@ -1487,11 +1644,12 @@ test_fun4 x =
 test_fun4 : Vec 64 Bool -> CompM (Vec 64 Bool);
 test_fun4 x =
   letRecM
-    (TypesCons (Vec 64 Bool) (Vec 64 Bool) TypesNil) (Vec 64 Bool)
-    (\ (funs:#((Vec 64 Bool -> CompM (Vec 64 Bool)), #())) ->
+    (LRT_Cons (Vec 64 Bool) (\ (_:Vec 64 Bool) -> LRT_Ret (Vec 64 Bool))
+     LRT_Nil)
+    (Vec 64 Bool)
+    (\ (f:(Vec 64 Bool -> CompM (Vec 64 Bool))) ->
       ((\ (y:Vec 64 Bool) -> returnM (Vec 64 Bool) (bvNat 64 0)), ()))
-    (\ (funs:#((Vec 64 Bool -> CompM (Vec 64 Bool)), #())) ->
-      funs.1 x);
+    (\ (f:(Vec 64 Bool -> CompM (Vec 64 Bool))) -> f x);
 -}
 
 -- let rec f = f in f x
@@ -1506,15 +1664,18 @@ test_fun5 x =
 test_fun6 : Vec 64 Bool -> CompM (Vec 64 Bool);
 test_fun6 x =
   letRecM
-    (TypesCons (Vec 64 Bool) (Vec 64 Bool)
-      (TypesCons (Vec 64 Bool) (Vec 64 Bool) TypesNil))
+    (LRT_Cons
+      (LRT_Fun (Vec 64 Bool) (\ (_:Vec 64 Bool) -> LRT_Ret (Vec 64 Bool)))
+      (LRT_Cons
+        (LRT_Fun (Vec 64 Bool) (\ (_:Vec 64 Bool) -> LRT_Ret (Vec 64 Bool)))
+        LRT_Nil))
     (Vec 64 Bool)
-    (\ (funs:#((Vec 64 Bool -> CompM (Vec 64 Bool)),
-                 #((Vec 64 Bool -> CompM (Vec 64 Bool)), #()))) ->
-      (funs.2, (funs.1, ())))
-    (\ (funs:#((Vec 64 Bool -> CompM (Vec 64 Bool)),
-                 #((Vec 64 Bool -> CompM (Vec 64 Bool)), #()))) ->
-      funs.1 x);
+    (\ (f1:(Vec 64 Bool -> CompM (Vec 64 Bool)))
+       (f2:(Vec 64 Bool -> CompM (Vec 64 Bool))) ->
+      (f2, (f1, ())))
+    (\ (f1:(Vec 64 Bool -> CompM (Vec 64 Bool)))
+       (f2:(Vec 64 Bool -> CompM (Vec 64 Bool))) ->
+      f1 x);
 
 --------------------------------------------------------------------------------
 -- SMT Array

--- a/saw-core/prelude/Prelude.sawcore
+++ b/saw-core/prelude/Prelude.sawcore
@@ -115,6 +115,7 @@ data Eq (t : sort 1) (x : t) : t -> Prop where {
     Refl : Eq t x x;
   }
 
+
 -- The eliminator for the Eq type at sort 1, assuming the usual parameter-index
 -- structure of the Eq type
 Eq__rec : (t : sort 1) -> (x : t) -> (p : (y : t) -> Eq t x y -> sort 1) ->
@@ -744,6 +745,32 @@ pred x = Nat_cases Nat Zero (\ (n:Nat) -> \ (m:Nat) -> n) x;
 eqNatPrec : (x y : Nat) -> eqNat (Succ x) (Succ y) -> eqNat x y;
 eqNatPrec x y eq' =
   eq_cong Nat (Succ x) (Succ y) eq' Nat pred;
+
+-- | Propositional less than or equal to; defined the same way as in Coq
+data IsLeNat (n:Nat) : Nat -> Prop where {
+  IsLeNat_base : IsLeNat n n;
+  IsLeNat_succ : (m:Nat) -> IsLeNat n m -> IsLeNat n (Succ m);
+}
+
+-- | m < n is defined as m+1 <= n (as in Coq)
+IsLtNat : Nat -> Nat -> Prop;
+IsLtNat m n = IsLeNat (Succ m) n;
+
+-- | Test if m < n or n <= m
+-- FIXME: implement this!
+primitive natCompareLe : (m n : Nat) -> Either (IsLtNat m n) (IsLeNat n m);
+
+-- | Test if m = n
+-- FIXME: implement this!
+primitive proveEqNat : (m n : Nat) -> Maybe (Eq Nat m n);
+
+-- | Try to prove x <= y (FIXME: implement this from natCompareLe!)
+primitive proveLeNat : (x y : Nat) -> Maybe (IsLeNat x y);
+
+-- | Try to prove x < y
+proveLtNat : (x y : Nat) -> Maybe (IsLtNat x y);
+proveLtNat x y = proveLeNat (Succ x) y;
+
 
 -- | Addition
 addNat : Nat -> Nat -> Nat;
@@ -1393,6 +1420,58 @@ List__rec :
   ((x : a) -> (l : List a) -> P l -> P (Cons a x l)) ->
   (l : List a) -> P l;
 List__rec a P f1 f2 l = List#rec a P f1 f2 l;
+
+
+--------------------------------------------------------------------------------
+-- Vector operations with built-in casts of their resulting lengths
+
+-- Decide equality on two bitvectors, returning a proof if they are equal
+primitive bvEqWithProof : (n : Nat) -> (v1 v2 : Vec n Bool) ->
+                          Maybe (Eq (Vec n Bool) v1 v2);
+
+-- Compare two bitvectors with bvult, returning a proof if bvult succeeds
+bvultWithProof : (n : Nat) -> (v1 v2 : Vec n Bool) ->
+                 Maybe (Eq Bool (bvult n v1 v2) True);
+bvultWithProof n v1 v2 =
+  iteDep (\ (b:Bool) -> Maybe (Eq Bool b True)) (bvult n v1 v2)
+         (Just (Eq Bool True True) (Refl Bool True))
+         (Nothing (Eq Bool False True));
+
+-- Compare two bitvectors with bvule, returning a proof if bvule succeeds
+bvuleWithProof : (n : Nat) -> (v1 v2 : Vec n Bool) ->
+                 Maybe (Eq Bool (bvule n v1 v2) True);
+bvuleWithProof n v1 v2 =
+  iteDep (\ (b:Bool) -> Maybe (Eq Bool b True)) (bvule n v1 v2)
+         (Just (Eq Bool True True) (Refl Bool True))
+         (Nothing (Eq Bool False True));
+
+-- Convert a proof of bitvector equality to one of Nat equality
+primitive bvEqToEqNat : (n : Nat) -> (v1 v2 : Vec n Bool) ->
+                        Eq (Vec n Bool) v1 v2 ->
+                        eqNat (bvToNat n v1) (bvToNat n v2);
+
+-- Convert a proof of bitvector less-than to one of Nat less-than
+primitive bvultToIsLtNat : (n : Nat) -> (v1 v2 : Vec n Bool) ->
+                           Eq Bool (bvult n v1 v2) True ->
+                           IsLtNat (bvToNat n v1) (bvToNat n v2);
+
+-- | Index a vector using a proof that the index is in the range of the vector
+-- FIXME: atWithDefault should maybe use this...?
+primitive atWithProof : (n : Nat) -> (a : sort 0) -> a -> Vec n a ->
+                        (i : Nat) -> IsLtNat i n -> a;
+
+-- Set the value at index i in a vector using a proof that i is in range
+primitive updWithProof : (n : Nat) -> (a : sort 0) -> Vec n a ->
+                         (i : Nat) -> a -> IsLtNat i n -> Vec n a;
+
+-- Take a slice of a vector using a proof that the slice is in range
+primitive sliceWithProof : (a : sort 0) -> (n off len : Nat) ->
+                           IsLeNat (addNat off len) n -> Vec n a -> Vec len a;
+
+-- Update a slice of a vector using a proof that the slice is in range
+primitive updSliceWithProof : (a : sort 0) -> (n off len : Nat) ->
+                              IsLeNat (addNat off len) n ->
+                              Vec n a -> Vec len a -> Vec n a;
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This PR pulls over only the changes to `Prelude.sawcore` from `wip-heapster` which are necessary to get `saw-core-coq`'s `make` to succeed. Specifically, they are:
- Replace `InputOutputTypes` with `LetRecTypes`
- Add `bvultWithProof`, `bvuleWithProof`, etc. (which depend on `EqP`, `IsLeNat`, etc.)
- Add `bvSBorrow`
- Add `unfoldList`, `foldList`, and `W64List`

I originally tried cherry-picking individual commits for the first two, but it got very tricky tracking all the changes (which go back to at least 2019) and figured it might not be worth the time. Instead, I ran `git checkout --patch wip-heapster Prelude.sawcore` and took only the relevant lines. If folks think we should preserve the original commit history, I'm happy to go back, do that digging, and re-make this PR.

Note that for all of these commits I had to replace `bitvector n` with `Vec n Bool`. We should also probably delete `EqP` since it's the same as `Eq` now (on `wip-heapster`, `Eq` is still in `sort 1`) but I figure maybe that's better suited for a different PR? I don't know @eddywestbrook's original reasoning for making it a separate type.

Resolves #174