### PR TITLE
Expose Simulator.What4 helper functions for use in compositional crux-mir

### DIFF
--- a/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
+++ b/saw-core-what4/src/Verifier/SAW/Simulator/What4.hs
@@ -40,6 +40,7 @@
 
 module Verifier.SAW.Simulator.What4
   ( w4Solve
+  , w4SolveBasic
   , SymFnCache
   , TypedExpr(..)
   , SValue
@@ -51,6 +52,9 @@ module Verifier.SAW.Simulator.What4
 
   , w4SimulatorEval
   , NeutralTermException(..)
+
+  , valueToSymExpr
+  , symExprToValue
   ) where
 
 


### PR DESCRIPTION
Adds some helper functions to the `Verifier.SAW.Simulator.What4` export list so that compositional crux-mir (GaloisInc/saw-script#1117) can use them for conversions between `SAW.Term` and `W4.Expr`.  Main use is [here](https://github.com/GaloisInc/saw-script/blob/1fadf37a8e4427242c6635d740fdb67a6f444fc7/crux-mir-comp/src/Mir/Compositional/Override.hs#L561), where they're used for converting a `SAW.Term` (partially) produced by `Verifier.SAW.Simulator.What4.ReturnTrip.toSC` back into a `W4.Expr` while preserving references to what4 variables.