### PR TITLE
Fix cryptol primitives module name

### DIFF
--- a/saw-core-coq/src/Verifier/SAW/Translation/Coq/SpecialTreatment.hs
+++ b/saw-core-coq/src/Verifier/SAW/Translation/Coq/SpecialTreatment.hs
@@ -149,7 +149,7 @@ sawVectorDefinitionsModule (TranslationConfiguration {..}) =
   mkModuleName [vectorModule]
 
 cryptolPrimitivesModule :: ModuleName
-cryptolPrimitivesModule = mkModuleName ["CryptolPrimitivesForSAWCORE"]
+cryptolPrimitivesModule = mkModuleName ["CryptolPrimitivesForSAWCore"]
 
 sawCoreScaffoldingModule :: ModuleName
 sawCoreScaffoldingModule = mkModuleName ["SAWCoreScaffolding"]


### PR DESCRIPTION
It was incorrectly set in f0ed5993d027438756b9e5d56114277a0ef31e1a.