### PR TITLE
workflow: faster workflow + lower bound on ocaml

### DIFF
--- a/.github/workflows/saw-core-coq-check-coq-files.yml
+++ b/.github/workflows/saw-core-coq-check-coq-files.yml
@@ -19,14 +19,14 @@ jobs:
     name: saw-core-coq - ${{ matrix.os }} - coq-${{ matrix.coq }}
     env:
       COQ_VERSION: ${{ matrix.coq }}
-      OCAML_VERSION: 4.11.0
+      # coq-bits claims to support < 4.10 only
+      OCAML_VERSION: 4.09.1
       COQBITS_VERSION: 1.0.0
     steps:
 
       - uses: actions/checkout@v2
 
-      - run: |
-          git config --global url.https://github.com/.insteadOf git@github.com:
+      - run: git config --global url.https://github.com/.insteadOf git@github.com:
 
       - name: Cache ~/.opam
         uses: actions/cache@v2
@@ -34,8 +34,11 @@ jobs:
           path: ~/.opam
           key: opam-${{ runner.os }}-${{ env.OCAML_VERSION }}-${{ env.COQ_VERSION }}-${{ env.COQBITS_VERSION }}
 
+      # NOTE: this action is marked as experimental by their author, but it is
+      # much faster than avsm@setup-ocaml@v1.  However, if this one ever becomes
+      # problematic, it should suffice to switch back to that version.
       - name: Set up ocaml and opam
-        uses: avsm/setup-ocaml@v1.1.5
+        uses: actions-ml/setup-ocaml@df8c831c6c1e49804621d6e09c4ab9235da31fb5
         with:
           ocaml-version: ${{ env.OCAML_VERSION }}
 


### PR DESCRIPTION
The old workflow was a little too lax on the Ocaml versioning, as our coq-bits
dependency is pretty old.

This also switches to a much faster setup-ocaml action, going down from 4+
minutes to < 2 minutes.  However, it is experimental, and time will tell
whether we stay happy with it.

I believe this should make the checks in #179 pass.