### PR TITLE
Proof conventions

### DIFF
--- a/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
+++ b/cryptol-saw-core/src/Verifier/SAW/Cryptol.hs
@@ -1565,7 +1565,7 @@ asCryptolTypeValue v =
 scCryptolType :: SharedContext -> Term -> IO C.Type
 scCryptolType sc t =
   do modmap <- scGetModuleMap sc
-     case SC.evalSharedTerm modmap Map.empty t of
+     case SC.evalSharedTerm modmap Map.empty Map.empty t of
        SC.TValue (asCryptolTypeValue -> Just ty) -> return ty
        _ -> panic "scCryptolType" ["scCryptolType: unsupported type " ++ showTerm t]
 

--- a/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
+++ b/saw-core-aig/src/Verifier/SAW/Simulator/BitBlast.hs
@@ -525,7 +525,7 @@ withBitBlastedTerm proxy sc addlPrims t c = AIG.withNewGraph proxy $ \be -> do
 asFiniteType :: SharedContext -> Term -> IO FiniteType
 asFiniteType sc t =
   scGetModuleMap sc >>= \modmap ->
-  case asFiniteTypeValue (Concrete.evalSharedTerm modmap Map.empty t) of
+  case asFiniteTypeValue (Concrete.evalSharedTerm modmap Map.empty Map.empty t) of
     Just ft -> return ft
     Nothing ->
       fail $ "asFiniteType: unsupported type " ++ scPrettyTerm defaultPPOpts t

--- a/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
+++ b/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
@@ -40,7 +40,6 @@
 
 module Verifier.SAW.Simulator.What4
   ( w4Solve
-  , w4SolveAny
   , w4SolveBasic
   , SymFnCache
   , TypedExpr(..)
@@ -82,6 +81,7 @@ import Numeric.Natural (Natural)
 import qualified Verifier.SAW.Recognizer as R
 import qualified Verifier.SAW.Simulator as Sim
 import qualified Verifier.SAW.Simulator.Prims as Prims
+import Verifier.SAW.SATQuery
 import Verifier.SAW.SharedTerm
 import Verifier.SAW.Simulator.Value
 import Verifier.SAW.FiniteValue (FirstOrderType(..), FirstOrderValue(..))
@@ -658,14 +658,16 @@ w4SolveBasic ::
   sym ->
   SharedContext ->
   Map Ident (SValue sym) {- ^ additional primitives -} ->
+  Map VarIndex (SValue sym) {- ^ bindings for ExtCns values -} ->
   IORef (SymFnCache sym) {- ^ cache for uninterpreted function symbols -} ->
   Set VarIndex {- ^ 'unints' Constants in this list are kept uninterpreted -} ->
   Term {- ^ term to simulate -} ->
   IO (SValue sym)
-w4SolveBasic sym sc addlPrims ref unintSet t =
+w4SolveBasic sym sc addlPrims ecMap ref unintSet t =
   do m <- scGetModuleMap sc
-     let extcns (EC ix nm ty) =
-             parseUninterpreted sym ref (mkUnintApp (Text.unpack (toShortName nm) ++ "_" ++ show ix)) ty
+     let extcns (EC ix nm ty)
+            | Just v <- Map.lookup ix ecMap = return v
+            | otherwise = parseUninterpreted sym ref (mkUnintApp (Text.unpack (toShortName nm) ++ "_" ++ show ix)) ty
      let uninterpreted ec
            | Set.member (ecVarIndex ec) unintSet = Just (extcns ec)
            | otherwise                           = Nothing
@@ -860,47 +862,24 @@ applyUnintApp sym app0 v =
 
 ------------------------------------------------------------
 
-w4SolveAny ::
-  forall sym. (IsSymExprBuilder sym) =>
-  sym -> SharedContext -> Map Ident (SValue sym) -> Set VarIndex -> Term ->
-  IO ([String], ([Maybe (Labeler sym)], SValue sym))
-w4SolveAny sym sc ps unintSet t = do
-  ref <- newIORef Map.empty
-  let eval = w4SolveBasic sym sc ps ref unintSet
-  ty <- eval =<< scTypeOf sc t
-
-  -- get the names of the arguments to the function
-  let argNames = map (Text.unpack . fst) (fst (R.asLambdaList t))
-  let moreNames = [ "var" ++ show (i :: Integer) | i <- [0 ..] ]
-
-  -- and their types
-  argTs <- argTypes (toTValue ty)
-
-  -- construct symbolic expressions for the variables
-  vars' <-
-    flip evalStateT 0 $
-    sequence (zipWith (newVarsForType sym ref) argTs (argNames ++ moreNames))
-
-  -- symbolically evaluate
-  bval <- eval t
-
-  -- apply and existentially quantify
-  let (bvs, vars) = unzip vars'
-  let vars'' = fmap ready vars
-  bval' <- applyAll bval vars''
-
-  return (argNames, (bvs, bval'))
-
-w4Solve ::
-  forall sym. (IsSymExprBuilder sym) =>
-  sym -> SharedContext -> Map Ident (SValue sym) -> Set VarIndex -> Term ->
-  IO ([String], ([Maybe (Labeler sym)], SBool sym))
-w4Solve sym sc ps unintSet t =
-  do (argNames, (bvs, bval)) <- w4SolveAny sym sc ps unintSet t
+w4Solve :: forall sym.
+  IsSymExprBuilder sym =>
+  sym ->
+  SharedContext ->
+  SATQuery ->
+  IO ([String], [Labeler sym], SBool sym)
+w4Solve sym sc satq =
+  do t <- satQueryAsTerm sc satq
+     varMap <- evalStateT (traverse (newVarFOT sym) (satVariables satq)) 0
+     let vars = Map.toList varMap
+     let argNames = map (Text.unpack . toShortName . ecName . fst) vars
+     let lbls     = map (fst . snd) vars
+     let varMap' = Map.fromList [ (ecVarIndex ec, v) | (ec, (_,v)) <- vars ]
+     ref <- newIORef Map.empty
+     bval <- w4SolveBasic sym sc mempty varMap' ref (satUninterp satq) t
      case bval of
-       VBool b -> return (argNames, (bvs, b))
+       VBool v -> return (argNames, lbls, v)
        _ -> fail $ "w4Solve: non-boolean result type. " ++ show bval
-
 
 --
 -- Pull out argument types until bottoming out at a non-Pi type

--- a/saw-core/saw-core.cabal
+++ b/saw-core/saw-core.cabal
@@ -72,6 +72,7 @@ library
      Verifier.SAW.Prim
      Verifier.SAW.Recognizer
      Verifier.SAW.Rewriter
+     Verifier.SAW.SATQuery
      Verifier.SAW.SCTypeCheck
      Verifier.SAW.Simulator
      Verifier.SAW.Simulator.Concrete

--- a/saw-core/src/Verifier/SAW/FiniteValue.hs
+++ b/saw-core/src/Verifier/SAW/FiniteValue.hs
@@ -216,7 +216,9 @@ asFiniteType sc t = do
 asFirstOrderType :: SharedContext -> Term -> IO FirstOrderType
 asFirstOrderType sc t = maybe err pure =<< runMaybeT (asFirstOrderTypeMaybe sc t)
   where
-    err = fail ("asFirstOrderType: unsupported argument type: " ++ scPrettyTerm defaultPPOpts t)
+    err =
+      do t' <- scWhnf sc t
+         fail ("asFirstOrderType: unsupported argument type: " ++ scPrettyTerm defaultPPOpts t')
 
 asFirstOrderTypeMaybe :: SharedContext -> Term -> MaybeT IO FirstOrderType
 asFirstOrderTypeMaybe sc t =

--- a/saw-core/src/Verifier/SAW/FiniteValue.hs
+++ b/saw-core/src/Verifier/SAW/FiniteValue.hs
@@ -14,6 +14,10 @@ module Verifier.SAW.FiniteValue where
 import Control.Applicative
 import Data.Traversable
 #endif
+
+import Control.Monad (mzero)
+import Control.Monad.Trans (lift)
+import Control.Monad.Trans.Maybe
 import qualified Control.Monad.State as S
 import Data.List (intersperse)
 import Data.Map (Map)
@@ -200,26 +204,32 @@ asFiniteType sc t = do
     _ -> fail $ "asFiniteType: unsupported argument type: " ++ scPrettyTerm defaultPPOpts t'
 
 asFirstOrderType :: SharedContext -> Term -> IO FirstOrderType
-asFirstOrderType sc t = do
-  t' <- scWhnf sc t
-  case t' of
-    (R.asBoolType -> Just ())
-      -> return FOTBit
-    (R.asIntegerType -> Just ())
-      -> return FOTInt
-    (R.asIntModType -> Just n)
-      -> return (FOTIntMod n)
-    (R.isVecType return -> Just (n R.:*: tp))
-      -> FOTVec n <$> asFirstOrderType sc tp
-    (R.asArrayType -> Just (tp1 R.:*: tp2)) -> do
-      tp1' <- asFirstOrderType sc tp1
-      tp2' <- asFirstOrderType sc tp2
-      return $ FOTArray tp1' tp2'
-    (R.asTupleType -> Just ts)
-      -> FOTTuple <$> traverse (asFirstOrderType sc) ts
-    (R.asRecordType -> Just tm)
-      -> FOTRec <$> traverse (asFirstOrderType sc) tm
-    _ -> fail $ "asFirstOrderType: unsupported argument type: " ++ scPrettyTerm defaultPPOpts t'
+asFirstOrderType sc t = maybe err pure =<< runMaybeT (asFirstOrderTypeMaybe sc t)
+  where
+    err = fail ("asFirstOrderType: unsupported argument type: " ++ scPrettyTerm defaultPPOpts t)
+
+asFirstOrderTypeMaybe :: SharedContext -> Term -> MaybeT IO FirstOrderType
+asFirstOrderTypeMaybe sc t =
+  do t' <- lift (scWhnf sc t)
+     case t' of
+       (R.asBoolType -> Just ())
+         -> return FOTBit
+       (R.asIntegerType -> Just ())
+         -> return FOTInt
+       (R.asIntModType -> Just n)
+         -> return (FOTIntMod n)
+       (R.isVecType return -> Just (n R.:*: tp))
+         -> FOTVec n <$> asFirstOrderTypeMaybe sc tp
+       (R.asArrayType -> Just (tp1 R.:*: tp2)) -> do
+         tp1' <- asFirstOrderTypeMaybe sc tp1
+         tp2' <- asFirstOrderTypeMaybe sc tp2
+         return $ FOTArray tp1' tp2'
+       (R.asTupleType -> Just ts)
+         -> FOTTuple <$> traverse (asFirstOrderTypeMaybe sc) ts
+       (R.asRecordType -> Just tm)
+         -> FOTRec <$> traverse (asFirstOrderTypeMaybe sc) tm
+       _ -> mzero
+
 
 asFiniteTypePure :: Term -> Maybe FiniteType
 asFiniteTypePure t =

--- a/saw-core/src/Verifier/SAW/FiniteValue.hs
+++ b/saw-core/src/Verifier/SAW/FiniteValue.hs
@@ -89,6 +89,16 @@ toFirstOrderValue fv =
     FVTuple vs -> FOVTuple (map toFirstOrderValue vs)
     FVRec vm   -> FOVRec (fmap toFirstOrderValue vm)
 
+
+toFiniteType :: FirstOrderType -> Maybe FiniteType
+toFiniteType FOTBit        = pure FTBit
+toFiniteType (FOTVec n t)  = FTVec n <$> toFiniteType t
+toFiniteType (FOTTuple ts) = FTTuple <$> traverse toFiniteType ts
+toFiniteType (FOTRec fs)   = FTRec   <$> traverse toFiniteType fs
+toFiniteType FOTInt{}      = Nothing
+toFiniteType FOTIntMod{}   = Nothing
+toFiniteType FOTArray{}    = Nothing
+
 instance Show FiniteValue where
   showsPrec p fv = showsPrec p (toFirstOrderValue fv)
 

--- a/saw-core/src/Verifier/SAW/Prelude.hs
+++ b/saw-core/src/Verifier/SAW/Prelude.hs
@@ -39,7 +39,7 @@ scEq :: SharedContext -> Term -> Term -> IO Term
 scEq sc x y = do
   xty <- scTypeOf sc x
   mmap <- scGetModuleMap sc
-  case asFirstOrderTypeValue (evalSharedTerm mmap mempty xty) of
+  case asFirstOrderTypeValue (evalSharedTerm mmap mempty mempty xty) of
     Just fot -> scDecEq sc fot (Just (x,y))
     Nothing  -> fail ("scEq: expected first order type, but got: " ++ showTerm xty)
 

--- a/saw-core/src/Verifier/SAW/SATQuery.hs
+++ b/saw-core/src/Verifier/SAW/SATQuery.hs
@@ -1,4 +1,8 @@
-module Verifier.SAW.SATQuery where
+module Verifier.SAW.SATQuery
+( SATQuery(..)
+, SATResult(..)
+, satQueryAsTerm
+) where
 
 import Control.Monad (foldM)
 import Data.Map (Map)
@@ -8,20 +12,57 @@ import Verifier.SAW.Name
 import Verifier.SAW.FiniteValue
 import Verifier.SAW.SharedTerm
 
+-- | This datatype represents a satisfiability query that might
+--   be dispatched to a solver.  It carries a series of assertions
+--   to be made to a solver, together with a collection of
+--   variables we expect the solver to report models over,
+--   and a collection of @VarIndex@ values identifying
+--   subterms that should be considered uninterpreted.
+--
+--   All the @ExtCns@ values in the query should
+--   appear either in @satVariables@ or @satUninterp@.
+--   Constant values for which definitions are provided
+--   may also appear in @satUninterp@, in which case
+--   they will be treated as uninterpreted.  Otherwise,
+--   their definitions will be unfolded.
+--
+--   Solve solvers do not support uninterpreted values
+--   and will fail if presented a query that requests them.
 data SATQuery =
   SATQuery
   { satVariables :: Map (ExtCns Term) FirstOrderType
-  , satUninterp  :: Set VarIndex
-  , satAsserts   :: [Term]
-  }
+      -- ^ The variables in the query, for which we
+      --   expect the solver to find values in satisfiable
+      --   cases.  INVARIANT: The type of the @ExtCns@ keys
+      --   should correspond to the @FirstOrderType@ values.
 
+  , satUninterp  :: Set VarIndex
+      -- ^ A set indicating which variables and constant
+      --   values should be considered uninterpreted by
+      --   the solver. Models will not report values
+      --   for uninterpreted values.
+
+  , satAsserts   :: [Term]
+      -- ^ A collection of assertions.  These should
+      --   all be terms of type @Bool@.  The overall
+      --   query should be understood as the conjunction
+      --   of these terms.
+  }
+-- TODO, allow first-order propositions in addition to Boolean terms.
+
+-- | The result of a sat query.  In the event a model is found,
+--   return a mapping from the @ExtCns@ variables to values.
 data SATResult
   = Unsatisfiable
   | Satisfiable (ExtCns Term -> IO FirstOrderValue)
   | Unknown
 
+-- | Compute the conjunction of all the assertions
+--   in this SAT query as a single term of type Bool.
 satQueryAsTerm :: SharedContext -> SATQuery -> IO Term
 satQueryAsTerm sc satq =
   case satAsserts satq of
          [] -> scBool sc True
          (x:xs) -> foldM (scAnd sc) x xs
+-- TODO, we may have to rethink this function
+--  once we allow first-order statements.

--- a/saw-core/src/Verifier/SAW/SATQuery.hs
+++ b/saw-core/src/Verifier/SAW/SATQuery.hs
@@ -1,0 +1,27 @@
+module Verifier.SAW.SATQuery where
+
+import Control.Monad (foldM)
+import Data.Map (Map)
+import Data.Set (Set)
+
+import Verifier.SAW.Name
+import Verifier.SAW.FiniteValue
+import Verifier.SAW.SharedTerm
+
+data SATQuery =
+  SATQuery
+  { satVariables :: Map (ExtCns Term) FirstOrderType
+  , satUninterp  :: Set VarIndex
+  , satAsserts   :: [Term]
+  }
+
+data SATResult
+  = Unsatisfiable
+  | Satisfiable (ExtCns Term -> IO FirstOrderValue)
+  | Unknown
+
+satQueryAsTerm :: SharedContext -> SATQuery -> IO Term
+satQueryAsTerm sc satq =
+  case satAsserts satq of
+         [] -> scBool sc True
+         (x:xs) -> foldM (scAnd sc) x xs

--- a/saw-core/src/Verifier/SAW/SharedTerm.hs
+++ b/saw-core/src/Verifier/SAW/SharedTerm.hs
@@ -392,7 +392,7 @@ scShowTerm sc opts t =
      pure (showTermWithNames opts env t)
 
 -- | Create a global variable with the given identifier (which may be "_") and type.
-scFreshEC :: SharedContext -> String -> Term -> IO (ExtCns Term)
+scFreshEC :: SharedContext -> String -> a -> IO (ExtCns a)
 scFreshEC sc x tp = do
   i   <- scFreshGlobalVar sc
   let x' = Text.pack x


### PR DESCRIPTION
Supporting changes for https://github.com/GaloisInc/saw-script/pull/1102

This mostly involves new top-level methods for translating saw-core terms using a new `SATQuery` datatype to replace the previous convention based on functions.  The random testing module, however, has been totally overhauled.

In a future pass, we may wish to remove the old methods and generally clean up cruft.